### PR TITLE
Add WebAssembly testing in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,34 @@ matrix:
    - rust: beta
    - rust: nightly
      env: CLIPPY=1
+   - rust: stable
+     env: WASM=1
   allow_failures:
     - rust: nightly
+    - env: WASM=1
 
 before_script:
   - if [ "$CLIPPY" ]; then
       (rustup component add clippy || rustup component add clippy-preview) && CLIPPY_INSTALLED=1 || CLIPPY_INSTALLED=0;
     fi
+  - if [ "$WASM" ]; then
+      curl https://wasmtime.dev/install.sh -sSf | bash &&
+      source ~/.bashrc &&
+      cargo install cargo-wasi &&
+      rustup target add wasm32-wasi;
+    fi
 
 script:
-  - cargo build --all
   - if [ "$CLIPPY_INSTALLED" == 1 ]; then
       cargo clippy;
     fi
-  # default features
-  - cargo test --all
-  # no inventory
-  - cargo test --manifest-path encoding/Cargo.toml --no-default-features
-  - cargo test --manifest-path transfer-syntax-registry/Cargo.toml --no-default-features
+  - if [ "$WASM" ]; then
+      cargo wasi test --workspace
+          --exclude dcmdump --exclude dicom-dictionary-builder --exclude dicom-scpproxy
+          --exclude dicom-object --exclude dicom-transfer-syntax-registry
+          -- --nocapture;
+    else
+      cargo test --all;
+      cargo test --manifest-path encoding/Cargo.toml --no-default-features;
+      cargo test --manifest-path transfer-syntax-registry/Cargo.toml --no-default-features;
+    fi


### PR DESCRIPTION
This PR adds a new job which runs tests in low-level and mid-level crates through wasmtime.