### PR TITLE
Transfer Syntax index abstraction & inventory-less registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,8 @@ script:
   - if [ "$CLIPPY_INSTALLED" == 1 ]; then
       cargo clippy;
     fi
+  # default features
   - cargo test --all
+  # no inventory
+  - cargo test --manifest-path encoding/Cargo.toml --no-default-features
+  - cargo test --manifest-path transfer-syntax-registry/Cargo.toml --no-default-features

--- a/dcmdump/Cargo.toml
+++ b/dcmdump/Cargo.toml
@@ -9,5 +9,8 @@ repository = "https://github.com/Enet4/dicom-rs"
 categories = ["command-line-utilities"]
 keywords = ["cli", "dicom", "dump"]
 
+[features]
+default = ['dicom/inventory-registry']
+
 [dependencies]
-dicom = { path = "../parent/", version = "0.1.0" }
+dicom = { path = "../parent/", version = "0.1.0", default-features = false }

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -9,10 +9,14 @@ repository = "https://github.com/Enet4/dicom-rs"
 categories = ["encoding"]
 keywords = ["dicom"]
 
+[features]
+default = []
+inventory-registry = ['inventory']
+
 [dependencies]
 dicom-core = { path = "../core", version = "0.1.0" }
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.1.0" }
 quick-error = "1.2.2"
 encoding = "0.2.33"
 byteordered = "0.4.0"
-inventory = "0.1.4"
+inventory = { version = "0.1.4", optional = true }

--- a/encoding/src/transfer_syntax/mod.rs
+++ b/encoding/src/transfer_syntax/mod.rs
@@ -43,6 +43,7 @@ pub struct TransferSyntax<A = DynDataRWAdapter> {
     codec: Codec<A>,
 }
 
+#[cfg(feature = "inventory-registry")]
 // Collect transfer syntax specifiers from other crates.
 inventory::collect!(TransferSyntax);
 
@@ -69,6 +70,7 @@ where
     }
 }
 
+#[cfg(feature = "inventory-registry")]
 #[macro_export]
 /// Submit a transfer syntax specifier to be supported by the
 /// program's runtime. This is to be used by crates wishing to provide
@@ -82,6 +84,23 @@ macro_rules! submit_transfer_syntax {
         inventory::submit! {
             ($ts).erased()
         }
+    };
+}
+
+#[cfg(not(feature = "inventory-registry"))]
+#[macro_export]
+/// Submit a transfer syntax specifier to be supported by the
+/// program's runtime. This is to be used by crates wishing to provide
+/// additional support for a certain transfer syntax using the
+/// main transfer syntax registry.
+///
+/// This macro does actually "run" anything, so place it outside of a
+/// function body at the root of the crate.
+/// 
+/// Without the `inventory-registry` feature, this request is ignored.
+macro_rules! submit_transfer_syntax {
+    ($ts: expr) => {
+        // ignore request
     };
 }
 

--- a/object/Cargo.toml
+++ b/object/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/Enet4/dicom-rs"
 description = "A high-level API for reading and manipulating DICOM objects"
 keywords = ["dicom"]
 
+[features]
+default = []
+inventory-registry = ['dicom-encoding/inventory-registry', 'dicom-transfer-syntax-registry/inventory-registry']
+
 [dependencies]
 dicom-core = { path = "../core", version = "0.1.0" }
 dicom-encoding = { path = "../encoding", version = "0.1.0" }

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -135,6 +135,24 @@ where
     /// This function assumes the standard file encoding structure: 128-byte
     /// preamble, file meta group, and the rest of the data set.
     pub fn open_file_with_dict<P: AsRef<Path>>(path: P, dict: D) -> Result<Self> {
+        Self::open_file_with(path, dict, TransferSyntaxRegistry)
+    }
+
+    /// Create a DICOM object by reading from a file.
+    ///
+    /// This function assumes the standard file encoding structure: 128-byte
+    /// preamble, file meta group, and the rest of the data set.
+    /// 
+    /// This function allows you to choose a different transfer syntax index,
+    /// but its use is only advised when the built-in transfer syntax registry
+    /// is insufficient. Otherwise, please use [`open_file_with_dict`] instead.
+    /// 
+    /// [`open_file_with_dict`]: #method.open_file_with_dict
+    pub fn open_file_with<P: AsRef<Path>, R>(path: P, dict: D, ts_index: R) -> Result<Self>
+    where
+        P: AsRef<Path>,
+        R: TransferSyntaxIndex,
+    {
         let mut file = BufReader::new(File::open(path)?);
 
         // skip preamble
@@ -148,7 +166,7 @@ where
         let meta = FileMetaTable::from_reader(&mut file)?;
 
         // read rest of data according to metadata, feed it to object
-        let ts = TransferSyntaxRegistry
+        let ts = ts_index
             .get(&meta.transfer_syntax)
             .ok_or(Error::UnsupportedTransferSyntax)?;
         let cs = SpecificCharacterSet::Default;
@@ -168,13 +186,31 @@ where
     where
         S: Read,
     {
+        Self::from_reader_with(src, dict, TransferSyntaxRegistry)
+    }
+
+    /// Create a DICOM object by reading from a byte source.
+    ///
+    /// This function assumes the standard file encoding structure without the
+    /// preamble: file meta group, followed by the rest of the data set.
+    /// 
+    /// This function allows you to choose a different transfer syntax index,
+    /// but its use is only advised when the built-in transfer syntax registry
+    /// is insufficient. Otherwise, please use [`from_reader_with_dict`] instead.
+    /// 
+    /// [`from_reader_with_dict`]: #method.from_reader_with_dict
+    pub fn from_reader_with<S, R>(src: S, dict: D, ts_index: R) -> Result<Self>
+    where
+        S: Read,
+        R: TransferSyntaxIndex,
+    {
         let mut file = BufReader::new(src);
 
         // read metadata header
         let meta = FileMetaTable::from_reader(&mut file)?;
 
         // read rest of data according to metadata, feed it to object
-        let ts = TransferSyntaxRegistry
+        let ts = ts_index
             .get(&meta.transfer_syntax)
             .ok_or(Error::UnsupportedTransferSyntax)?;
         let cs = SpecificCharacterSet::Default;
@@ -346,6 +382,7 @@ impl<D> IntoIterator for InMemDicomObject<D> {
     }
 }
 
+/// Base iterator type for an in-memory DICOM object.
 #[derive(Debug)]
 pub struct Iter<D> {
     inner: ::std::collections::btree_map::IntoIter<Tag, InMemElement<D>>,

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -15,10 +15,11 @@ use dicom_core::value::{DicomValueType, Value, ValueType, C};
 use dicom_core::{DataElement, Length, Tag, VR};
 use dicom_dictionary_std::StandardDataDictionary;
 use dicom_encoding::text::SpecificCharacterSet;
+use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_parser::dataset::{DataSetReader, DataToken};
 use dicom_parser::error::{DataSetSyntaxError, Error, Result};
 use dicom_parser::parser::Parse;
-use dicom_transfer_syntax_registry::get_registry;
+use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 
 /// A full in-memory DICOM data element.
 pub type InMemElement<D> = DataElement<InMemDicomObject<D>>;
@@ -147,7 +148,7 @@ where
         let meta = FileMetaTable::from_reader(&mut file)?;
 
         // read rest of data according to metadata, feed it to object
-        let ts = get_registry()
+        let ts = TransferSyntaxRegistry
             .get(&meta.transfer_syntax)
             .ok_or(Error::UnsupportedTransferSyntax)?;
         let cs = SpecificCharacterSet::Default;
@@ -173,7 +174,7 @@ where
         let meta = FileMetaTable::from_reader(&mut file)?;
 
         // read rest of data according to metadata, feed it to object
-        let ts = get_registry()
+        let ts = TransferSyntaxRegistry
             .get(&meta.transfer_syntax)
             .ok_or(Error::UnsupportedTransferSyntax)?;
         let cs = SpecificCharacterSet::Default;

--- a/parent/Cargo.toml
+++ b/parent/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/Enet4/dicom-rs"
 
+[features]
+default = ['inventory-registry']
+inventory-registry = ['dicom-encoding/inventory-registry', 'dicom-transfer-syntax-registry/inventory-registry']
+
 [badges]
 
 [badges.travis-ci]
@@ -18,4 +22,4 @@ dicom-dictionary-std = { path = "../dictionary-std", version = "0.1.0" }
 dicom-encoding = { path = "../encoding", version = "0.1.0" }
 dicom-parser = { path = "../parser", version = "0.1.0" }
 dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry", version = "0.1.0" }
-dicom-object = { path = "../object", version = "0.1.0" }
+dicom-object = { path = "../object", version = "0.1.0", default-features = false }

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -7,10 +7,14 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/Enet4/dicom-rs"
 
+[features]
+default = []
+inventory-registry = ['dicom-encoding/inventory-registry', 'inventory']
+
 [dependencies]
 dicom-core = { path = "../core", version = "0.1.0" }
 dicom-encoding = { path = "../encoding", version = "0.1.0" }
 lazy_static = "1.2.0"
 encoding = "0.2.33"
 byteordered = "0.4.0"
-inventory = "0.1.4"
+inventory = { version = "0.1.4", optional = true }

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -1,4 +1,10 @@
-// Compiled transfer syntax specifiers.
+//! Compiled transfer syntax specifiers.
+
+use byteordered::Endianness;
+use dicom_encoding::transfer_syntax::{
+    AdapterFreeTransferSyntax as Ts, Codec,
+};
+use crate::create_ts_stub;
 
 // -- the three base transfer syntaxes, fully supported --
 
@@ -9,7 +15,6 @@ pub const IMPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
     false,
     Codec::None,
 );
-submit_transfer_syntax!(IMPLICIT_VR_LITTLE_ENDIAN);
 
 pub const EXPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
     "1.2.840.10008.1.2.1",
@@ -18,7 +23,6 @@ pub const EXPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
     true,
     Codec::None,
 );
-submit_transfer_syntax!(EXPLICIT_VR_LITTLE_ENDIAN);
 
 pub const EXPLICIT_VR_BIG_ENDIAN: Ts = Ts::new(
     "1.2.840.10008.1.2.2",
@@ -27,7 +31,6 @@ pub const EXPLICIT_VR_BIG_ENDIAN: Ts = Ts::new(
     true,
     Codec::None,
 );
-submit_transfer_syntax!(EXPLICIT_VR_BIG_ENDIAN);
 
 // --- stub transfer syntaxes, known but not supported ---
 
@@ -38,7 +41,6 @@ pub const DEFLATED_EXPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
     true,
     Codec::Unsupported,
 );
-submit_transfer_syntax!(DEFLATED_EXPLICIT_VR_LITTLE_ENDIAN);
 
 pub const JPIP_DEREFERENCED_DEFLATE: Ts = Ts::new(
     "1.2.840.10008.1.2.4.95",
@@ -47,66 +49,44 @@ pub const JPIP_DEREFERENCED_DEFLATE: Ts = Ts::new(
     true,
     Codec::Unsupported,
 );
-submit_transfer_syntax!(JPIP_DEREFERENCED_DEFLATE);
 
 // --- partially supported transfer syntaxes, pixel data encapsulation not supported ---
 
 pub const JPEG_BASELINE: Ts = create_ts_stub("1.2.840.10008.1.2.4.50", "JPEG Baseline (Process 1)");
-submit_transfer_syntax!(JPEG_BASELINE);
 pub const JPEG_EXTENDED: Ts = create_ts_stub("1.2.840.10008.1.2.4.51", "JPEG Extended (Process 2 & 4)");
-submit_transfer_syntax!(JPEG_EXTENDED);
 pub const JPEG_LOSSLESS_NON_HIERARCHICAL: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.57", "JPEG Lossless, Non-Hierarchical (Process 14)");
-submit_transfer_syntax!(JPEG_LOSSLESS_NON_HIERARCHICAL);
 pub const JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.70", "JPEG Lossless, Non-Hierarchical, First-Order Prediction");
-submit_transfer_syntax!(JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION);
 pub const JPEG_LS_LOSSLESS_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.80", "JPEG-LS Lossless Image Compression");
-submit_transfer_syntax!(JPEG_LS_LOSSLESS_IMAGE_COMPRESSION);
 pub const JPEG_LS_LOSSY_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.81", "JPEG-LS Lossy (Near-Lossless) Image Compression");
-submit_transfer_syntax!(JPEG_LS_LOSSY_IMAGE_COMPRESSION);
 pub const JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.90", "JPEG 2000 Image Compression (Lossless Only)");
-submit_transfer_syntax!(JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY);
 pub const JPEG_2000_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.91", "JPEG 2000 Image Compression");
-submit_transfer_syntax!(JPEG_2000_IMAGE_COMPRESSION);
 pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.92", "JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)");
-submit_transfer_syntax!(JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION_LOSSLESS_ONLY);
 pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.93", "JPEG 2000 Part 2 Multi-component Image Compression");
-submit_transfer_syntax!(JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION);
 pub const JPIP_REFERENCED: Ts = create_ts_stub("1.2.840.10008.1.2.4.94", "JPIP Referenced");
-submit_transfer_syntax!(JPIP_REFERENCED);
 pub const MPEG2_MAIN_PROFILE_MAIN_LEVEL: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.100", "MPEG2 Main Profile / Main Level");
-submit_transfer_syntax!(MPEG2_MAIN_PROFILE_MAIN_LEVEL);
 pub const MPEG2_MAIN_PROFILE_HIGH_LEVEL: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.101", "MPEG2 Main Profile / High Level");
-submit_transfer_syntax!(MPEG2_MAIN_PROFILE_HIGH_LEVEL);
 pub const MPEG4_AVC_H264_HIGH_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.102", "MPEG-4 AVC/H.264 High Profile / Level 4.1");
-submit_transfer_syntax!(MPEG4_AVC_H264_HIGH_PROFILE);
 pub const MPEG4_AVC_H264_BD_COMPATIBLE_HIGH_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.103", "MPEG-4 AVC/H.264 BD-Compatible High Profile / Level 4.1");
-submit_transfer_syntax!(MPEG4_AVC_H264_BD_COMPATIBLE_HIGH_PROFILE);
 pub const MPEG4_AVC_H264_HIGH_PROFILE_FOR_2D_VIDEO: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.104", "MPEG-4 AVC/H.264 High Profile / Level 4.2 For 2D Video");
-submit_transfer_syntax!(MPEG4_AVC_H264_HIGH_PROFILE_FOR_2D_VIDEO);
 pub const MPEG4_AVC_H264_HIGH_PROFILE_FOR_3D_VIDEO: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.105", "MPEG-4 AVC/H.264 High Profile / Level 4.2 For 3D Video");
-submit_transfer_syntax!(MPEG4_AVC_H264_HIGH_PROFILE_FOR_3D_VIDEO);
 pub const MPEG4_AVC_H264_STEREO_HIGH_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.106", "MPEG-4 AVC/H.264 Stereo High Profile / Level 4.2");
-submit_transfer_syntax!(MPEG4_AVC_H264_STEREO_HIGH_PROFILE);
 pub const HEVC_H265_MAIN_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.107", "HEVC/H.265 Main Profile / Level 5.1");
-submit_transfer_syntax!(HEVC_H265_MAIN_PROFILE);
 pub const HEVC_H265_MAIN_10_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.108", "HEVC/H.265 Main 10 Profile / Level 5.1");
-submit_transfer_syntax!(HEVC_H265_MAIN_10_PROFILE);
 pub const RLE_LOSSLESS: Ts = create_ts_stub("1.2.840.10008.1.2.5", "RLE Lossless");
-submit_transfer_syntax!(RLE_LOSSLESS);

--- a/transfer-syntax-registry/tests/base.rs
+++ b/transfer-syntax-registry/tests/base.rs
@@ -1,9 +1,13 @@
 //! Registry tests, to ensure that transfer syntaxes are properly
 //! registered when linked together in a separate program.
 
-use dicom_transfer_syntax_registry::{get_registry, TransferSyntaxRegistry};
+use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
+use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 
-fn assert_fully_supported(registry: &TransferSyntaxRegistry, mut uid: &'static str) {
+fn assert_fully_supported<T>(registry: T, mut uid: &'static str)
+where
+    T: TransferSyntaxIndex,
+{
     let ts = registry.get(uid);
     assert!(ts.is_some());
     let ts = ts.unwrap();
@@ -16,17 +20,17 @@ fn assert_fully_supported(registry: &TransferSyntaxRegistry, mut uid: &'static s
 
 #[test]
 fn contains_base_ts() {
-    let registry = get_registry();
+    let registry = TransferSyntaxRegistry;
 
     // contains implicit VR little endian and is fully supported
-    assert_fully_supported(&registry, "1.2.840.10008.1.2");
+    assert_fully_supported(registry, "1.2.840.10008.1.2");
 
     // should work the same for trailing null characters
-    assert_fully_supported(&registry, "1.2.840.10008.1.2\0");
+    assert_fully_supported(registry, "1.2.840.10008.1.2\0");
 
     // contains explicit VR little endian and is fully supported
-    assert_fully_supported(&registry, "1.2.840.10008.1.2.1");
+    assert_fully_supported(registry, "1.2.840.10008.1.2.1");
 
     // contains explicit VR big endian and is fully supported
-    assert_fully_supported(&registry, "1.2.840.10008.1.2.2");
+    assert_fully_supported(registry, "1.2.840.10008.1.2.2");
 }

--- a/transfer-syntax-registry/tests/base.rs
+++ b/transfer-syntax-registry/tests/base.rs
@@ -4,17 +4,18 @@
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 
-fn assert_fully_supported<T>(registry: T, mut uid: &'static str)
+fn assert_fully_supported<T>(registry: T, mut uid: &'static str, name: &'static str)
 where
     T: TransferSyntaxIndex,
 {
     let ts = registry.get(uid);
-    assert!(ts.is_some());
+    assert!(ts.is_some(), "Registry did not provide TS {}", uid);
     let ts = ts.unwrap();
     if uid.ends_with("\0") {
         uid = &uid[0..uid.len() - 1];
     }
     assert_eq!(ts.uid(), uid);
+    assert_eq!(ts.name(), name);
     assert!(ts.fully_supported());
 }
 
@@ -23,14 +24,14 @@ fn contains_base_ts() {
     let registry = TransferSyntaxRegistry;
 
     // contains implicit VR little endian and is fully supported
-    assert_fully_supported(registry, "1.2.840.10008.1.2");
+    assert_fully_supported(registry, "1.2.840.10008.1.2", "Implicit VR Little Endian");
 
     // should work the same for trailing null characters
-    assert_fully_supported(registry, "1.2.840.10008.1.2\0");
+    assert_fully_supported(registry, "1.2.840.10008.1.2\0", "Implicit VR Little Endian");
 
     // contains explicit VR little endian and is fully supported
-    assert_fully_supported(registry, "1.2.840.10008.1.2.1");
+    assert_fully_supported(registry, "1.2.840.10008.1.2.1", "Explicit VR Little Endian");
 
     // contains explicit VR big endian and is fully supported
-    assert_fully_supported(registry, "1.2.840.10008.1.2.2");
+    assert_fully_supported(registry, "1.2.840.10008.1.2.2", "Explicit VR Big Endian");
 }

--- a/transfer-syntax-registry/tests/submit.rs
+++ b/transfer-syntax-registry/tests/submit.rs
@@ -1,7 +1,7 @@
 //! Independent test for testing that submitting a TS in a separate crate work.
 use dicom_encoding::submit_transfer_syntax;
-use dicom_encoding::transfer_syntax::{Codec, DataRWAdapter, Endianness, TransferSyntax};
-use dicom_transfer_syntax_registry::get_registry;
+use dicom_encoding::transfer_syntax::{Codec, DataRWAdapter, Endianness, TransferSyntax, TransferSyntaxIndex};
+use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use std::io::{Read, Write};
 
 /// this would, in theory, provide a dataset adapter
@@ -40,10 +40,8 @@ submit_transfer_syntax! {
 
 #[test]
 fn contains_dummy_ts() {
-    let registry = get_registry();
-
     // contains our dummy TS, and claims to be fully supported
-    let ts = registry.get("1.2.840.10008.9999.9999");
+    let ts = TransferSyntaxRegistry.get("1.2.840.10008.9999.9999");
     assert!(ts.is_some());
     let ts = ts.unwrap();
     assert_eq!(ts.uid(), "1.2.840.10008.9999.9999");

--- a/transfer-syntax-registry/tests/submit.rs
+++ b/transfer-syntax-registry/tests/submit.rs
@@ -1,4 +1,8 @@
 //! Independent test for testing that submitting a TS in a separate crate work.
+//! 
+//! Only applicable to the inventory-based registry.
+#![cfg(feature = "inventory-registry")]
+
 use dicom_encoding::submit_transfer_syntax;
 use dicom_encoding::transfer_syntax::{Codec, DataRWAdapter, Endianness, TransferSyntax, TransferSyntaxIndex};
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;


### PR DESCRIPTION
This PR introduces a trait for transfer syntax dictionaries and makes it so that the main TS registry can work even without support for the `inventory` based registry. The inventory will be behind the Cargo feature `inventory-registry`, enabled by default only at the parent crate `dicom` and in end user tools such as `dcmdump`. If this is disabled, built-in TSes will still be available, but the registry will be unable to be extended. <s>We can think of ways to overcome this issue in future contributions.</s> This can be overcome by creating a new registry implementation.

This should address the main concern presented in #6, although I would be grateful to have this tested in that environment (CC @ibaryshnikov).