### PR TITLE
Add integration test for unknown OB length

### DIFF
--- a/object/Cargo.toml
+++ b/object/Cargo.toml
@@ -21,3 +21,6 @@ dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry", version
 itertools = "0.9.0"
 byteordered = "0.5.0"
 smallvec = "1.0.0"
+
+[dev-dependencies]
+dicom-test-files = "0.2.0"

--- a/object/tests/integration_test.rs
+++ b/object/tests/integration_test.rs
@@ -11,7 +11,7 @@ fn test_ob_value_with_unknown_length() {
 
     match element.value() {
         Value::PixelSequence { fragments, .. } => {
-            // check the start and end of the bytes the check it looks right
+            // check if the leading and trailing bytes look right
             assert_eq!(fragments.len(), 1);
             let fragment = &fragments[0];
             assert_eq!(fragment[0..2], [255, 79]);

--- a/object/tests/integration_test.rs
+++ b/object/tests/integration_test.rs
@@ -1,0 +1,24 @@
+use dicom_core::value::Value;
+use dicom_object::open_file;
+use dicom_test_files;
+
+#[test]
+fn test_ob_value_with_unknown_length() {
+    let path =
+        dicom_test_files::path("pydicom/JPEG2000.dcm").expect("test DICOM file should exist");
+    let object = open_file(&path).unwrap();
+    let element = object.element_by_name("PixelData").unwrap();
+
+    match element.value() {
+        Value::PixelSequence { fragments, .. } => {
+            // check the start and end of the bytes the check it looks right
+            assert_eq!(fragments.len(), 1);
+            let fragment = &fragments[0];
+            assert_eq!(fragment[0..2], [255, 79]);
+            assert_eq!(fragment[fragment.len() - 2..fragment.len()], [255, 217]);
+        },
+        _ => {
+            panic!("expected a byte value");
+        }
+    }
+}


### PR DESCRIPTION
This test makes use of a DICOM file that was originally from [pydicom](https://github.com/pydicom/pydicom) that contains an OB field with unknown length.

This makes use of the [dicom-test-files](https://github.com/robyoung/dicom-test-files) crate that provides access to
DICOM files that can be used for testing across different DICOM readers.