### PR TITLE
Add support for OB values with unkown length

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,6 +21,7 @@ pub use dictionary::DataDictionary;
 pub use error::{Error, Result};
 pub use header::{DataElement, DataElementHeader, Length, Tag, VR};
 pub use value::{PrimitiveValue, Value as DicomValue};
+pub use util::ReadSeek;
 
 // re-export the chrono crate, as used in the public API
 pub use chrono;

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -22,6 +22,7 @@ where
     }
 }
 
+/// A trait that combines io::Read and io::Seek
 pub trait ReadSeek: Read + Seek {}
 impl<T: ?Sized> ReadSeek for T where T: Read + Seek {}
 

--- a/encoding/src/transfer_syntax/mod.rs
+++ b/encoding/src/transfer_syntax/mod.rs
@@ -16,6 +16,7 @@ pub mod implicit_le;
 use crate::decode::basic::BasicDecoder;
 use crate::decode::DecodeFrom;
 use crate::encode::{EncodeTo, EncoderFor};
+use dicom_core::ReadSeek;
 use std::io::{Read, Write};
 
 pub use byteordered::Endianness;
@@ -276,7 +277,7 @@ impl<A> TransferSyntax<A> {
     /// The resulting decoder does not consider pixel data encapsulation or
     /// data set compression rules. This means that the consumer of this method
     /// needs to adapt the reader before using the decoder.
-    pub fn decoder<'s>(&self) -> Option<DynDecoder<dyn Read + 's>> {
+    pub fn decoder<'s>(&self) -> Option<DynDecoder<dyn ReadSeek + 's>> {
         self.decoder_for()
     }
 

--- a/object/Cargo.toml
+++ b/object/Cargo.toml
@@ -21,3 +21,6 @@ dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry", version
 itertools = "0.9.0"
 byteordered = "0.5.0"
 smallvec = "1.0.0"
+
+[dev-dependencies]
+dicom-test-files = "0.1.2"

--- a/object/src/file.rs
+++ b/object/src/file.rs
@@ -1,6 +1,6 @@
 use crate::DefaultDicomObject;
 use dicom_parser::error::Result;
-use std::io::Read;
+use std::io::{Read, Seek};
 use std::path::Path;
 
 /// Create a DICOM object by reading from a byte source.
@@ -9,7 +9,7 @@ use std::path::Path;
 /// preamble: file meta group, followed by the rest of the data set.
 pub fn from_reader<F>(file: F) -> Result<DefaultDicomObject>
 where
-    F: Read,
+    F: Read + Seek,
 {
     DefaultDicomObject::from_reader(file)
 }

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use smallvec::SmallVec;
 use std::collections::BTreeMap;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, Read, Seek};
 use std::path::Path;
 
 use crate::meta::FileMetaTable;
@@ -85,7 +85,7 @@ impl RootDicomObject<InMemDicomObject<StandardDataDictionary>> {
     /// preamble: file meta group, followed by the rest of the data set.
     pub fn from_reader<S>(src: S) -> Result<Self>
     where
-        S: Read,
+        S: Read + Seek,
     {
         Self::from_reader_with_dict(src, StandardDataDictionary)
     }
@@ -190,7 +190,7 @@ where
     /// preamble: file meta group, followed by the rest of the data set.
     pub fn from_reader_with_dict<S>(src: S, dict: D) -> Result<Self>
     where
-        S: Read,
+        S: Read + Seek,
     {
         Self::from_reader_with(src, dict, TransferSyntaxRegistry)
     }
@@ -207,7 +207,7 @@ where
     /// [`from_reader_with_dict`]: #method.from_reader_with_dict
     pub fn from_reader_with<'s, S: 's, R>(src: S, dict: D, ts_index: R) -> Result<Self>
     where
-        S: Read,
+        S: Read + Seek,
         R: TransferSyntaxIndex,
     {
         let mut file = BufReader::new(src);

--- a/object/tests/integration_test.rs
+++ b/object/tests/integration_test.rs
@@ -9,11 +9,15 @@ fn test_ob_value_with_unknown_length() {
     let object = open_file(&path).unwrap();
     let element = object.element_by_name("PixelData").unwrap();
 
-    if let Value::Primitive(PrimitiveValue::U8(bytes)) = element.value() {
-        // check the start and end of the bytes the check it looks right
-        assert_eq!(bytes[0..2], [0xfe, 0xff]);
-        assert_eq!(bytes[bytes.len() - 2..bytes.len()], [0xff, 0xd9]);
-    } else {
-        panic!("expected a byte value");
+    println!("{:?}", element.value());
+    match element.value() {
+        Value::PixelSequence { fragments, .. } => {
+            // check the start and end of the bytes the check it looks right
+            assert_eq!(fragments[0][0..2], [0xfe, 0xff]);
+            assert_eq!(fragments[0][fragments.len() - 2..fragments.len()], [0xff, 0xd9]);
+        },
+        _ => {
+            panic!("expected a byte value");
+        }
     }
 }

--- a/object/tests/integration_test.rs
+++ b/object/tests/integration_test.rs
@@ -1,0 +1,19 @@
+use dicom_core::value::{PrimitiveValue, Value};
+use dicom_object::open_file;
+use dicom_test_files;
+
+#[test]
+fn test_ob_value_with_unknown_length() {
+    let path =
+        dicom_test_files::path("pydicom/JPEG2000.dcm").expect("test DICOM file should exist");
+    let object = open_file(&path).unwrap();
+    let element = object.element_by_name("PixelData").unwrap();
+
+    if let Value::Primitive(PrimitiveValue::U8(bytes)) = element.value() {
+        // check the start and end of the bytes the check it looks right
+        assert_eq!(bytes[0..2], [0xfe, 0xff]);
+        assert_eq!(bytes[bytes.len() - 2..bytes.len()], [0xff, 0xd9]);
+    } else {
+        panic!("expected a byte value");
+    }
+}

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -14,3 +14,4 @@ quick-error = "1.2.3"
 chrono = "0.4.6"
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.2.0" }
 smallvec = "1.0.0"
+byteordered = "0.5.0"

--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -848,7 +848,7 @@ mod tests {
             DataToken::PrimitiveValue(PrimitiveValue::U8([0x00; 8].as_ref().into())),
         ];
 
-        validate_dataset_reader(DATA, ground_truth);
+        validate_dataset_reader(&mut Cursor::new(DATA), ground_truth);
     }
 
     #[test]
@@ -900,6 +900,6 @@ mod tests {
             DataToken::PrimitiveValue(PrimitiveValue::U8([0x00; 8].as_ref().into())),
         ];
 
-        validate_dataset_reader(DATA, ground_truth);
+        validate_dataset_reader(&mut Cursor::new(DATA), ground_truth);
     }
 }


### PR DESCRIPTION
This PR needs a bit of rearranging but the core of it is here and works. There are two distinct parts to it.

## Add integration test for unknown OB length

While trying to parse some example DICOM files the most common issue I came across was failing because the file had an OB value of unknown length. In order to get some good high level tests around this I asked over at [pydicom](https://github.com/pydicom/pydicom/issues/1112) if I could use some of their example files. Off the back of that I have created a separate crate for providing example DICOM files called (rather unimaginatively) [dicom-test-files](https://github.com/robyoung/dicom-test-files) and created a failing integration test for a file that uses unknown OB length.

## Add support for decoding OB value of unknown length

Change `Read` to `ReadSeek` in a few places (or just add `Write`) so that we can read ahead in chunks and then seek back when we overshoot rather than reading a byte at a time. I experimented with reading with very small chunks and even though we're going over a `BufferedReader` performance took a massive hit.

Getting a `Tag` as bytes in a given endianness feels like it's in the wrong place but I'm not sure where the right place is. It feels like a trait that provides `as_bytes` would be ideal but I'm not sure
where that should live. Neither core nor parser seem quite right.

Panicking when the trailing 4 zero bytes are not found is not ideal but I'm not sure of the best error to return there.




