### PR TITLE
RootDicomObject into_inner + into_iter

### DIFF
--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -138,5 +138,17 @@ where
     }
 }
 
+impl<T> IntoIterator for RootDicomObject<T>
+where
+    T: IntoIterator
+{
+    type Item = <T as IntoIterator>::Item;
+    type IntoIter = <T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.obj.into_iter()
+    }
+}
+
 #[cfg(test)]
 mod tests {}

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -88,6 +88,11 @@ impl<T> RootDicomObject<T> {
     pub fn meta(&self) -> &FileMetaTable {
         &self.meta
     }
+
+    /// Retrieve the inner DICOM object structure, discarding the meta table.
+    pub fn into_inner(self) -> T {
+        self.obj
+    }
 }
 
 impl<T> ::std::ops::Deref for RootDicomObject<T> {


### PR DESCRIPTION
Provides `RootDicomObject.into_inner` and makes it implement `IntoIterator`, currently by traversing the elements of the inner object (the meta table is not included).
