### PR TITLE
Data set level reading and writing of encapsulated pixel data

### DIFF
--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -44,6 +44,11 @@ pub trait Header: HasLength {
     fn is_sequence_delimiter(&self) -> bool {
         self.tag() == Tag(0xFFFE, 0xE0DD)
     }
+
+    /// Check whether this is the header of an encapsulated pixel data.
+    fn is_encapsulated_pixeldata(&self) -> bool {
+        self.tag() == Tag(0x7FE0, 0x0010) && self.length().is_undefined()
+    }
 }
 
 /// Stub type representing a non-existing DICOM object.

--- a/dcmdump/src/main.rs
+++ b/dcmdump/src/main.rs
@@ -216,8 +216,7 @@ where
     writeln!(
         to,
         "{}(FFFE,E00D) na (ItemDelimitationItem) {:23} # 0, 0 ItemDelimitationItem",
-        indent,
-        ""
+        indent, ""
     )?;
     Ok(())
 }

--- a/dcmdump/src/main.rs
+++ b/dcmdump/src/main.rs
@@ -257,7 +257,7 @@ fn value_summary(value: &PrimitiveValue, vr: VR, max_characters: u32) -> Cow<str
 
 fn item_value_summary(data: &[u8], max_characters: u32) -> String {
     format_value_list(
-        data.into_iter().map(|n| format!("{:02X}", n)),
+        data.iter().map(|n| format!("{:02X}", n)),
         max_characters,
     )
 }

--- a/dcmdump/src/main.rs
+++ b/dcmdump/src/main.rs
@@ -42,7 +42,7 @@ fn dump_file(obj: DefaultDicomObject) -> IoResult<()> {
 
     let meta = obj.meta();
 
-    let width = 40;
+    let width = 48;
 
     meta_dump(&mut to, &meta, width)?;
 
@@ -127,32 +127,76 @@ where
         _ => elem.value().multiplicity(),
     };
 
-    if let DicomValue::Sequence { ref items, .. } = elem.value() {
-        writeln!(
-            to,
-            "{} {}                                # {},    {}",
-            elem.tag(),
-            elem.vr(),
-            vm,
-            tag_alias
-        )?;
-        for item in items {
-            dump_item(&mut *to, item, width, depth + 1)?;
+    match elem.value() {
+        DicomValue::Sequence { items, .. } => {
+            writeln!(
+                to,
+                "{} {} {:48} # {},    {}",
+                elem.tag(),
+                elem.vr(),
+                "",
+                vm,
+                tag_alias
+            )?;
+            for item in items {
+                dump_item(&mut *to, item, width, depth + 2)?;
+            }
+            writeln!(
+                to,
+                "(FFFE, E0DD) na (SequenceDelimitationItem) {:20} # 0, SequenceDelimitationItem",
+                "",
+            )?;
         }
-    } else {
-        let vr = elem.vr();
-        let value = elem.value().primitive().unwrap();
-        let byte_len = value.calculate_byte_len();
-        writeln!(
-            to,
-            "{} {} {:48} # {}, {} {}",
-            elem.tag(),
-            vr,
-            value_summary(&value, vr, width),
-            byte_len,
-            vm,
-            tag_alias
-        )?;
+        DicomValue::PixelSequence {
+            fragments,
+            offset_table,
+        } => {
+            // write pixel sequence start line
+            let vr = elem.vr();
+            let num_items = 1 + fragments.len();
+            writeln!(
+                to,
+                "{} {} (PixelSequence=#{}) {:29} # u/l, 1 PixelData",
+                elem.tag(),
+                vr,
+                num_items,
+                ""
+            )?;
+
+            // write offset table
+            let byte_len = offset_table.len();
+            writeln!(
+                to,
+                "  (FFFE,E000) pi {:48} # {}, 1 Item",
+                item_value_summary(&offset_table, width),
+                byte_len,
+            )?;
+
+            // write compressed fragments
+            for fragment in fragments {
+                let byte_len = fragment.len();
+                writeln!(
+                    to,
+                    "  (FFFE,E000) pi {:48} # {}, 1 Item",
+                    item_value_summary(&fragment, width),
+                    byte_len,
+                )?;
+            }
+        }
+        DicomValue::Primitive(value) => {
+            let vr = elem.vr();
+            let byte_len = value.calculate_byte_len();
+            writeln!(
+                to,
+                "{} {} {:48} # {}, {} {}",
+                elem.tag(),
+                vr,
+                value_summary(&value, vr, width),
+                byte_len,
+                vm,
+                tag_alias
+            )?;
+        }
     }
 
     Ok(())
@@ -165,14 +209,15 @@ where
 {
     let indent: String = std::iter::repeat(' ').take((depth * 2) as usize).collect();
     let trail: String = std::iter::repeat(' ')
-        .take(usize::max(21, width as usize - 21 - indent.len()))
+        .take(usize::max(21, width as usize - 4 - indent.len()))
         .collect();
     writeln!(to, "{}(FFFE,E000) na Item {} # 0, 0 Item", indent, trail)?;
     dump(to, item, width, depth + 1)?;
     writeln!(
         to,
-        "{}(FFFE,E00D) na (ItemDelimitationItem)  # 0, 0 ItemDelimitationItem",
+        "{}(FFFE,E00D) na (ItemDelimitationItem) {:23} # 0, 0 ItemDelimitationItem",
         indent,
+        ""
     )?;
     Ok(())
 }
@@ -188,13 +233,13 @@ fn value_summary(value: &PrimitiveValue, vr: VR, max_characters: u32) -> Cow<str
         (U64(values), _) => format_value_list(values, max_characters).into(),
         (I16(values), _) => format_value_list(values, max_characters).into(),
         (U16(values), VR::OW) => format_value_list(
-            values.into_iter().map(|n| format!("{:#x}", n)),
+            values.into_iter().map(|n| format!("{:02X}", n)),
             max_characters,
         )
         .into(),
         (U16(values), _) => format_value_list(values, max_characters).into(),
         (U8(values), VR::OB) | (U8(values), VR::UN) => format_value_list(
-            values.into_iter().map(|n| format!("{:#x}", n)),
+            values.into_iter().map(|n| format!("{:02X}", n)),
             max_characters,
         )
         .into(),
@@ -211,6 +256,13 @@ fn value_summary(value: &PrimitiveValue, vr: VR, max_characters: u32) -> Cow<str
     }
 }
 
+fn item_value_summary(data: &[u8], max_characters: u32) -> String {
+    format_value_list(
+        data.into_iter().map(|n| format!("{:02X}", n)),
+        max_characters,
+    )
+}
+
 fn format_value_list<I>(values: I, max_characters: u32) -> String
 where
     I: IntoIterator,
@@ -221,7 +273,7 @@ where
     let mut o = String::with_capacity(max);
     for piece in pieces {
         o.push_str(&piece.to_string());
-        o.push(',');
+        o.push('\\');
         if o.len() > max {
             break;
         }

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -386,7 +386,15 @@ where
                         fragments.push(data);
                     }
                 }
-                DataToken::ItemStart { len: _ } | DataToken::ItemEnd => { /* no-op */ }
+                DataToken::ItemEnd => {
+                    // at the end of the first item ensure the presence of
+                    // an empty offset_table here, so that the next items
+                    // are seen as compressed fragments
+                    if offset_table.is_none() {
+                        offset_table = Some(C::new())
+                    }
+                }
+                DataToken::ItemStart { len: _ } => { /* no-op */ }
                 DataToken::SequenceEnd => {
                     // end of pixel data
                     break;

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -323,6 +323,7 @@ where
         // perform a structured parsing of incoming tokens
         while let Some(token) = dataset.next() {
             let elem = match token? {
+                DataToken::EncapsulatedElementStart => todo!("encapsulated element"),
                 DataToken::ElementHeader(header) => {
                     // fetch respective value, place it in the entries
                     let next_token = dataset.next().ok_or_else(|| Error::MissingElementValue)?;

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -224,7 +224,7 @@ impl FileMetaTable {
         builder.build()
     }
 
-    pub fn into_element_iter(self) -> impl Iterator<Item = DataElement<EmptyObject>> {
+    pub fn into_element_iter(self) -> impl Iterator<Item = DataElement<EmptyObject, [u8; 0]>> {
         let mut elems = vec![
             // file information group length
             DataElement::new(

--- a/object/src/tokens.rs
+++ b/object/src/tokens.rs
@@ -30,9 +30,9 @@ where
     }
 }
 
-impl<E, I> Iterator for InMemObjectTokens<E>
+impl<P, I, E> Iterator for InMemObjectTokens<E>
 where
-    E: Iterator<Item = DataElement<I>>,
+    E: Iterator<Item = DataElement<I, P>>,
     E::Item: IntoTokens,
 {
     type Item = DataToken;

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -19,8 +19,8 @@ pub enum DataToken {
     ElementHeader(DataElementHeader),
     /// The beginning of a sequence element.
     SequenceStart { tag: Tag, len: Length },
-    /// The beginning of an encapsulated data element (Pixel Data).
-    EncapsulatedElementStart,
+    /// The beginning of an encapsulated pixel data element.
+    PixelSequenceStart,
     /// The ending delimiter of a sequence or encapsulated pixel data.
     SequenceEnd,
     /// The beginning of a new item in the sequence.
@@ -78,7 +78,7 @@ impl PartialEq<Self> for DataToken {
             (ItemValue(v1), ItemValue(v2)) => v1 == v2,
             (ItemEnd, ItemEnd)
             | (SequenceEnd, SequenceEnd)
-            | (EncapsulatedElementStart, EncapsulatedElementStart) => true,
+            | (PixelSequenceStart, PixelSequenceStart) => true,
             _ => false,
         }
     }

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -201,7 +201,7 @@ where
                 // data element header token
                 let header = *elem.header();
 
-                let token = dbg!(DataToken::from(header));
+                let token = DataToken::from(header);
                 match token {
                     DataToken::SequenceStart { .. } => {
                         // retrieve sequence value, begin item sequence

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -19,7 +19,7 @@ pub enum DataToken {
     ElementHeader(DataElementHeader),
     /// The beginning of a sequence element.
     SequenceStart { tag: Tag, len: Length },
-    /// The ending delimiter of a sequence.
+    /// The ending delimiter of a sequence or encapsulated pixel data.
     SequenceEnd,
     /// The beginning of a new item in the sequence.
     ItemStart { len: Length },
@@ -27,6 +27,12 @@ pub enum DataToken {
     ItemEnd,
     /// A primitive data element value.
     PrimitiveValue(PrimitiveValue),
+    /// An owned piece of raw data representing an item's value.
+    ///
+    /// This variant is used to represent the value of an offset table or a
+    /// compressed fragment. It should not be used to represent nested data
+    /// sets.
+    ItemValue(Vec<u8>),
 }
 
 impl fmt::Display for DataToken {
@@ -67,6 +73,7 @@ impl PartialEq<Self> for DataToken {
             ) => tag1 == tag2 && len1.inner_eq(*len2),
             (ItemStart { len: len1 }, ItemStart { len: len2 }) => len1.inner_eq(*len2),
             (PrimitiveValue(v1), PrimitiveValue(v2)) => v1 == v2,
+            (ItemValue(v1), ItemValue(v2)) => v1 == v2,
             (ItemEnd, ItemEnd) | (SequenceEnd, SequenceEnd) => true,
             _ => false,
         }

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -97,9 +97,20 @@ impl From<DataElementHeader> for DataToken {
 }
 
 impl DataToken {
+    /// Check whether this token represents the start of a sequence
+    /// of nested data sets.
     pub fn is_sequence_start(&self) -> bool {
         match self {
             DataToken::SequenceStart { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Check whether this token represents the end of a sequence
+    /// or the end of an encapsulated element.
+    pub fn is_sequence_end(&self) -> bool {
+        match self {
+            DataToken::SequenceEnd => true,
             _ => false,
         }
     }

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -19,6 +19,8 @@ pub enum DataToken {
     ElementHeader(DataElementHeader),
     /// The beginning of a sequence element.
     SequenceStart { tag: Tag, len: Length },
+    /// The beginning of an encapsulated data element (Pixel Data).
+    EncapsulatedElementStart,
     /// The ending delimiter of a sequence or encapsulated pixel data.
     SequenceEnd,
     /// The beginning of a new item in the sequence.
@@ -74,7 +76,9 @@ impl PartialEq<Self> for DataToken {
             (ItemStart { len: len1 }, ItemStart { len: len2 }) => len1.inner_eq(*len2),
             (PrimitiveValue(v1), PrimitiveValue(v2)) => v1 == v2,
             (ItemValue(v1), ItemValue(v2)) => v1 == v2,
-            (ItemEnd, ItemEnd) | (SequenceEnd, SequenceEnd) => true,
+            (ItemEnd, ItemEnd)
+            | (SequenceEnd, SequenceEnd)
+            | (EncapsulatedElementStart, EncapsulatedElementStart) => true,
             _ => false,
         }
     }

--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -840,8 +840,12 @@ mod tests {
             DataToken::ItemValue(vec![0x99; 32]),
             DataToken::ItemEnd,
             DataToken::SequenceEnd,
-            DataToken::ElementHeader(DataElementHeader::new(Tag(0xfffc, 0xfffc), VR::OB, Length(8))),
-            DataToken::PrimitiveValue(PrimitiveValue::U8([0x00; 8].as_ref().into()))
+            DataToken::ElementHeader(DataElementHeader::new(
+                Tag(0xfffc, 0xfffc),
+                VR::OB,
+                Length(8),
+            )),
+            DataToken::PrimitiveValue(PrimitiveValue::U8([0x00; 8].as_ref().into())),
         ];
 
         validate_dataset_reader(DATA, ground_truth);
@@ -888,11 +892,14 @@ mod tests {
             DataToken::ItemValue(vec![0x99; 32]),
             DataToken::ItemEnd,
             DataToken::SequenceEnd,
-            DataToken::ElementHeader(DataElementHeader::new(Tag(0xfffc, 0xfffc), VR::OB, Length(8))),
-            DataToken::PrimitiveValue(PrimitiveValue::U8([0x00; 8].as_ref().into()))
+            DataToken::ElementHeader(DataElementHeader::new(
+                Tag(0xfffc, 0xfffc),
+                VR::OB,
+                Length(8),
+            )),
+            DataToken::PrimitiveValue(PrimitiveValue::U8([0x00; 8].as_ref().into())),
         ];
 
         validate_dataset_reader(DATA, ground_truth);
     }
-
 }

--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -296,7 +296,7 @@ where
                     self.last_header = Some(header);
                     // token variant depends on whether it's encapsulated pixel data
                     if header.is_encapsulated_pixeldata() {
-                        Some(Ok(DataToken::EncapsulatedElementStart))
+                        Some(Ok(DataToken::PixelSequenceStart))
                     } else {
                         Some(Ok(DataToken::ElementHeader(header)))
                     }
@@ -833,7 +833,7 @@ mod tests {
         ];
 
         let ground_truth = vec![
-            DataToken::EncapsulatedElementStart,
+            DataToken::PixelSequenceStart,
             DataToken::ItemStart { len: Length(0) },
             DataToken::ItemEnd,
             DataToken::ItemStart { len: Length(32) },

--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -339,7 +339,7 @@ where
                             token = DataToken::ItemEnd;
                         }
                     }
-                    dbg!(self.seq_delimiters.pop());
+                    self.seq_delimiters.pop();
                     return Ok(Some(token));
                 } else if eos < bytes_read {
                     return Err(Error::InconsistentSequenceEnd(eos, bytes_read));
@@ -351,12 +351,12 @@ where
     }
 
     fn push_sequence_token(&mut self, typ: SeqTokenType, len: Length, pixel_data: bool) {
-        self.seq_delimiters.push(dbg!(SeqToken {
+        self.seq_delimiters.push(SeqToken {
             typ,
             pixel_data,
             len,
             base_offset: self.parser.bytes_read(),
-        }))
+        })
     }
 }
 

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -123,8 +123,9 @@ where
                 });
                 self.write_impl(token)
             }
-            token @ DataToken::ItemValue(_)
-            | token @ DataToken::PrimitiveValue(_) => self.write_impl(token),
+            token @ DataToken::ItemValue(_) | token @ DataToken::PrimitiveValue(_) => {
+                self.write_impl(token)
+            }
         }
     }
 
@@ -344,7 +345,11 @@ mod tests {
             DataToken::ItemValue(vec![0x99; 32]),
             DataToken::ItemEnd,
             DataToken::SequenceEnd,
-            DataToken::ElementHeader(DataElementHeader::new(Tag(0xfffc, 0xfffc), VR::OB, Length(8))),
+            DataToken::ElementHeader(DataElementHeader::new(
+                Tag(0xfffc, 0xfffc),
+                VR::OB,
+                Length(8),
+            )),
             DataToken::PrimitiveValue(PrimitiveValue::U8([0x00; 8].as_ref().into())),
         ];
 
@@ -378,5 +383,4 @@ mod tests {
 
         validate_dataset_writer(tokens, GROUND_TRUTH);
     }
-
 }

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -116,7 +116,7 @@ where
                 self.last_de = Some(de.clone());
                 self.write_impl(token)
             }
-            token @ DataToken::EncapsulatedElementStart => {
+            token @ DataToken::PixelSequenceStart => {
                 self.seq_tokens.push(SeqToken {
                     typ: SeqTokenType::Sequence,
                     len: Length::UNDEFINED,
@@ -137,7 +137,7 @@ where
                 self.printer
                     .encode_element_header(DataElementHeader::new(tag, VR::SQ, len))?;
             }
-            DataToken::EncapsulatedElementStart => {
+            DataToken::PixelSequenceStart => {
                 self.printer.encode_element_header(DataElementHeader::new(
                     Tag(0x7fe0, 0x0010),
                     VR::OB,
@@ -337,7 +337,7 @@ mod tests {
     #[test]
     fn write_encapsulated_pixeldata() {
         let tokens = vec![
-            DataToken::EncapsulatedElementStart,
+            DataToken::PixelSequenceStart,
             DataToken::ItemStart { len: Length(0) },
             DataToken::ItemEnd,
             DataToken::ItemStart { len: Length(32) },

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -335,7 +335,7 @@ mod tests {
     }
 
     #[test]
-    fn read_encapsulated_pixeldata() {
+    fn write_encapsulated_pixeldata() {
         let tokens = vec![
             DataToken::EncapsulatedElementStart,
             DataToken::ItemStart { len: Length(0) },
@@ -344,6 +344,8 @@ mod tests {
             DataToken::ItemValue(vec![0x99; 32]),
             DataToken::ItemEnd,
             DataToken::SequenceEnd,
+            DataToken::ElementHeader(DataElementHeader::new(Tag(0xfffc, 0xfffc), VR::OB, Length(8))),
+            DataToken::PrimitiveValue(PrimitiveValue::U8([0x00; 8].as_ref().into())),
         ];
 
         #[rustfmt::skip]
@@ -366,6 +368,12 @@ mod tests {
             // -- 60 -- End of pixel data
             0xfe, 0xff, 0xdd, 0xe0, // sequence end tag
             0x00, 0x00, 0x00, 0x00,
+            // -- 68 -- padding
+            0xfc, 0xff, 0xfc, 0xff, // (fffc,fffc) DataSetTrailingPadding
+            b'O', b'B', // VR
+            0x00, 0x00, // reserved
+            0x08, 0x00, 0x00, 0x00, // length: 8
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
 
         validate_dataset_writer(tokens, GROUND_TRUTH);

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -121,31 +121,33 @@ where
     }
 
     fn write_impl(&mut self, token: DataToken) -> Result<()> {
-        use DataToken::*;
         match token {
-            ElementHeader(header) => {
+            DataToken::ElementHeader(header) => {
                 self.printer.encode_element_header(header)?;
             }
-            SequenceStart { tag, len } => {
+            DataToken::SequenceStart { tag, len } => {
                 self.printer
                     .encode_element_header(DataElementHeader::new(tag, VR::SQ, len))?;
             }
-            SequenceEnd => {
+            DataToken::SequenceEnd => {
                 self.printer.encode_sequence_delimiter()?;
             }
-            ItemStart { len } => {
+            DataToken::ItemStart { len } => {
                 self.printer.encode_item_header(len.0)?;
             }
-            ItemEnd => {
+            DataToken::ItemEnd => {
                 self.printer.encode_item_delimiter()?;
             }
-            PrimitiveValue(ref value) => {
+            DataToken::PrimitiveValue(ref value) => {
                 let last_de = self
                     .last_de
                     .as_ref()
                     .ok_or_else(|| DataSetSyntaxError::UnexpectedToken(token.clone()))?;
                 self.printer.encode_primitive(last_de, value)?;
                 self.last_de = None;
+            }
+            DataToken::ItemValue(data) => {
+                self.printer.write_bytes(&data)?;
             }
         }
         Ok(())

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -116,7 +116,9 @@ where
                 self.last_de = Some(de.clone());
                 self.write_impl(token)
             }
-            _ => self.write_impl(token),
+            token @ DataToken::EncapsulatedElementStart
+            | token @ DataToken::ItemValue(_)
+            | token @ DataToken::PrimitiveValue(_) => self.write_impl(token),
         }
     }
 
@@ -128,6 +130,13 @@ where
             DataToken::SequenceStart { tag, len } => {
                 self.printer
                     .encode_element_header(DataElementHeader::new(tag, VR::SQ, len))?;
+            }
+            DataToken::EncapsulatedElementStart => {
+                self.printer.encode_element_header(DataElementHeader::new(
+                    Tag(0x7fe0, 0x0010),
+                    VR::OB,
+                    Length::UNDEFINED,
+                ))?;
             }
             DataToken::SequenceEnd => {
                 self.printer.encode_sequence_delimiter()?;

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -72,6 +72,9 @@ pub trait StatefulDecode {
         header: &DataElementHeader,
     ) -> Result<std::io::Take<&mut Self::Reader>>;
 
+    /// Read the exact amount of bytes to fill the buffer.
+    fn read_bytes(&mut self, buf: &mut [u8]) -> Result<()>;
+
     /// Retrieve the exact number of bytes read so far by the stateful decoder.
     fn bytes_read(&self) -> u64;
 }
@@ -647,6 +650,12 @@ where
                     .unwrap_or(std::u64::MAX),
             )),
         }
+    }
+
+    fn read_bytes(&mut self, buf: &mut [u8]) -> Result<()> {
+        self.from.read_exact(buf)?;
+        self.bytes_read += buf.len() as u64;
+        Ok(())
     }
 
     fn bytes_read(&self) -> u64 {

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -737,9 +737,9 @@ mod tests {
             assert_eq!(decoder.bytes_read(), 8);
 
             // read value
-            let value = dbg!(decoder
+            let value = decoder
                 .read_value(&elem)
-                .expect("value after element header"));
+                .expect("value after element header");
             assert_eq!(value.multiplicity(), 1);
             assert_eq!(value.string(), Some("1.2.840.10008.5.1.4.1.1.1\0"));
 

--- a/parser/src/stateful/encode.rs
+++ b/parser/src/stateful/encode.rs
@@ -14,7 +14,8 @@ use std::io::Write;
 
 /// Also called a printer, this encoder type provides a stateful mid-level
 /// abstraction for writing DICOM content. Unlike `Encode`,
-/// the stateful encoder knows how to write text values.
+/// the stateful encoder knows how to write text values and keeps track
+/// of how many bytes were written.
 /// `W` is the write target, `E` is the encoder, and `T` is the text codec.
 #[derive(Debug)]
 pub struct StatefulEncoder<W, E, T> {
@@ -93,6 +94,13 @@ where
     pub fn encode_sequence_delimiter(&mut self) -> Result<()> {
         self.encoder.encode_sequence_delimiter(&mut self.to)?;
         self.bytes_written += 8;
+        Ok(())
+    }
+
+    /// Write all bytes directly to the inner writer.
+    pub fn write_bytes(&mut self, bytes: &[u8]) -> Result<()> {
+        self.to.write_all(bytes)?;
+        self.bytes_written += bytes.len() as u64;
         Ok(())
     }
 


### PR DESCRIPTION
This PR extends the data set reader/writer so that it understands the logic of pixel sequences in the data set. This ultimately makes it possible to read files with an encapsulated pixel data. Resolves #23.

- Two new types of `DataToken`s: `PixelSequenceStart` (for the beginning of an encapsulated pixel data element) and `ItemValue` (for the raw contents of a pixel data item).
- Handle Pixel Data (7EF0, 0010) elements with an undefined length as encapsulated pixel data.
- New DICOM value variant PixelSequence allows you to represent DICOM pixel sequences in memory, including .
   - The current implementation of `InMemDicomObject` will collect all fragments and the offset table as-is into memory, thus retaining the fact that the pixel data is encapsulated.

The known caveat is that DICOM values and data tokens need to own the memory that they are working with. This means that data may still need to be copied around in some cases (e.g. saving a DICOM object to disk), and that each data token has to be fully contained in memory. This is likely to be reiterated to address the concerns presented in #1, so that tokens may instead borrow or refer to an arbitrary reader source.