### PR TITLE
Parse explicit length sequences and items correctly

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,4 +1,5 @@
 //! This module aggregates errors that may emerge from the library.
+use crate::Tag;
 use crate::value::ValueType;
 use quick_error::quick_error;
 use std::error::Error as BaseError;
@@ -11,8 +12,9 @@ quick_error! {
     #[derive(Debug)]
     pub enum Error {
         /// Raised when the obtained data element was not the one expected.
-        UnexpectedElement {
-            description("Unexpected DICOM element in current reading position")
+        UnexpectedTag(tag: Tag) {
+            description("Unexpected DICOM element tag in current reading position")
+            display("Unexpected DICOM tag {}", tag)
         }
         /// Raised when the obtained length is inconsistent.
         UnexpectedDataValueLength {

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -304,7 +304,7 @@ impl SequenceItemHeader {
                 // sequence delimiter
                 Ok(SequenceItemHeader::SequenceDelimiter)
             }
-            _ => Err(Error::UnexpectedElement),
+            tag => Err(Error::UnexpectedTag(tag)),
         }
     }
 }

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -702,39 +702,51 @@ impl ::std::ops::Add<i32> for Length {
     }
 }
 
-impl ::std::ops::Sub<Length> for Length {
+impl std::ops::Sub<Length> for Length {
     type Output = Self;
 
     fn sub(self, rhs: Length) -> Self::Output {
+        let mut o = self;
+        o -= rhs;
+        o
+    }
+}
+
+impl std::ops::SubAssign<Length> for Length {
+    fn sub_assign(&mut self, rhs: Length) {
         match (self.0, rhs.0) {
-            (UNDEFINED_LEN, _) | (_, UNDEFINED_LEN) => Length::UNDEFINED,
-            (l1, l2) => {
-                let o = l1 - l2;
+            (UNDEFINED_LEN, _) | (_, UNDEFINED_LEN) => (), // no-op
+            (_, l2) => {
+                self.0 -= l2;
                 debug_assert!(
-                    o != UNDEFINED_LEN,
+                    self.0 != UNDEFINED_LEN,
                     "integer overflow (0xFFFF_FFFF reserved for undefined length)"
                 );
-
-                Length(o)
             }
         }
     }
 }
 
-impl ::std::ops::Sub<i32> for Length {
+impl std::ops::Sub<i32> for Length {
     type Output = Self;
 
     fn sub(self, rhs: i32) -> Self::Output {
+        let mut o = self;
+        o -= rhs;
+        o
+    }
+}
+
+impl std::ops::SubAssign<i32> for Length {
+    fn sub_assign(&mut self, rhs: i32) {
         match self.0 {
-            UNDEFINED_LEN => Length::UNDEFINED,
+            UNDEFINED_LEN => (), // no-op
             len => {
-                let o = (len as i32 - rhs) as u32;
+                self.0 = (len as i32 - rhs) as u32;
                 debug_assert!(
-                    o != UNDEFINED_LEN,
+                    self.0 != UNDEFINED_LEN,
                     "integer overflow (0xFFFF_FFFF reserved for undefined length)"
                 );
-
-                Length(o)
             }
         }
     }

--- a/dcmdump/src/main.rs
+++ b/dcmdump/src/main.rs
@@ -171,7 +171,8 @@ where
     dump(to, item, width, depth + 1)?;
     writeln!(
         to,
-        "(FFFE,E00D) na (ItemDelimitationItem)  # 0, 0 ItemDelimitationItem"
+        "{}(FFFE,E00D) na (ItemDelimitationItem)  # 0, 0 ItemDelimitationItem",
+        indent,
     )?;
     Ok(())
 }

--- a/encoding/src/decode/mod.rs
+++ b/encoding/src/decode/mod.rs
@@ -257,8 +257,10 @@ pub trait Decode {
      *
      * Decoding an item or sequence delimiter is considered valid, and so should be properly handled
      * by the decoder. The value representation in this case should be `UN`.
+     * 
+     * Returns the expected header and the exact number of bytes read from the source.
      */
-    fn decode_header(&self, source: &mut Self::Source) -> Result<DataElementHeader>;
+    fn decode_header(&self, source: &mut Self::Source) -> Result<(DataElementHeader, usize)>;
 
     /** Fetch and decode the next sequence item head from the given source. It is a separate method
      * because value representation is always implicit when reading item headers and delimiters.
@@ -277,7 +279,7 @@ where
 {
     type Source = <T as Decode>::Source;
 
-    fn decode_header(&self, source: &mut Self::Source) -> Result<DataElementHeader> {
+    fn decode_header(&self, source: &mut Self::Source) -> Result<(DataElementHeader, usize)> {
         (**self).decode_header(source)
     }
 
@@ -296,7 +298,7 @@ where
 {
     type Source = <T as Decode>::Source;
 
-    fn decode_header(&self, source: &mut Self::Source) -> Result<DataElementHeader> {
+    fn decode_header(&self, source: &mut Self::Source) -> Result<(DataElementHeader, usize)> {
         (**self).decode_header(source)
     }
 

--- a/encoding/src/error.rs
+++ b/encoding/src/error.rs
@@ -1,3 +1,4 @@
+use dicom_core::Tag;
 use dicom_core::error::Error as CoreError;
 pub use dicom_core::error::{CastValueError, InvalidValueReadError};
 use quick_error::quick_error;
@@ -13,9 +14,10 @@ quick_error! {
     /// The main data type for errors in the library.
     #[derive(Debug)]
     pub enum Error {
-        /// Raised when the obtained data element was not the one expected.
-        UnexpectedElement {
-            description("Unexpected DICOM element in current reading position")
+        /// Raised when the obtained data element tag was not the one expected.
+        UnexpectedTag(tag: Tag) {
+            description("Unexpected DICOM element tag in current reading position")
+            display("Unexpected DICOM tag {}", tag)
         }
         /// Raised when the obtained length is inconsistent.
         UnexpectedDataValueLength {
@@ -56,7 +58,7 @@ impl From<CoreError> for Error {
     fn from(e: CoreError) -> Self {
         match e {
             CoreError::UnexpectedDataValueLength => Error::UnexpectedDataValueLength,
-            CoreError::UnexpectedElement => Error::UnexpectedElement,
+            CoreError::UnexpectedTag(tag) => Error::UnexpectedTag(tag),
             CoreError::ReadValue(e) => Error::ReadValue(e),
             CoreError::CastValue(e) => Error::CastValue(e),
         }

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -60,7 +60,7 @@ where
     T: TextCodec,
 {
     let elem_len = {
-        let elem = decoder.decode_header(source)?;
+        let (elem, _bytes_read) = decoder.decode_header(source)?;
         if elem.tag() != tag {
             return Err(Error::UnexpectedElement);
         }
@@ -113,7 +113,7 @@ impl FileMetaTable {
         let builder = FileMetaTableBuilder::new();
 
         let group_length: u32 = {
-            let elem = decoder.decode_header(&mut file)?;
+            let (elem, _bytes_read) = decoder.decode_header(&mut file)?;
             if elem.tag() != (0x0002, 0x0000) {
                 return Err(Error::UnexpectedElement);
             }
@@ -130,7 +130,7 @@ impl FileMetaTable {
         let mut builder = builder
             .group_length(group_length)
             .information_version({
-                let elem = decoder.decode_header(&mut file)?;
+                let (elem, _bytes_read) = decoder.decode_header(&mut file)?;
                 if elem.tag() != (0x0002, 0x0001) {
                     return Err(Error::UnexpectedElement);
                 }
@@ -173,7 +173,7 @@ impl FileMetaTable {
 
         // Fetch optional data elements
         while group_length_remaining > 0 {
-            let elem = decoder.decode_header(&mut file)?;
+            let (elem, _bytes_read) = decoder.decode_header(&mut file)?;
             let elem_len = match elem.len().get() {
                 None => {
                     return Err(Error::from(InvalidValueReadError::UnresolvedValueLength));

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -62,7 +62,7 @@ where
     let elem_len = {
         let (elem, _bytes_read) = decoder.decode_header(source)?;
         if elem.tag() != tag {
-            return Err(Error::UnexpectedElement);
+            return Err(Error::UnexpectedTag(elem.tag()));
         }
         match elem.len().get() {
             None => {
@@ -115,7 +115,7 @@ impl FileMetaTable {
         let group_length: u32 = {
             let (elem, _bytes_read) = decoder.decode_header(&mut file)?;
             if elem.tag() != (0x0002, 0x0000) {
-                return Err(Error::UnexpectedElement);
+                return Err(Error::UnexpectedTag(elem.tag()));
             }
             if elem.len() != Length(4) {
                 return Err(Error::UnexpectedDataValueLength);
@@ -132,7 +132,7 @@ impl FileMetaTable {
             .information_version({
                 let (elem, _bytes_read) = decoder.decode_header(&mut file)?;
                 if elem.tag() != (0x0002, 0x0001) {
-                    return Err(Error::UnexpectedElement);
+                    return Err(Error::UnexpectedTag(elem.tag()));
                 }
                 if elem.len() != Length(2) {
                     return Err(Error::UnexpectedDataValueLength);

--- a/parser/src/dataset.rs
+++ b/parser/src/dataset.rs
@@ -27,14 +27,36 @@ pub struct DataSetReader<S, P, D> {
     source: S,
     parser: P,
     dict: D,
-    /// the current depth in the sequence tree
-    depth: u32,
     /// whether the reader is expecting an item next (or a sequence delimiter)
     in_sequence: bool,
+    /// whether a check for a sequence or item delimitation is pending
+    delimiter_check_pending: bool,
+    /// a stack of delimiters
+    seq_delimiters: Vec<SeqToken>,
     /// fuse the iteration process if true
     hard_break: bool,
     /// last decoded header
     last_header: Option<DataElementHeader>,
+}
+
+/// A token representing a sequence start.
+#[derive(Debug)]
+struct SeqToken {
+    /// Whether it is the start of a sequence or the start of an item.
+    typ: SeqTokenType,
+    /// The length of the value, as indicated by the starting element,
+    /// can be unknown.
+    len: Length,
+    /// The number of bytes the parser has read until it reached the
+    /// beginning of the sequence or item value data.
+    base_offset: u64,
+}
+
+/// The type of delimiter: sequence or item.
+#[derive(Debug)]
+enum SeqTokenType {
+    Sequence,
+    Item,
 }
 
 fn is_parse<S: ?Sized, P>(_: &P)
@@ -56,7 +78,8 @@ impl<'s, S: 's> DataSetReader<S, DynamicDicomParser, StandardDataDictionary> {
             source,
             parser,
             dict: StandardDataDictionary,
-            depth: 0,
+            seq_delimiters: Vec::new(),
+            delimiter_check_pending: false,
             in_sequence: false,
             hard_break: false,
             last_header: None,
@@ -81,7 +104,8 @@ impl<'s, S: 's, D> DataSetReader<S, DynamicDicomParser, D> {
             source,
             parser,
             dict,
-            depth: 0,
+            seq_delimiters: Vec::new(),
+            delimiter_check_pending: false,
             in_sequence: false,
             hard_break: false,
             last_header: None,
@@ -100,7 +124,8 @@ where
             source,
             parser,
             dict: StandardDataDictionary,
-            depth: 0,
+            seq_delimiters: Vec::new(),
+            delimiter_check_pending: false,
             in_sequence: false,
             hard_break: false,
             last_header: None,
@@ -148,22 +173,36 @@ where
         if self.hard_break {
             return None;
         }
+
+        // item or sequence delimitation logic for explicit lengths
+        if self.delimiter_check_pending {
+            if let Some(token) = self.update_seq_delimiters() {
+                return Some(Ok(token));
+            }
+        }
+
         if self.in_sequence {
             match self.parser.decode_item_header(&mut self.source) {
                 Ok(header) => match header {
                     SequenceItemHeader::Item { len } => {
                         // entered a new item
                         self.in_sequence = false;
+                        self.seq_delimiters.push(SeqToken {
+                            typ: SeqTokenType::Item,
+                            len,
+                            base_offset: self.parser.bytes_read(),
+                        });
                         Some(Ok(DataToken::ItemStart { len }))
                     }
                     SequenceItemHeader::ItemDelimiter => {
                         // closed an item
+                        self.seq_delimiters.pop();
                         self.in_sequence = true;
                         Some(Ok(DataToken::ItemEnd))
                     }
                     SequenceItemHeader::SequenceDelimiter => {
                         // closed a sequence
-                        self.depth -= 1;
+                        self.seq_delimiters.pop();
                         self.in_sequence = false;
                         Some(Ok(DataToken::SequenceEnd))
                     }
@@ -187,6 +226,9 @@ where
 
             self.last_header = None;
 
+            // sequences can end after this token
+            self.delimiter_check_pending = true;
+
             Some(Ok(DataToken::PrimitiveValue(value)))
         } else {
             // a data element header or item delimiter is expected
@@ -197,7 +239,11 @@ where
                     len,
                 }) => {
                     self.in_sequence = true;
-                    self.depth += 1;
+                    self.seq_delimiters.push(SeqToken {
+                        typ: SeqTokenType::Sequence,
+                        len,
+                        base_offset: self.parser.bytes_read(),
+                    });
                     Some(Ok(DataToken::SequenceStart { tag, len }))
                 }
                 Ok(DataElementHeader {
@@ -216,6 +262,8 @@ where
                     // TODO there might be a better way to check for the end of
                     // a DICOM object. This approach might ignore trailing
                     // garbage.
+                    // TODO x2: I no longer remember why I wrote this.
+                    // What trailing garbage?
                     self.hard_break = true;
                     None
                 }
@@ -225,6 +273,43 @@ where
                 }
             }
         }
+    }
+}
+
+
+impl<'s, S: 's, P, D> DataSetReader<S, P, D>
+where
+    P: Parse<dyn Read + 's>,
+    S: Read,
+{
+    fn update_seq_delimiters(&mut self) -> Option<DataToken> {
+        if let Some(sd) = self.seq_delimiters.last() {
+            if let Some(len) = sd.len.get() {
+                let eos = sd.base_offset + len as u64;
+                let bytes_read = self.parser.bytes_read();
+                if eos == bytes_read {
+                    // end of delimiter, as indicated by the element's length
+                    let token;
+                    match sd.typ {
+                        SeqTokenType::Sequence => {
+                            self.in_sequence = false;
+                            token = DataToken::SequenceEnd;
+                        },
+                        SeqTokenType::Item =>  {
+                            self.in_sequence = true;
+                            token = DataToken::ItemEnd;
+                        },
+                    }
+
+                    self.seq_delimiters.pop();
+                    return Some(token);
+                } else if eos < bytes_read {
+                    panic!("already read {} bytes, but end of sequence is @ {} bytes", bytes_read, eos);
+                }
+            }
+        }
+        self.delimiter_check_pending = false;
+        None
     }
 }
 
@@ -427,5 +512,113 @@ impl Header for DicomElementMarker {
 
     fn len(&self) -> Length {
         self.header.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Parse;
+    use super::{DataSetReader, DataToken, DicomParser};
+    use dicom_core::header::{DataElementHeader, Length};
+    use dicom_core::value::PrimitiveValue;
+    use dicom_core::{Tag, VR};
+    use dicom_encoding::transfer_syntax::explicit_le::ExplicitVRLittleEndianDecoder;
+    use dicom_encoding::decode::basic::LittleEndianBasicDecoder;
+    use dicom_encoding::text::DefaultCharacterSetCodec;
+    
+    #[test]
+    fn sequence_reading_explicit() {
+        #[rustfmt::skip]
+        static DATA: &[u8] = &[
+            0x18, 0x00, 0x11, 0x60, // sequence tag: (0018,6011) SequenceOfUltrasoundRegions
+            b'S', b'Q', // VR 
+            0x00, 0x00, // reserved
+            0x2e, 0x00, 0x00, 0x00, // length: 28 + 18 = 46 (#= 2)
+            // -- 12 --
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0x14, 0x00, 0x00, 0x00, // item length: 20 (#= 2)
+            // -- 20 --
+            0x18, 0x00, 0x12, 0x60, b'U', b'S', 0x02, 0x00, 0x01, 0x00, // (0018, 6012) RegionSpatialformat, len = 2, value = 1
+            // -- 30 --
+            0x18, 0x00, 0x14, 0x60, b'U', b'S', 0x02, 0x00, 0x02, 0x00, // (0018, 6012) RegionDataType, len = 2, value = 2
+            // -- 40 --
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0x0a, 0x00, 0x00, 0x00, // item length: 10 (#= 1)
+            // -- 48 --
+            0x18, 0x00, 0x12, 0x60, b'U', b'S', 0x02, 0x00, 0x04, 0x00, // (0018, 6012) RegionSpatialformat, len = 2, value = 4
+            // -- 58 --
+            0x20, 0x00, 0x00, 0x40, b'L', b'T', 0x04, 0x00, // (0020,4000) ImageComments, len = 4  
+            b'T', b'E', b'S', b'T', // value = "TEST"
+        ];
+
+        let ground_truth = vec![
+            DataToken::SequenceStart {
+                tag: Tag(0x0018, 0x6011),
+                len: Length(46)
+            },
+            DataToken::ItemStart {
+                len: Length(20)
+            },
+            DataToken::ElementHeader(DataElementHeader {
+                tag: Tag(0x0018, 0x6012),
+                vr: VR::US,
+                len: Length(2)
+            }),
+            DataToken::PrimitiveValue(
+                PrimitiveValue::U16([1].as_ref().into())
+            ),
+            DataToken::ElementHeader(DataElementHeader {
+                tag: Tag(0x0018, 0x6014),
+                vr: VR::US,
+                len: Length(2)
+            }),
+            DataToken::PrimitiveValue(
+                PrimitiveValue::U16([2].as_ref().into())
+            ),
+            DataToken::ItemEnd,
+            DataToken::ItemStart {
+                len: Length(10)
+            },
+            DataToken::ElementHeader(DataElementHeader {
+                tag: Tag(0x0018, 0x6012),
+                vr: VR::US,
+                len: Length(2)
+            }),
+            DataToken::PrimitiveValue(
+                PrimitiveValue::U16([4].as_ref().into())
+            ),
+            DataToken::ItemEnd,
+            DataToken::SequenceEnd,
+            DataToken::ElementHeader(DataElementHeader {
+                tag: Tag(0x0020, 0x4000),
+                vr: VR::LT,
+                len: Length(4)
+            }),
+            DataToken::PrimitiveValue(
+                PrimitiveValue::Str("TEST".into())
+            ),
+        ];
+        
+        let parser = DicomParser::new(
+            ExplicitVRLittleEndianDecoder::default(),
+            LittleEndianBasicDecoder::default(),
+            Box::new(DefaultCharacterSetCodec::default()) as Box<_>, // trait object
+        );
+
+        let mut dset_reader = DataSetReader::new(DATA, parser);
+
+        let mut iter = Iterator::zip(dset_reader.by_ref(), ground_truth);
+
+        while let Some((res, gt_token)) = iter.next() {
+            let token = res.expect("should parse without an error");
+            assert_eq!(token, gt_token);
+        }
+
+        assert_eq!(
+            iter.count(), // consume til the end
+            0, // we have already read all of them
+            "unexpected number of tokens remaining"
+        );
+        assert_eq!(dset_reader.parser.bytes_read(), 70);
     }
 }

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -24,6 +24,10 @@ quick_error! {
             description("Unexpected DICOM element tag in current reading position")
             display("Unexpected DICOM tag {}", tag)
         }
+        InconsistentSequenceEnd(eos: u64, bytes_read: u64) {
+            description("inconsistence sequence end position")
+            display("already read {} bytes, but end of sequence is @ {} bytes", bytes_read, eos)
+        }
         /// Raised when the obtained length is inconsistent.
         UnexpectedDataValueLength {
             description("Inconsistent data value length in data element")

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -1,4 +1,5 @@
 use crate::dataset::DataToken;
+use dicom_core::Tag;
 use dicom_core::error::Error as CoreError;
 pub use dicom_core::error::{CastValueError, InvalidValueReadError};
 use dicom_encoding::error::{Error as EncodingError, TextEncodingError};
@@ -19,8 +20,9 @@ quick_error! {
             description("Content is not DICOM or is corrupted")
         }
         /// Raised when the obtained data element was not the one expected.
-        UnexpectedElement {
-            description("Unexpected DICOM element in current reading position")
+        UnexpectedTag(tag: Tag) {
+            description("Unexpected DICOM element tag in current reading position")
+            display("Unexpected DICOM tag {}", tag)
         }
         /// Raised when the obtained length is inconsistent.
         UnexpectedDataValueLength {
@@ -98,7 +100,7 @@ impl From<CoreError> for Error {
     fn from(e: CoreError) -> Self {
         match e {
             CoreError::UnexpectedDataValueLength => Error::UnexpectedDataValueLength,
-            CoreError::UnexpectedElement => Error::UnexpectedElement,
+            CoreError::UnexpectedTag(tag) => Error::UnexpectedTag(tag),
             CoreError::ReadValue(e) => Error::ReadValue(e),
             CoreError::CastValue(e) => Error::CastValue(e),
         }
@@ -108,7 +110,7 @@ impl From<CoreError> for Error {
 impl From<EncodingError> for Error {
     fn from(e: EncodingError) -> Self {
         match e {
-            EncodingError::UnexpectedElement => Error::UnexpectedElement,
+            EncodingError::UnexpectedTag(tag) => Error::UnexpectedTag(tag),
             EncodingError::UnexpectedDataValueLength => Error::UnexpectedDataValueLength,
             EncodingError::ReadValue(e) => Error::ReadValue(e),
             EncodingError::TextEncoding(e) => Error::TextEncoding(e),

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! For a more intuitive, object-oriented API, please see the `dicom-object`
 //! crate.
-#![recursion_limit = "72"]
+#![recursion_limit = "80"]
 
 pub mod dataset;
 pub mod error;

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -272,8 +272,8 @@ where
         // sequence of 16-bit signed integers
         let len = require_known_length!(header);
 
-        let len = len >> 1;
-        let vec: EncodingResult<C<_>> = n_times(len)
+        let n = len >> 1;
+        let vec: EncodingResult<C<_>> = n_times(n)
             .map(|_| self.basic.decode_ss(&mut *from))
             .collect();
         self.bytes_read += len as u64;
@@ -283,8 +283,8 @@ where
     fn read_value_fl(&mut self, from: &mut S, header: &DataElementHeader) -> Result<PrimitiveValue> {
         let len = require_known_length!(header);
         // sequence of 32-bit floats
-        let len = len >> 2;
-        let vec: EncodingResult<C<_>> = n_times(len)
+        let n = len >> 2;
+        let vec: EncodingResult<C<_>> = n_times(n)
             .map(|_| self.basic.decode_fl(&mut *from))
             .collect();
         self.bytes_read += len as u64;
@@ -432,8 +432,8 @@ where
     fn read_value_od(&mut self, from: &mut S, header: &DataElementHeader) -> Result<PrimitiveValue> {
         let len = require_known_length!(header);
         // sequence of 64-bit floats
-        let len = len >> 3;
-        let vec: EncodingResult<C<_>> = n_times(len)
+        let n = len >> 3;
+        let vec: EncodingResult<C<_>> = n_times(n)
             .map(|_| self.basic.decode_fd(&mut *from))
             .collect();
         self.bytes_read += len as u64;
@@ -444,8 +444,8 @@ where
         let len = require_known_length!(header);
         // sequence of 32-bit unsigned integers
 
-        let len = len >> 2;
-        let vec: EncodingResult<C<_>> = n_times(len)
+        let n = len >> 2;
+        let vec: EncodingResult<C<_>> = n_times(n)
             .map(|_| self.basic.decode_ul(&mut *from))
             .collect();
         self.bytes_read += len as u64;
@@ -456,8 +456,8 @@ where
         let len = require_known_length!(header);
         // sequence of 16-bit unsigned integers
 
-        let len = len >> 1;
-        let vec: EncodingResult<C<_>> = n_times(len)
+        let n = len >> 1;
+        let vec: EncodingResult<C<_>> = n_times(n)
             .map(|_| self.basic.decode_us(&mut *from))
             .collect();
         self.bytes_read += len as u64;
@@ -468,8 +468,8 @@ where
         let len = require_known_length!(header);
         // sequence of 64-bit unsigned integers
 
-        let len = len >> 3;
-        let vec: EncodingResult<C<_>> = n_times(len)
+        let n = len >> 3;
+        let vec: EncodingResult<C<_>> = n_times(n)
             .map(|_| self.basic.decode_uv(&mut *from))
             .collect();
         self.bytes_read += len as u64;
@@ -480,8 +480,8 @@ where
         let len = require_known_length!(header);
         // sequence of 32-bit signed integers
 
-        let len = len >> 2;
-        let vec: EncodingResult<C<_>> = n_times(len)
+        let n = len >> 2;
+        let vec: EncodingResult<C<_>> = n_times(n)
             .map(|_| self.basic.decode_sl(&mut *from))
             .collect();
         self.bytes_read += len as u64;
@@ -492,8 +492,8 @@ where
         let len = require_known_length!(header);
         // sequence of 64-bit signed integers
 
-        let len = len >> 3;
-        let vec: EncodingResult<C<_>> = n_times(len)
+        let n = len >> 3;
+        let vec: EncodingResult<C<_>> = n_times(n)
             .map(|_| self.basic.decode_sv(&mut *from))
             .collect();
         self.bytes_read += len as u64;


### PR DESCRIPTION
This resolves #20. The parser should now know when the end of an item or a sequence is found, with delimiters (unknown length), or without delimiters (explicit length).

CC @ibaryshnikov @victorgabr