### PR TITLE
[dcmdump] term size and primitive columns

### DIFF
--- a/dcmdump/Cargo.toml
+++ b/dcmdump/Cargo.toml
@@ -14,3 +14,4 @@ default = ['dicom/inventory-registry']
 
 [dependencies]
 dicom = { path = "../parent/", version = "0.2.0", default-features = false }
+term_size = "0.3.2"


### PR DESCRIPTION
- Add term_size crate to expand width for wider screens.
- Add divider between meta and body.
- Reorder Primitive fields so that tag and tag alias are together on the
  left and other fields expand out from there. The hope is that this
  makes it easier to scan the output.