### PR TITLE
Text encoding revamp: trait changes and more text encodings

### DIFF
--- a/encoding/src/text.rs
+++ b/encoding/src/text.rs
@@ -12,7 +12,11 @@
 //! - GB 18030
 //! - GB2312
 //!
-//! At the moment, this library supports only IR-6 and IR-192.
+//! At the moment, text encoding support is limited.
+//! Please see [`SpecificCharacterSet`] for a complete enumeration
+//! of all supported character encoding in the crate.
+//!
+//! [`SpecificCharacterSet`]: ./enum.SpecificCharacterSet.html
 
 use crate::error::{Result, TextEncodingError};
 use encoding::all::{GB18030, ISO_8859_1, UTF_8};
@@ -83,16 +87,17 @@ where
 /// text encoding format at run-time.
 pub type DynamicTextCodec = Box<dyn TextCodec>;
 
-/// An enum type for the the supported character sets.
+/// An enum type for all currently supported character sets.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum SpecificCharacterSet {
-    /// The default character set.
+    /// **ISO-IR 6**: the default character set.
     Default,
-    /// The Unicode character set defined in ISO IR 192, based on the UTF-8 encoding.
+    /// **ISO-IR 192**:: The Unicode character set based on the UTF-8 encoding.
     IsoIr192,
-    /// The Simplified Chinese character set defined in GB18030.
+    /// **GB18030**: The Simplified Chinese character set.
     GB18030,
-    // TODO make this more flexible (maybe registry-based)
+    // Support for more text encodings is tracked in issue #40.
 }
 
 impl Default for SpecificCharacterSet {

--- a/encoding/src/text.rs
+++ b/encoding/src/text.rs
@@ -303,12 +303,20 @@ pub fn validate_cs(text: &[u8]) -> TextValidationOutcome {
 mod tests {
     use super::*;
 
+    fn test_codec<T>(codec: T, string: &str, bytes: &[u8])
+    where
+        T: TextCodec,
+    {
+        assert_eq!(codec.encode(string).expect("encoding"), bytes);
+        assert_eq!(codec.decode(bytes).expect("decoding"), string);
+    }
+
     #[test]
     fn iso_ir_6_baseline() {
         let codec = SpecificCharacterSet::Default
             .codec()
             .expect("Must be fully supported");
-        assert_eq!(codec.decode(b"Smith^John").unwrap(), "Smith^John");
+        test_codec(codec, "Smith^John", b"Smith^John");
     }
 
     #[test]
@@ -316,14 +324,8 @@ mod tests {
         let codec = SpecificCharacterSet::IsoIr192
             .codec()
             .expect("Should be fully supported");
-        assert_eq!(
-            codec.decode("Simões^John".as_bytes()).unwrap(),
-            "Simões^John",
-        );
-        assert_eq!(
-            codec.decode("Иванков^Андрей".as_bytes()).unwrap(),
-            "Иванков^Андрей",
-        );
+        test_codec(&codec, "Simões^John", "Simões^John".as_bytes());
+        test_codec(codec, "Иванков^Андрей", "Иванков^Андрей".as_bytes());
     }
 
     #[test]
@@ -331,8 +333,8 @@ mod tests {
         let codec = SpecificCharacterSet::IsoIr100
             .codec()
             .expect("Should be fully supported");
-        assert_eq!(codec.decode(b"Sim\xF5es^Jo\xE3o").unwrap(), "Simões^João");
-        assert_eq!(codec.decode(b"G\xfcnther^Hans").unwrap(), "Günther^Hans");
+        test_codec(&codec, "Simões^João", b"Sim\xF5es^Jo\xE3o");
+        test_codec(codec, "Günther^Hans", b"G\xfcnther^Hans");
     }
 
     #[test]
@@ -340,7 +342,7 @@ mod tests {
         let codec = SpecificCharacterSet::IsoIr101
             .codec()
             .expect("Should be fully supported");
-        assert_eq!(codec.decode(b"G\xfcnther^Hans").unwrap(), "Günther^Hans");
+        test_codec(codec, "Günther^Hans", b"G\xfcnther^Hans");
     }
 
     #[test]
@@ -348,11 +350,10 @@ mod tests {
         let codec = SpecificCharacterSet::IsoIr144
             .codec()
             .expect("Should be fully supported");
-        assert_eq!(
-            codec
-                .decode(b"\xb8\xd2\xd0\xdd\xda\xde\xd2^\xb0\xdd\xd4\xe0\xd5\xd9")
-                .unwrap(),
+        test_codec(
+            codec,
             "Иванков^Андрей",
+            b"\xb8\xd2\xd0\xdd\xda\xde\xd2^\xb0\xdd\xd4\xe0\xd5\xd9",
         );
     }
 }

--- a/encoding/src/text.rs
+++ b/encoding/src/text.rs
@@ -14,7 +14,7 @@
 //!
 //! At the moment, text encoding support is limited.
 //! Please see [`SpecificCharacterSet`] for a complete enumeration
-//! of all supported character encoding in the crate.
+//! of all supported text encodings.
 //!
 //! [`SpecificCharacterSet`]: ./enum.SpecificCharacterSet.html
 
@@ -92,7 +92,7 @@ pub type DynamicTextCodec = Box<dyn TextCodec>;
 pub enum SpecificCharacterSet {
     /// **ISO-IR 6**: the default character set.
     Default,
-    /// **ISO-IR 101** (ISO-8859-1): Right-hand part of the Latin alphabet no. 1,
+    /// **ISO-IR 100** (ISO-8859-1): Right-hand part of the Latin alphabet no. 1,
     /// the Western Europe character set.
     IsoIr100,
     /// **ISO-IR 101** (ISO-8859-2): Right-hand part of the Latin alphabet no. 2,


### PR DESCRIPTION
This is another step intended to cover some of the current issues in text encoding.

**Major changes:**

- `TextCodec` no longer implies `Debug`
   - This is not a common practice anyway, such a constraint makes more sense where it is actually needed.
- New method `TextCodec::name`, for retrieving the character set's defined term.
- `SpecificCharacterSet` is marked as non-exhaustive, so that the presence of future encodings does not break future code upon this change.

**New:**

- New character encodings: ISO-IR 100, ISO-IR 101, ISO-IR 109, ISO-IR 110, ISO-IR 144.  
- Report to stderr when an unsupported text encoding is decoded (should become a warning log line with #49).

**Misc:**

- Added a test at `parser` to check that the specific character set is updated after decoding the respective data element (verifies #52).
- Used a macro to implement existing text encodings via the `encoding` crate.
- Add baseline tests for some of the current text encodings.