### PR TITLE
DICOM object writing

### DIFF
--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -3,7 +3,7 @@
 //! element header, and element composite types.
 
 use crate::error::{Error, Result};
-use crate::value::{DicomValueType, PrimitiveValue, Value};
+use crate::value::{PrimitiveValue, Value};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt;
@@ -46,9 +46,23 @@ pub trait Header: HasLength {
     }
 }
 
+/// Stub type representing a non-existing DICOM object.
+/// 
+/// This type implements `HasLength`, but cannot be instantiated.
+/// This makes it so that `Value<EmptyObject>` is sure to be either a primitive
+/// value or a sequence with no items.
+#[derive(Debug, PartialEq)]
+pub enum EmptyObject {}
+
+impl HasLength for EmptyObject {
+    fn length(&self) -> Length {
+        unreachable!()
+    }
+}
+
 /// A data type that represents and owns a DICOM data element. Unlike
 /// [`PrimitiveDataElement`], this type may contain multiple data elements
-/// through the item sequence VR (of type `I`).
+/// through the item sequence VR (where each item contains an object of type `I`).
 #[derive(Debug, PartialEq, Clone)]
 pub struct DataElement<I> {
     header: DataElementHeader,

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -50,7 +50,7 @@ where
     }
 
     /// Gets a reference to the items.
-    pub fn item(&self) -> Option<&[I]> {
+    pub fn items(&self) -> Option<&[I]> {
         match *self {
             Value::Sequence { ref items, .. } => Some(items),
             _ => None,
@@ -66,7 +66,7 @@ where
     }
 
     /// Retrieves the items.
-    pub fn into_item(self) -> Option<C<I>> {
+    pub fn into_items(self) -> Option<C<I>> {
         match self {
             Value::Sequence { items, .. } => Some(items),
             _ => None,

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -271,7 +271,7 @@ impl PrimitiveValue {
         PrimitiveValue::U16(C::from_elem(value, 1))
     }
 
-    /// Create a single unsinged 32 value.
+    /// Create a single unsigned 32-bit value.
     pub fn new_u32(value: u32) -> Self {
         PrimitiveValue::U32(C::from_elem(value, 1))
     }

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -212,7 +212,62 @@ pub enum PrimitiveValue {
     Time(C<NaiveTime>),
 }
 
+/// A utility macro for implementing the conversion from a core type into a
+/// DICOM primitive value with a single element.
+macro_rules! impl_from_for_primitive {
+    ($typ: ty, $variant: ident) => {
+        impl From< $typ > for PrimitiveValue {
+            fn from(value: $typ) -> Self {
+                PrimitiveValue:: $variant (C::from_elem(value, 1))
+            }
+        }
+    };
+}
+
+impl_from_for_primitive!(u8, U8);
+impl_from_for_primitive!(u16, U16);
+impl_from_for_primitive!(i16, I16);
+impl_from_for_primitive!(u32, U32);
+impl_from_for_primitive!(i32, I32);
+impl_from_for_primitive!(u64, U64);
+impl_from_for_primitive!(i64, I64);
+impl_from_for_primitive!(f32, F32);
+impl_from_for_primitive!(f64, F64);
+
+impl_from_for_primitive!(Tag, Tags);
+impl_from_for_primitive!(NaiveDate, Date);
+impl_from_for_primitive!(NaiveTime, Time);
+impl_from_for_primitive!(DateTime<FixedOffset>, DateTime);
+
+impl From<String> for PrimitiveValue {
+    fn from(value: String) -> Self {
+        PrimitiveValue::Str(value)
+    }
+} 
+
+impl From<&str> for PrimitiveValue {
+    fn from(value: &str) -> Self {
+        PrimitiveValue::Str(value.to_owned())
+    }
+} 
+
 impl PrimitiveValue {
+
+    /// Create a single unsigned 16-bit value.
+    pub fn new_u16(value: u16) -> Self {
+        PrimitiveValue::U16(C::from_elem(value, 1))
+    }
+
+    /// Create a single unsinged 32 value.
+    pub fn new_u32(value: u32) -> Self {
+        PrimitiveValue::U32(C::from_elem(value, 1))
+    }
+
+    /// Create a single I32 value.
+    pub fn new_i32(value: u32) -> Self {
+        PrimitiveValue::U32(C::from_elem(value, 1))
+    }
+
     /// Obtain the number of individual elements. This number may not
     /// match the DICOM value multiplicity in some value representations.
     pub fn multiplicity(&self) -> u32 {

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -216,9 +216,9 @@ pub enum PrimitiveValue {
 /// DICOM primitive value with a single element.
 macro_rules! impl_from_for_primitive {
     ($typ: ty, $variant: ident) => {
-        impl From< $typ > for PrimitiveValue {
+        impl From<$typ> for PrimitiveValue {
             fn from(value: $typ) -> Self {
-                PrimitiveValue:: $variant (C::from_elem(value, 1))
+                PrimitiveValue::$variant(C::from_elem(value, 1))
             }
         }
     };
@@ -239,20 +239,33 @@ impl_from_for_primitive!(NaiveDate, Date);
 impl_from_for_primitive!(NaiveTime, Time);
 impl_from_for_primitive!(DateTime<FixedOffset>, DateTime);
 
+/// Construct a DICOM value.
+#[macro_export]
+macro_rules! dicom_value {
+    ($typ: ident, [ $($elem: expr),* ]) => {
+        {
+            use smallvec::smallvec; // import smallvec macro
+            dicom_core::value::PrimitiveValue :: $typ (smallvec![$($elem,)*])
+        }
+    };
+    ($typ: ident, $elem: expr) => {
+        dicom_core::value::PrimitiveValue :: $typ (dicom_core::value::C::from_elem($elem, 1))
+    };
+}
+
 impl From<String> for PrimitiveValue {
     fn from(value: String) -> Self {
         PrimitiveValue::Str(value)
     }
-} 
+}
 
 impl From<&str> for PrimitiveValue {
     fn from(value: &str) -> Self {
         PrimitiveValue::Str(value.to_owned())
     }
-} 
+}
 
 impl PrimitiveValue {
-
     /// Create a single unsigned 16-bit value.
     pub fn new_u16(value: u16) -> Self {
         PrimitiveValue::U16(C::from_elem(value, 1))

--- a/encoding/src/text.rs
+++ b/encoding/src/text.rs
@@ -60,6 +60,9 @@ where
 }
 
 /// Type alias for a type erased text codec.
+/// 
+/// It is important because stateful decoders may need to change the expected
+/// text encoding format at run-time.
 pub type DynamicTextCodec = Box<dyn TextCodec>;
 
 /// An enum type for the the supported character sets.
@@ -89,7 +92,7 @@ impl SpecificCharacterSet {
     }
 
     /// Retrieve the respective text codec.
-    pub fn codec(self) -> Option<Box<dyn TextCodec>> {
+    pub fn codec(self) -> Option<DynamicTextCodec> {
         match self {
             SpecificCharacterSet::Default => Some(Box::new(DefaultCharacterSetCodec)),
             SpecificCharacterSet::IsoIr192 => Some(Box::new(Utf8CharacterSetCodec)),

--- a/encoding/src/transfer_syntax/mod.rs
+++ b/encoding/src/transfer_syntax/mod.rs
@@ -309,7 +309,7 @@ impl<A> TransferSyntax<A> {
     /// Retrieve the appropriate data element encoder for this transfer syntax.
     /// Can yield none if encoding is not supported. The resulting encoder does not
     /// consider pixel data encapsulation or data set compression rules.
-    pub fn encoder(&self) -> Option<DynEncoder<dyn Write>> {
+    pub fn encoder<'w>(&self) -> Option<DynEncoder<dyn Write + 'w>> {
         self.encoder_for()
     }
 

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -111,10 +111,10 @@ where
         let mut to = BufWriter::new(file);
 
         // write preamble
-        to.write(&[0_u8; 128][..])?;
+        to.write_all(&[0_u8; 128][..])?;
 
         // write magic sequence
-        to.write(b"DICM")?;
+        to.write_all(b"DICM")?;
 
         // write meta group
         self.meta.write(&mut to)?;

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -35,6 +35,7 @@ pub mod loader;
 pub mod mem;
 pub mod meta;
 pub mod pixeldata;
+pub mod tokens;
 
 mod util;
 

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -202,6 +202,8 @@ mod tests {
 
     #[test]
     fn smoke_test() {
+        const FILE_NAME: &str = ".smoke-test.dcm";
+
         let meta = FileMetaTableBuilder::new()
             .transfer_syntax(dicom_transfer_syntax_registry::entries::EXPLICIT_VR_LITTLE_ENDIAN.uid())
             .media_storage_sop_class_uid("1.2.840.10008.5.1.4.1.1.1")
@@ -212,7 +214,12 @@ mod tests {
         let obj = RootDicomObject::new_empty_with_meta(
             meta);
         
-        obj.write_to_file(".smoke-test.dcm").unwrap();
-        let _ = std::fs::remove_file(".smoke-test.dcm");
+        obj.write_to_file(FILE_NAME).unwrap();
+
+        let obj2 = RootDicomObject::open_file(FILE_NAME).unwrap();
+
+        assert_eq!(obj, obj2);
+
+        let _ = std::fs::remove_file(FILE_NAME);
     }
 }

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -203,10 +203,10 @@ mod tests {
     #[test]
     fn smoke_test() {
         let meta = FileMetaTableBuilder::new()
-            .transfer_syntax(dicom_transfer_syntax_registry::entries::EXPLICIT_VR_LITTLE_ENDIAN.uid().to_owned() + "\0")
-            .media_storage_sop_class_uid("1.2.840.10008.5.1.4.1.1.1\0".to_owned())
-            .media_storage_sop_instance_uid("1.2.3.456\0".to_owned())
-            .implementation_class_uid("1.2.345.6.7890.1.234".to_owned())
+            .transfer_syntax(dicom_transfer_syntax_registry::entries::EXPLICIT_VR_LITTLE_ENDIAN.uid())
+            .media_storage_sop_class_uid("1.2.840.10008.5.1.4.1.1.1")
+            .media_storage_sop_instance_uid("1.2.3.456")
+            .implementation_class_uid("1.2.345.6.7890.1.234")
             .build()
             .unwrap();
         let obj = RootDicomObject::new_empty_with_meta(

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -18,7 +18,7 @@ use dicom_encoding::text::SpecificCharacterSet;
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_parser::dataset::{DataSetReader, DataToken};
 use dicom_parser::error::{DataSetSyntaxError, Error, Result};
-use dicom_parser::parser::Parse;
+use dicom_parser::StatefulDecode;
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 
 /// A full in-memory DICOM data element.
@@ -279,15 +279,14 @@ where
     // private methods
 
     /// Build an object by consuming a data set parser.
-    fn build_object<'s, S: 's, P>(
-        dataset: &mut DataSetReader<S, P, D>,
+    fn build_object<P>(
+        dataset: &mut DataSetReader<P, D>,
         dict: D,
         in_item: bool,
         len: Length,
     ) -> Result<Self>
     where
-        S: Read,
-        P: Parse<dyn Read + 's>,
+        P: StatefulDecode,
     {
         let mut entries: BTreeMap<Tag, InMemElement<D>> = BTreeMap::new();
         // perform a structured parsing of incoming tokens
@@ -323,15 +322,14 @@ where
     }
 
     /// Build a DICOM sequence by consuming a data set parser.
-    fn build_sequence<'s, S: 's, P>(
+    fn build_sequence<P>(
         _tag: Tag,
         _len: Length,
-        dataset: &mut DataSetReader<S, P, D>,
+        dataset: &mut DataSetReader<P, D>,
         dict: &D,
     ) -> Result<C<InMemDicomObject<D>>>
     where
-        S: Read,
-        P: Parse<dyn Read + 's>,
+        P: StatefulDecode,
     {
         let mut items: C<_> = SmallVec::new();
         while let Some(token) = dataset.next() {

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -224,6 +224,20 @@ where
     }
 }
 
+impl RootDicomObject<InMemDicomObject<StandardDataDictionary>> {
+    /// Create a new empty object, using the given file meta table.
+    pub fn new_empty_with_meta(meta: FileMetaTable) -> Self {
+        RootDicomObject {
+            meta,
+            obj: InMemDicomObject {
+                entries: BTreeMap::new(),
+                dict: StandardDataDictionary,
+                len: Length::UNDEFINED,
+            },
+        }
+    }
+}
+
 impl<D> InMemDicomObject<D>
 where
     D: DataDictionary,

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -10,8 +10,8 @@ use std::path::Path;
 use crate::meta::FileMetaTable;
 use crate::{DicomObject, RootDicomObject};
 use dicom_core::dictionary::{DataDictionary, DictionaryEntry};
-use dicom_core::header::Header;
-use dicom_core::value::{DicomValueType, Value, ValueType, C};
+use dicom_core::header::{HasLength, Header};
+use dicom_core::value::{Value, C};
 use dicom_core::{DataElement, Length, Tag, VR};
 use dicom_dictionary_std::StandardDataDictionary;
 use dicom_encoding::text::SpecificCharacterSet;
@@ -45,12 +45,8 @@ impl<'s, D> PartialEq for InMemDicomObject<D> {
     }
 }
 
-impl<D> DicomValueType for InMemDicomObject<D> {
-    fn value_type(&self) -> ValueType {
-        ValueType::Item
-    }
-
-    fn size(&self) -> Length {
+impl<D> HasLength for InMemDicomObject<D> {
+    fn length(&self) -> Length {
         self.len
     }
 }

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -360,6 +360,36 @@ impl Default for FileMetaTableBuilder {
     }
 }
 
+/// Ensure that the string is even lengthed, by adding a trailing character
+/// if not.
+#[inline]
+fn padded<T>(s: T, pad: char) -> String
+where
+    T: Into<String>,
+{
+    let mut s = s.into();
+    if s.len() % 2 == 1 {
+        s.push(pad);
+    }
+    s
+}
+
+/// Ensure that the string is even lengthed with trailing '\0's.
+fn ui_padded<T>(s: T) -> String
+where
+    T: Into<String>,
+{
+    padded(s, '\0')
+}
+
+/// Ensure that the string is even lengthed with trailing spaces.
+fn txt_padded<T>(s: T) -> String
+where
+    T: Into<String>,
+{
+    padded(s, ' ')
+}
+
 impl FileMetaTableBuilder {
     /// Create a new, empty builder.
     pub fn new() -> FileMetaTableBuilder {
@@ -379,62 +409,92 @@ impl FileMetaTableBuilder {
     }
 
     /// Define the media storage SOP class UID.
-    pub fn media_storage_sop_class_uid(mut self, value: String) -> FileMetaTableBuilder {
-        self.media_storage_sop_class_uid = Some(value);
+    pub fn media_storage_sop_class_uid<T>(mut self, value: T) -> FileMetaTableBuilder
+    where
+        T: Into<String>,
+    {
+        self.media_storage_sop_class_uid = Some(ui_padded(value));
         self
     }
 
     /// Define the media storage SOP instance UID.
-    pub fn media_storage_sop_instance_uid(mut self, value: String) -> FileMetaTableBuilder {
-        self.media_storage_sop_instance_uid = Some(value);
+    pub fn media_storage_sop_instance_uid<T>(mut self, value: T) -> FileMetaTableBuilder
+    where
+        T: Into<String>,
+    {
+        self.media_storage_sop_instance_uid = Some(ui_padded(value));
         self
     }
 
-    /// Define the transfer syntax.
-    pub fn transfer_syntax(mut self, value: String) -> FileMetaTableBuilder {
-        self.transfer_syntax = Some(value);
+    /// Define the transfer syntax UID.
+    pub fn transfer_syntax<T>(mut self, value: T) -> FileMetaTableBuilder
+    where
+        T: Into<String>,
+    {
+        self.transfer_syntax = Some(ui_padded(value));
         self
     }
 
     /// Define the implementation class UID.
-    pub fn implementation_class_uid(mut self, value: String) -> FileMetaTableBuilder {
-        self.implementation_class_uid = Some(value);
+    pub fn implementation_class_uid<T>(mut self, value: T) -> FileMetaTableBuilder
+    where
+        T: Into<String>,
+    {
+        self.implementation_class_uid = Some(ui_padded(value));
         self
     }
 
     /// Define the implementation version name.
-    pub fn implementation_version_name(mut self, value: String) -> FileMetaTableBuilder {
-        self.implementation_version_name = Some(value);
+    pub fn implementation_version_name<T>(mut self, value: T) -> FileMetaTableBuilder
+    where
+        T: Into<String>,
+    {
+        self.implementation_version_name = Some(txt_padded(value));
         self
     }
 
     /// Define the source application entity title.
-    pub fn source_application_entity_title(mut self, value: String) -> FileMetaTableBuilder {
-        self.source_application_entity_title = Some(value);
+    pub fn source_application_entity_title<T>(mut self, value: T) -> FileMetaTableBuilder
+    where
+        T: Into<String>,
+    {
+        self.source_application_entity_title = Some(txt_padded(value));
         self
     }
 
     /// Define the sending application entity title.
-    pub fn sending_application_entity_title(mut self, value: String) -> FileMetaTableBuilder {
-        self.sending_application_entity_title = Some(value);
+    pub fn sending_application_entity_title<T>(mut self, value: T) -> FileMetaTableBuilder
+    where
+        T: Into<String>,
+    {
+        self.sending_application_entity_title = Some(txt_padded(value));
         self
     }
 
     /// Define the receiving application entity title.
-    pub fn receiving_application_entity_title(mut self, value: String) -> FileMetaTableBuilder {
-        self.receiving_application_entity_title = Some(value);
+    pub fn receiving_application_entity_title<T>(mut self, value: T) -> FileMetaTableBuilder
+    where
+        T: Into<String>,
+    {
+        self.receiving_application_entity_title = Some(txt_padded(value));
         self
     }
 
     /// Define the private information creator UID.
-    pub fn private_information_creator_uid(mut self, value: String) -> FileMetaTableBuilder {
-        self.private_information_creator_uid = Some(value);
+    pub fn private_information_creator_uid<T>(mut self, value: T) -> FileMetaTableBuilder
+    where
+        T: Into<String>,
+    {
+        self.private_information_creator_uid = Some(ui_padded(value));
         self
     }
 
     /// Define the private information as a vector of bytes.
-    pub fn private_information(mut self, value: Vec<u8>) -> FileMetaTableBuilder {
-        self.private_information = Some(value);
+    pub fn private_information<T>(mut self, value: T) -> FileMetaTableBuilder
+    where
+        T: Into<Vec<u8>>,
+    {
+        self.private_information = Some(value.into());
         self
     }
 

--- a/object/src/tokens.rs
+++ b/object/src/tokens.rs
@@ -1,0 +1,99 @@
+//! Convertion of DICOM objects into tokens.
+use crate::mem::{InMemDicomObject};
+use dicom_core::value::{PrimitiveValue};
+use dicom_core::{DataElement, Length};
+use dicom_parser::dataset::{DataToken, IntoTokens};
+use std::collections::VecDeque;
+
+/// A stream of tokens from a DICOM object.
+pub struct InMemObjectTokens<E> {
+    /// iterators of tokens in order of priority.
+    tokens_pending: VecDeque<DataToken>,
+    /// the iterator of data elements in order.
+    elem_iter: E,
+    /// whenever a primitive data element is yet to be processed
+    elem_pending: Option<PrimitiveValue>,
+    /// whether the tokens are done
+    fused: bool,
+}
+
+impl<E> InMemObjectTokens<E>
+where
+    E: Iterator,
+{
+    pub fn new<T>(obj: T) -> Self
+    where
+        T: IntoIterator<IntoIter = E, Item = E::Item>,
+    {
+        InMemObjectTokens {
+            tokens_pending: Default::default(),
+            elem_iter: obj.into_iter(),
+            elem_pending: None,
+            fused: false,
+        }
+    }
+}
+
+impl<E> InMemObjectTokens<E>
+where
+    E: Iterator,
+    E::Item: IntoTokens,
+{
+    fn next_token(&mut self) -> Option<DataToken> {
+        if let Some(token) = self.tokens_pending.pop_front() {
+            return Some(token);
+        }
+
+        // otherwise, expand next element, recurse
+        if let Some(elem) = self.elem_iter.next() {
+            // TODO eventually optimize this to be less eager
+            self.tokens_pending = elem.into_tokens().collect();
+            
+            self.next_token()
+        } else {
+            // no more elements
+            None
+        }
+    }
+}
+
+impl<E, I> Iterator for InMemObjectTokens<E>
+where
+    E: Iterator<Item = DataElement<I>>,
+    E::Item: IntoTokens,
+{
+    type Item = DataToken;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.fused {
+            return None;
+        }        
+        // if a data element is pending, return a value token
+        if let Some(val) = self.elem_pending.take() {
+            return Some(DataToken::PrimitiveValue(val));
+        }
+
+        // otherwise, consume pending tokens
+        if let Some(token) = self.next_token() {
+            return Some(token);
+        };
+
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // make a slightly better estimation for the minimum
+        // number of tokens that follow: 2 tokens per element left
+        (self.elem_iter.size_hint().0 * 2, None)
+    }
+}
+
+impl<D> IntoTokens for InMemDicomObject<D> {
+    type Iter =
+        InMemObjectTokens<<InMemDicomObject<D> as IntoIterator>::IntoIter>;
+
+    fn into_tokens(self) -> Self::Iter {
+        InMemObjectTokens::new(self)
+    }
+}
+

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -1,7 +1,7 @@
 //! Interpretation of DICOM data sets as streams of tokens.
-use dicom_core::header::{DataElementHeader, Length};
+use dicom_core::header::{DataElementHeader, Length, VR};
 use dicom_core::value::{DicomValueType, PrimitiveValue};
-use dicom_core::Tag;
+use dicom_core::{value::Value, DataElement, Tag};
 use std::fmt;
 
 pub mod read;
@@ -73,9 +73,285 @@ impl PartialEq<Self> for DataToken {
     }
 }
 
+impl From<DataElementHeader> for DataToken {
+    fn from(header: DataElementHeader) -> Self {
+        match header.vr() {
+            VR::SQ => DataToken::SequenceStart {
+                tag: header.tag,
+                len: header.len,
+            },
+            _ => DataToken::ElementHeader(header),
+        }
+    }
+}
+
+impl DataToken {
+    pub fn is_sequence_start(&self) -> bool {
+        match self {
+            DataToken::SequenceStart { .. } => true,
+            _ => false,
+        }
+    }
+}
+
 /// The type of delimiter: sequence or item.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum SeqTokenType {
     Sequence,
     Item,
+}
+
+/// A trait for converting structured DICOM data into a stream of data tokens.
+pub trait IntoTokens {
+    /// The iterator type through which tokens are obtained.
+    type Iter: Iterator<Item = DataToken>;
+
+    /// Convert the value into tokens.
+    fn into_tokens(self) -> Self::Iter;
+}
+
+/// Token generator from a DICOM data element.
+pub enum DataElementTokens<I>
+where
+    I: IntoTokens,
+{
+    /// initial state, at the beginning of the element
+    Start(
+        // Option is used for easy taking from a &mut,
+        // should always be Some in practice
+        Option<DataElement<I>>,
+    ),
+    /// header was read
+    Header(
+        // Option is used for easy taking from a &mut,
+        // should always be Some in practice
+        Option<DataElement<I>>,
+    ),
+    /// reading tokens from items
+    Items(
+        FlattenTokens<
+            <dicom_core::value::C<AsItem<I>> as IntoIterator>::IntoIter,
+            ItemTokens<I::Iter>,
+        >,
+    ),
+    /// no more elements
+    End,
+}
+
+impl<I> Iterator for DataElementTokens<I>
+where
+    I: IntoTokens,
+{
+    type Item = DataToken;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use DataElementTokens::*;
+        let (out, next_state) = match self {
+            Start(elem) => {
+                let elem = elem.take().unwrap();
+                // data element header token
+
+                let token = DataToken::from(*elem.header());
+                if token.is_sequence_start() {
+                    // retrieve sequence value, begin item sequence
+                    match elem.into_value() {
+                        Value::Primitive(_) => unreachable!(),
+                        Value::Sequence { items, size: _ } => {
+                            let items: dicom_core::value::C<_> = items
+                                .into_iter()
+                                .map(|o| AsItem(Length::UNDEFINED, o))
+                                .collect();
+                            (Some(token), DataElementTokens::Items(items.into_tokens()))
+                        }
+                    }
+                } else {
+                    (
+                        Some(DataToken::ElementHeader(*elem.header())),
+                        Header(Some(elem)),
+                    )
+                }
+            }
+            Header(elem) => {
+                let elem = elem.take().unwrap();
+                match elem.into_value() {
+                    Value::Sequence { .. } => unreachable!(),
+                    Value::Primitive(value) => {
+                        // return primitive value, done
+                        let token = DataToken::PrimitiveValue(value);
+                        (Some(token), End)
+                    }
+                }
+            }
+            Items(tokens) => {
+                if let Some(token) = tokens.next() {
+                    // bypass manual state transition
+                    return Some(token);
+                } else {
+                    // sequence end token, end
+                    (Some(DataToken::SequenceEnd), End)
+                }
+            }
+            End => (None, End),
+        };
+        *self = next_state;
+
+        out
+    }
+}
+
+impl<I> IntoTokens for DataElement<I>
+where
+    I: IntoTokens,
+{
+    type Iter = DataElementTokens<I>;
+
+    fn into_tokens(self) -> Self::Iter {
+        DataElementTokens::Start(Some(self))
+    }
+}
+
+/// Flatten a sequence of elements into their respective
+/// token sequence in order.
+#[derive(Debug, PartialEq)]
+pub struct FlattenTokens<O, K> {
+    seq: O,
+    tokens: Option<K>,
+}
+
+impl<O, K> Iterator for FlattenTokens<O, K>
+where
+    O: Iterator,
+    O::Item: IntoTokens<Iter = K>,
+    K: Iterator<Item = DataToken>,
+{
+    type Item = DataToken;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // ensure a token sequence
+        if self.tokens.is_none() {
+            match self.seq.next() {
+                Some(entries) => {
+                    self.tokens = Some(entries.into_tokens());
+                }
+                None => return None,
+            }
+        }
+
+        // retrieve the next token
+        match self.tokens.as_mut().map(|s| s.next()) {
+            Some(Some(token)) => Some(token),
+            Some(None) => {
+                self.tokens = None;
+                self.next()
+            }
+            None => unreachable!(),
+        }
+    }
+}
+
+impl<T> IntoTokens for Vec<T>
+where
+    T: IntoTokens,
+{
+    type Iter = FlattenTokens<<Vec<T> as IntoIterator>::IntoIter, <T as IntoTokens>::Iter>;
+
+    fn into_tokens(self) -> Self::Iter {
+        FlattenTokens {
+            seq: self.into_iter(),
+            tokens: None,
+        }
+    }
+}
+
+impl<T> IntoTokens for dicom_core::value::C<T>
+where
+    T: IntoTokens,
+{
+    type Iter =
+        FlattenTokens<<dicom_core::value::C<T> as IntoIterator>::IntoIter, <T as IntoTokens>::Iter>;
+
+    fn into_tokens(self) -> Self::Iter {
+        FlattenTokens {
+            seq: self.into_iter(),
+            tokens: None,
+        }
+    }
+}
+
+// A stream of tokens from a DICOM item.
+#[derive(Debug)]
+pub enum ItemTokens<T> {
+    /// Just started, an item header token will come next
+    Start {
+        len: Length,
+        object_tokens: Option<T>,
+    },
+    /// Will return tokens from the inner object, then an end of item token
+    /// when it ends
+    Object { object_tokens: T },
+    /// Just ended, no more tokens
+    End,
+}
+
+impl<T> ItemTokens<T>
+where
+    T: Iterator<Item = DataToken>,
+{
+    pub fn new<O>(len: Length, object: O) -> Self
+    where
+        O: IntoTokens<Iter = T>,
+    {
+        ItemTokens::Start {
+            len,
+            object_tokens: Some(object.into_tokens()),
+        }
+    }
+}
+
+impl<T> Iterator for ItemTokens<T>
+where
+    T: Iterator<Item = DataToken>,
+{
+    type Item = DataToken;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (next_state, out) = match self {
+            ItemTokens::Start { len, object_tokens } => (
+                ItemTokens::Object {
+                    object_tokens: object_tokens.take().unwrap(),
+                },
+                Some(DataToken::ItemStart { len: *len }),
+            ),
+            ItemTokens::Object { object_tokens } => {
+                if let Some(token) = object_tokens.next() {
+                    return Some(token);
+                } else {
+                    (ItemTokens::End, Some(DataToken::ItemEnd))
+                }
+            }
+            ItemTokens::End => {
+                return None;
+            }
+        };
+
+        *self = next_state;
+        out
+    }
+}
+
+/// A newtype for interpreting the given data as an item.
+/// When converting a value of this type into tokens, the inner value's tokens
+/// will be surrounded by an item start and an item delimiter.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AsItem<I>(Length, I);
+
+impl<I> IntoTokens for AsItem<I>
+where
+    I: IntoTokens,
+{
+    type Iter = ItemTokens<I::Iter>;
+
+    fn into_tokens(self) -> Self::Iter {
+        ItemTokens::new(self.0, self.1)
+    }
 }

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -110,6 +110,14 @@ pub trait IntoTokens {
     fn into_tokens(self) -> Self::Iter;
 }
 
+impl IntoTokens for dicom_core::header::EmptyObject {
+    type Iter = std::iter::Empty<DataToken>;
+
+    fn into_tokens(self) -> Self::Iter {
+        unreachable!()
+    }
+}
+
 /// Token generator from a DICOM data element.
 pub enum DataElementTokens<I>
 where

--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -8,7 +8,7 @@ use crate::error::{Error, InvalidValueReadError, Result};
 use crate::stateful::decode::{DynStatefulDecoder, StatefulDecode, StatefulDecoder};
 use crate::util::{ReadSeek, SeekInterval};
 use dicom_core::dictionary::DataDictionary;
-use dicom_core::header::{DataElementHeader, Header, Length, SequenceItemHeader};
+use dicom_core::header::{DataElementHeader, HasLength, Header, Length, SequenceItemHeader};
 use dicom_core::{Tag, VR};
 use dicom_dictionary_std::StandardDataDictionary;
 use dicom_encoding::text::SpecificCharacterSet;
@@ -434,7 +434,7 @@ impl DicomElementMarker {
     {
         let len = u64::from(
             self.header
-                .len()
+                .length()
                 .get()
                 .ok_or(InvalidValueReadError::UnresolvedValueLength)?,
         );
@@ -458,13 +458,14 @@ impl DicomElementMarker {
     }
 }
 
+impl HasLength for DicomElementMarker {
+    fn length(&self) -> Length {
+        self.header.length()
+    }
+}
 impl Header for DicomElementMarker {
     fn tag(&self) -> Tag {
         self.header.tag()
-    }
-
-    fn len(&self) -> Length {
-        self.header.len()
     }
 }
 

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -1,7 +1,7 @@
 //! Module for the data set reader
 use crate::dataset::*;
 use crate::error::{DataSetSyntaxError, Error, Result};
-use crate::printer::Printer;
+use crate::stateful::encode::StatefulEncoder;
 use dicom_core::{DataElementHeader, Length, VR};
 use dicom_encoding::encode::{Encode, EncodeTo};
 use dicom_encoding::text::{SpecificCharacterSet, TextCodec};
@@ -23,7 +23,7 @@ struct SeqToken {
 /// set tokens to bytes.
 #[derive(Debug)]
 pub struct DataSetWriter<W, E, T> {
-    printer: Printer<W, E, T>,
+    printer: StatefulEncoder<W, E, T>,
     seq_tokens: Vec<SeqToken>,
     last_de: Option<DataElementHeader>,
 }
@@ -44,7 +44,7 @@ where
 impl<W, E, T> DataSetWriter<W, E, T> {
     pub fn new(to: W, encoder: E, text: T) -> Self {
         DataSetWriter {
-            printer: Printer::new(to, encoder, text),
+            printer: StatefulEncoder::new(to, encoder, text),
             seq_tokens: Vec::new(),
             last_de: None,
         }
@@ -77,7 +77,7 @@ where
         // the respective delimiter
 
         match token {
-            DataToken::SequenceStart { tag: _, len } => {
+            DataToken::SequenceStart { len, .. } => {
                 self.seq_tokens.push(SeqToken {
                     typ: SeqTokenType::Sequence,
                     len,

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -19,6 +19,10 @@ quick_error! {
         InvalidFormat {
             description("Content is not DICOM or is corrupted")
         }
+        /// A required element in the meta group is missing
+        MissingMetaElement(name: &'static str) {
+            display("Missing required meta element `{}`", name)
+        }
         /// Raised when the obtained data element was not the one expected.
         UnexpectedTag(tag: Tag) {
             description("Unexpected DICOM element tag in current reading position")

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -11,10 +11,10 @@
 
 pub mod dataset;
 pub mod error;
-pub mod parser;
-pub mod printer;
+pub mod stateful;
 
 mod util;
 
 pub use dataset::DataSetReader;
-pub use parser::{DicomParser, DynamicDicomParser, Parse};
+pub use stateful::decode::{DynStatefulDecoder, StatefulDecode, StatefulDecoder};
+pub use stateful::encode::StatefulEncoder;

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! For a more intuitive, object-oriented API, please see the `dicom-object`
 //! crate.
-#![recursion_limit = "80"]
+#![recursion_limit = "90"]
 
 pub mod dataset;
 pub mod error;

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -5,7 +5,7 @@
 use crate::error::{Error, Result};
 use crate::util::n_times;
 use chrono::FixedOffset;
-use dicom_core::header::{DataElementHeader, Header, Length, SequenceItemHeader, Tag, VR};
+use dicom_core::header::{DataElementHeader, HasLength, Length, SequenceItemHeader, Tag, VR};
 use dicom_core::value::{PrimitiveValue, C};
 use dicom_encoding::decode::basic::{BasicDecoder, LittleEndianBasicDecoder};
 use dicom_encoding::decode::primitive_value::*;
@@ -544,7 +544,7 @@ where
     }
 
     fn read_value(&mut self, header: &DataElementHeader) -> Result<PrimitiveValue> {
-        if header.len() == Length(0) {
+        if header.length() == Length(0) {
             return Ok(PrimitiveValue::Empty);
         }
 
@@ -578,7 +578,7 @@ where
     }
 
     fn read_value_preserved(&mut self, header: &DataElementHeader) -> Result<PrimitiveValue> {
-        if header.len() == Length(0) {
+        if header.length() == Length(0) {
             return Ok(PrimitiveValue::Empty);
         }
 
@@ -615,7 +615,7 @@ where
     }
 
     fn read_value_bytes(&mut self, header: &DataElementHeader) -> Result<PrimitiveValue> {
-        if header.len() == Length(0) {
+        if header.length() == Length(0) {
             return Ok(PrimitiveValue::Empty);
         }
 
@@ -642,7 +642,7 @@ where
             _ => Ok(self
                 .from
                 .by_ref()
-                .take(header.len().get().map(u64::from).unwrap_or(std::u64::MAX))),
+                .take(header.length().get().map(u64::from).unwrap_or(std::u64::MAX))),
         }
     }
 
@@ -663,7 +663,7 @@ fn require_known_length(
     header: &DataElementHeader,
 ) -> std::result::Result<usize, InvalidValueReadError> {
     header
-        .len()
+        .length()
         .get()
         .map(|len| len as usize)
         .ok_or_else(|| InvalidValueReadError::UnresolvedValueLength)
@@ -672,7 +672,7 @@ fn require_known_length(
 #[cfg(test)]
 mod tests {
     use super::{StatefulDecode, StatefulDecoder};
-    use dicom_core::header::{Header, Length};
+    use dicom_core::header::{HasLength, Header, Length};
     use dicom_core::{Tag, VR};
     use dicom_encoding::decode::basic::LittleEndianBasicDecoder;
     use dicom_encoding::text::{DefaultCharacterSetCodec, DynamicTextCodec};
@@ -720,7 +720,7 @@ mod tests {
             let elem = decoder.decode_header().expect("should find an element");
             assert_eq!(elem.tag(), Tag(2, 2));
             assert_eq!(elem.vr(), VR::UI);
-            assert_eq!(elem.len(), Length(26));
+            assert_eq!(elem.length(), Length(26));
 
             assert_eq!(decoder.bytes_read(), 8);
 
@@ -738,7 +738,7 @@ mod tests {
             let elem = decoder.decode_header().expect("should find an element");
             assert_eq!(elem.tag(), Tag(2, 16));
             assert_eq!(elem.vr(), VR::UI);
-            assert_eq!(elem.len(), Length(20));
+            assert_eq!(elem.length(), Length(20));
 
             assert_eq!(decoder.bytes_read(), 8 + 26 + 8);
 

--- a/parser/src/stateful/encode.rs
+++ b/parser/src/stateful/encode.rs
@@ -9,6 +9,7 @@ use dicom_encoding::{
     text::{DefaultCharacterSetCodec, SpecificCharacterSet, TextCodec},
     TransferSyntax,
 };
+use dicom_encoding::transfer_syntax::DynEncoder;
 use std::io::Write;
 
 /// Also called a printer, this encoder type provides a stateful mid-level
@@ -23,9 +24,9 @@ pub struct StatefulEncoder<W, E, T> {
     bytes_written: u64,
 }
 
-pub type DynStatefulEncoder<'s> =
-    StatefulEncoder<Box<dyn Write + 's>, Box<dyn EncodeTo<dyn Write + 's>>, Box<dyn TextCodec>>;
-
+pub type DynStatefulEncoder<'w> =
+    StatefulEncoder< Box<dyn Write + 'w>, DynEncoder<'w, dyn Write>, Box<dyn TextCodec>>;
+    
 impl<W, E, T> StatefulEncoder<W, E, T> {
     pub fn new(to: W, encoder: E, text: T) -> Self {
         StatefulEncoder {

--- a/parser/src/stateful/mod.rs
+++ b/parser/src/stateful/mod.rs
@@ -1,0 +1,4 @@
+//! Stateful counterparts for decoding and encoding DICOM content.
+
+pub mod decode;
+pub mod encode;


### PR DESCRIPTION
This is another bulky set of contributions that ultimately enable users of DICOM-rs to write objects to a file. Resolves #15 as the MVP to writing, future issues related with the writing process can be made into more specific issues.

This was accompanied by several major changes, but I will summarize them here:

- substantially changed the parser and printer abstractions to be become _stateful_ decoder and encoder abstractions, thus being easier to understand their purpose and behaviour: they are like plain encoders/decoders, but target a specific byte source/sink and are aware of changes to text encoding.
- extended the dataset module with the `IntoTokens` trait and multiple useful implementations of it (including for the in-memory DICOM object type and for the file meta table).
- new experimental `dicom_value!` macro for constructing primitive values of variable cardinality.
- the method `RootDicomObject.write_to_file(path)` lets you write a complete DICOM object to disk.