### PR TITLE
Remove use of deprecated `Error::description`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,5 +16,5 @@ repository = "Enet4/dicom-rs"
 [dependencies]
 chrono = "0.4.6"
 itertools = "0.8.0"
-quick-error = "1.2.2"
+quick-error = "1.2.3"
 smallvec = "1.0.0"

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -1,7 +1,9 @@
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::marker::PhantomData;
-use std::ops::{DerefMut, Range};
+use std::ops::DerefMut;
+#[cfg(test)]
+use std::ops::Range;
 
 /** A private type trait for the ability to efficiently implement stream skipping.
  */
@@ -37,6 +39,7 @@ where
     S: Seek,
     B: DerefMut<Target = S>,
 {
+    #[cfg(test)]
     /// Create an interval from the current position and ending
     /// after `n` bytes.
     pub fn new_here(mut source: B, n: u32) -> io::Result<Self> {
@@ -50,6 +53,7 @@ where
         })
     }
 
+    #[cfg(test)]
     /// Create an interval that starts and ends according to the given
     /// range of bytes.
     pub fn new_at(mut source: B, range: Range<u64>) -> io::Result<Self> {

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -16,7 +16,7 @@ inventory-registry = ['inventory']
 [dependencies]
 dicom-core = { path = "../core", version = "0.1.0" }
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.1.0" }
-quick-error = "1.2.2"
+quick-error = "1.2.3"
 encoding = "0.2.33"
 byteordered = "0.5.0"
 inventory = { version = "0.1.4", optional = true }

--- a/encoding/src/error.rs
+++ b/encoding/src/error.rs
@@ -3,7 +3,6 @@ pub use dicom_core::error::{CastValueError, InvalidValueReadError};
 use dicom_core::Tag;
 use quick_error::quick_error;
 use std::borrow::Cow;
-use std::error::Error as BaseError;
 use std::fmt;
 use std::io;
 
@@ -16,40 +15,31 @@ quick_error! {
     pub enum Error {
         /// Raised when the obtained data element tag was not the one expected.
         UnexpectedTag(tag: Tag) {
-            description("Unexpected DICOM element tag in current reading position")
             display("Unexpected DICOM tag {}", tag)
         }
         /// Raised when the obtained length is inconsistent.
         UnexpectedDataValueLength {
-            description("Inconsistent data value length in data element")
+            display("Inconsistent data value length in data element")
         }
         /// Error related to an invalid value read.
         ReadValue(err: InvalidValueReadError) {
-            description("Invalid value read")
             from()
-            cause(err)
-            display(self_) -> ("{}: {}", self_.description(), err.description())
+            display("Invalid value read: {}", err)
         }
         /// Error related to a failed text encoding / decoding procedure.
         TextEncoding(err: TextEncodingError) {
-            description("Failed text encoding/decoding")
+            display("Failed text encoding/decoding: {}", err)
             from()
-            cause(err)
-            display(self_) -> ("{}: {}", self_.description(), err.description())
         }
         /// A failed attempt to cast a value to an inappropriate format.
         CastValue(err: CastValueError) {
-            description("Failed value cast")
+            display("Failed value cast: {}", err)
             from()
-            cause(err)
-            display(self_) -> ("{}: {}", self_.description(), err.description())
         }
         /// Other I/O errors.
         Io(err: io::Error) {
-            description("I/O error")
+            display("I/O error: {}", err)
             from()
-            cause(err)
-            display(self_) -> ("{}: {}", self_.description(), err.description())
         }
     }
 }
@@ -79,12 +69,8 @@ impl TextEncodingError {
 
 impl fmt::Display for TextEncodingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: {}", self.description(), self.0)
+        write!(f, "encoding/decoding process failed: {}", self.0)
     }
 }
 
-impl ::std::error::Error for TextEncodingError {
-    fn description(&self) -> &str {
-        "encoding/decoding process failed"
-    }
-}
+impl ::std::error::Error for TextEncodingError {}

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/Enet4/dicom-rs"
 [dependencies]
 dicom-core = { path = "../core", version = "0.1.0" }
 dicom-encoding = { path = "../encoding", version = "0.1.0" }
-quick-error = "1.2.2"
+quick-error = "1.2.3"
 chrono = "0.4.6"
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.1.0" }
 smallvec = "1.0.0"

--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -517,7 +517,7 @@ mod tests {
         #[rustfmt::skip]
         static DATA: &[u8] = &[
             0x18, 0x00, 0x11, 0x60, // sequence tag: (0018,6011) SequenceOfUltrasoundRegions
-            b'S', b'Q', // VR 
+            b'S', b'Q', // VR
             0x00, 0x00, // reserved
             0x2e, 0x00, 0x00, 0x00, // length: 28 + 18 = 46 (#= 2)
             // -- 12 --
@@ -533,7 +533,7 @@ mod tests {
             // -- 48 --
             0x18, 0x00, 0x12, 0x60, b'U', b'S', 0x02, 0x00, 0x04, 0x00, // (0018, 6012) RegionSpatialformat, len = 2, value = 4
             // -- 58 --
-            0x20, 0x00, 0x00, 0x40, b'L', b'T', 0x04, 0x00, // (0020,4000) ImageComments, len = 4  
+            0x20, 0x00, 0x00, 0x40, b'L', b'T', 0x04, 0x00, // (0020,4000) ImageComments, len = 4
             b'T', b'E', b'S', b'T', // value = "TEST"
         ];
 
@@ -657,7 +657,7 @@ mod tests {
         #[rustfmt::skip]
         static DATA: &[u8] = &[
             0x18, 0x00, 0x11, 0x60, // sequence tag: (0018,6011) SequenceOfUltrasoundRegions
-            b'S', b'Q', // VR 
+            b'S', b'Q', // VR
             0x00, 0x00, // reserved
             0xff, 0xff, 0xff, 0xff, // length: undefined
             // -- 12 --
@@ -679,7 +679,7 @@ mod tests {
             // -- 74 --
             0xfe, 0xff, 0xdd, 0xe0, 0x00, 0x00, 0x00, 0x00, // sequence end
             // -- 82 --
-            0x20, 0x00, 0x00, 0x40, b'L', b'T', 0x04, 0x00, // (0020,4000) ImageComments, len = 4  
+            0x20, 0x00, 0x00, 0x40, b'L', b'T', 0x04, 0x00, // (0020,4000) ImageComments, len = 4
             b'T', b'E', b'S', b'T', // value = "TEST"
         ];
 

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -4,7 +4,6 @@ pub use dicom_core::error::{CastValueError, InvalidValueReadError};
 use dicom_core::Tag;
 use dicom_encoding::error::{Error as EncodingError, TextEncodingError};
 use quick_error::quick_error;
-use std::error::Error as BaseError;
 use std::fmt;
 use std::io;
 
@@ -17,7 +16,7 @@ quick_error! {
     pub enum Error {
         /// Not valid DICOM content, typically raised when checking the magic code.
         InvalidFormat {
-            description("Content is not DICOM or is corrupted")
+            display("Content is not DICOM or is corrupted")
         }
         /// A required element in the meta group is missing
         MissingMetaElement(name: &'static str) {
@@ -25,81 +24,69 @@ quick_error! {
         }
         /// Raised when the obtained data element was not the one expected.
         UnexpectedTag(tag: Tag) {
-            description("Unexpected DICOM element tag in current reading position")
             display("Unexpected DICOM tag {}", tag)
         }
         InconsistentSequenceEnd(eos: u64, bytes_read: u64) {
-            description("inconsistence sequence end position")
             display("already read {} bytes, but end of sequence is @ {} bytes", bytes_read, eos)
         }
         /// Raised when the obtained length is inconsistent.
         UnexpectedDataValueLength {
-            description("Inconsistent data value length in data element")
+            display("Inconsistent data value length in data element")
         }
         /// Raised when a read was illegally attempted.
         IllegalDataRead {
-            description("Illegal data value read")
+            display("Illegal data value read")
         }
         /// Raised when the demanded transfer syntax is not supported.
         UnsupportedTransferSyntax {
-            description("Unsupported transfer syntax")
+            display("Unsupported transfer syntax")
         }
         /// Raised when the required character set is not supported.
         UnsupportedCharacterSet {
-            description("Unsupported character set")
+            display("Unsupported character set")
         }
         /// Raised when attempting to fetch an element by an unknown attribute name.
         NoSuchAttributeName {
-            description("No such attribute name")
+            display("No such attribute name")
         }
         /// Raised when attempting to fetch an unexistent element.
         NoSuchDataElement {
-            description("No such data element")
+            display("No such data element")
         }
         /// Raised when attempting to read pixel data out of bounds.
         PixelDataOutOfBounds {
-            description("Pixel data access index out of bounds")
+            display("Pixel data access index out of bounds")
         }
         /// Raised when a data set parser couldn't fetch a value after a primitive
         /// data element's header.
         MissingElementValue {
-            description("Expected value after data element header, but was missing")
+            display("Expected value after data element header, but was missing")
         }
         /// Raised while parsing a DICOM data set and found an unexpected
         /// element header or value.
         DataSetSyntax(err: DataSetSyntaxError) {
-            description("Data set syntax error")
             from()
-            cause(err)
-            display(self_) -> ("{}: {}", self_.description(), err.description())
+            display("Data set syntax error: {}", err)
         }
         /// Error related to an invalid value read.
         ReadValue(err: InvalidValueReadError) {
-            description("Invalid value read")
             from()
-            cause(err)
-            display(self_) -> ("{}: {}", self_.description(), err.description())
+            display("Invalid value read: {}", err)
         }
         /// Error related to a failed text encoding / decoding procedure.
         TextEncoding(err: TextEncodingError) {
-            description("Failed text encoding/decoding")
             from()
-            cause(err)
-            display(self_) -> ("{}: {}", self_.description(), err.description())
+            display("Failed text encoding/decoding: {}", err)
         }
         /// A failed attempt to cast a value to an inappropriate format.
         CastValue(err: CastValueError) {
-            description("Failed value cast")
             from()
-            cause(err)
-            display(self_) -> ("{}: {}", self_.description(), err.description())
+            display("Failed value cast: {}", err)
         }
         /// Other I/O errors.
         Io(err: io::Error) {
-            description("I/O error")
             from()
-            cause(err)
-            display(self_) -> ("{}: {}", self_.description(), err.description())
+            display("I/O error: {}", err)
         }
     }
 }
@@ -137,10 +124,8 @@ pub enum DataSetSyntaxError {
 impl fmt::Display for DataSetSyntaxError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            DataSetSyntaxError::PrematureEnd => f.write_str(self.description()),
-            DataSetSyntaxError::UnexpectedToken(ref token) => {
-                write!(f, "{} {}", self.description(), token)
-            }
+            DataSetSyntaxError::PrematureEnd => write!(f, "{}", self),
+            DataSetSyntaxError::UnexpectedToken(ref token) => write!(f, "{} {}", self, token),
         }
     }
 }

--- a/scpproxy/Cargo.toml
+++ b/scpproxy/Cargo.toml
@@ -9,6 +9,6 @@ repository = "https://github.com/Enet4/dicom-rs"
 
 [dependencies]
 clap = "2.33.0"
-quick-error = "1.2.2"
+quick-error = "1.2.3"
 dicom-ul = { path = "../ul/", version = "0.1.0" }
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.1.0" }

--- a/ul/Cargo.toml
+++ b/ul/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/Enet4/dicom-rs"
 
 [dependencies]
-quick-error = "1.2.2"
+quick-error = "1.2.3"
 byteordered = "0.5.0"
 dicom-encoding = { path = "../encoding/", version = "0.1.0" }
 

--- a/ul/src/error.rs
+++ b/ul/src/error.rs
@@ -1,5 +1,4 @@
 use quick_error::quick_error;
-use std::error::Error as BaseError;
 
 /// Type alias for a result from this crate.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -9,64 +8,50 @@ quick_error! {
     pub enum Error {
         Io(err: std::io::Error) {
             from()
-            display(self_) -> ("io error: {}", err)
+            display("io error: {}", err)
         }
         NoPduAvailable {
-            description("no pdu was available")
-            display(self_) -> ("{}", self_.description())
+            display("no pdu was available")
         }
         InvalidMaxPdu {
-            description("invalid max pdu")
-            display(self_) -> ("{}", self_.description())
+            display("invalid max pdu")
         }
         PduTooLarge {
-            description("the incoming pdu was too large")
-            display(self_) -> ("{}", self_.description())
+            display("the incoming pdu was too large")
         }
         InvalidPduVariable {
-            description("the pdu contained an invalid value")
-            display(self_) -> ("{}", self_.description())
+            display("the pdu contained an invalid value")
         }
         MultipleTransferSyntaxesAccepted {
-            description("multiple transfer syntaxes were accepted")
-            display(self_) -> ("{}", self_.description())
+            display("multiple transfer syntaxes were accepted")
         }
         InvalidRejectSourceOrReason {
-            description("the reject source or reason was invalid")
-            display(self_) -> ("{}", self_.description())
+            display("the reject source or reason was invalid")
         }
         InvalidAbortSourceOrReason {
-            description("the abort service provider reason was invalid")
-            display(self_) -> ("{}", self_.description())
+            display("the abort service provider reason was invalid")
         }
         InvalidPresentationContextResultReason {
-            description("the presentation context result reason was invalid")
-            display(self_) -> ("{}", self_.description())
+            display("the presentation context result reason was invalid")
         }
         InvalidTransferSyntaxSubItem {
-            description("invalid transfer syntax sub-item")
-            display(self_) -> ("{}", self_.description())
+            display("invalid transfer syntax sub-item")
         }
         UnknownPresentationContextSubItem {
-            description("unknown presentation context sub-item")
-            display(self_) -> ("{}", self_.description())
+            display("unknown presentation context sub-item")
         }
         EncodingError(err: dicom_encoding::error::Error) {
             from()
-            description("encoding error")
-            display(self_) -> ("{} {}", err, self_.description())
+            display("{} encoding error", err)
         }
         MissingApplicationContextName {
-            description("missing application context name")
-            display(self_) -> ("{}", self_.description())
+            display("missing application context name")
         }
         MissingAbstractSyntax {
-            description("missing abstract syntax")
-            display(self_) -> ("{}", self_.description())
+            display("missing abstract syntax")
         }
         MissingTransferSyntax {
-            description("missing transfer syntax")
-            display(self_) -> ("{}", self_.description())
+            display("missing transfer syntax")
         }
     }
 }


### PR DESCRIPTION
`Error::description` is fully deprecated now.

See: rust-lang/rust#66919

Also a couple of minor tidy ups.