### PR TITLE
Update and improve transfer-syntax-registry

### DIFF
--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -6,6 +6,7 @@ use dicom_encoding::transfer_syntax::{AdapterFreeTransferSyntax as Ts, Codec};
 
 // -- the three base transfer syntaxes, fully supported --
 
+/// **Fully implemented:** Implicit VR Little Endian: Default Transfer Syntax for DICOM
 pub const IMPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
     "1.2.840.10008.1.2",
     "Implicit VR Little Endian",
@@ -14,6 +15,7 @@ pub const IMPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
     Codec::None,
 );
 
+/// **Fully implemented:** Explicit VR Little Endian
 pub const EXPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
     "1.2.840.10008.1.2.1",
     "Explicit VR Little Endian",
@@ -22,6 +24,7 @@ pub const EXPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
     Codec::None,
 );
 
+/// **Fully implemented:** Explicit VR Big Endian
 pub const EXPLICIT_VR_BIG_ENDIAN: Ts = Ts::new(
     "1.2.840.10008.1.2.2",
     "Explicit VR Big Endian",
@@ -32,6 +35,7 @@ pub const EXPLICIT_VR_BIG_ENDIAN: Ts = Ts::new(
 
 // --- stub transfer syntaxes, known but not supported ---
 
+/// **Stub descriptor:** Deflated Explicit VR Little Endian
 pub const DEFLATED_EXPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
     "1.2.840.10008.1.2.1.99",
     "Deflated Explicit VR Little Endian",
@@ -40,7 +44,8 @@ pub const DEFLATED_EXPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
     Codec::Unsupported,
 );
 
-pub const JPIP_DEREFERENCED_DEFLATE: Ts = Ts::new(
+/// **Stub descriptor:** JPIP Referenced Deflate
+pub const JPIP_REFERENCED_DEFLATE: Ts = Ts::new(
     "1.2.840.10008.1.2.4.95",
     "JPIP Referenced Deflate",
     Endianness::Little,
@@ -50,70 +55,109 @@ pub const JPIP_DEREFERENCED_DEFLATE: Ts = Ts::new(
 
 // --- partially supported transfer syntaxes, pixel data encapsulation not supported ---
 
+/// **Stub descriptor:** JPEG Baseline (Process 1): Default Transfer Syntax for Lossy JPEG 8 Bit Image Compression
 pub const JPEG_BASELINE: Ts = create_ts_stub("1.2.840.10008.1.2.4.50", "JPEG Baseline (Process 1)");
+/// **Stub descriptor:** JPEG Extended (Process 2 & 4): Default Transfer Syntax for Lossy JPEG 12 Bit Image Compression (Process 4 only)
 pub const JPEG_EXTENDED: Ts =
     create_ts_stub("1.2.840.10008.1.2.4.51", "JPEG Extended (Process 2 & 4)");
+/// **Stub descriptor:** JPEG Lossless, Non-Hierarchical (Process 14)
 pub const JPEG_LOSSLESS_NON_HIERARCHICAL: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.57",
     "JPEG Lossless, Non-Hierarchical (Process 14)",
 );
+/// **Stub descriptor:** JPEG Lossless, Non-Hierarchical, First-Order Prediction
+/// (Process 14 [Selection Value 1]):
+/// Default Transfer Syntax for Lossless JPEG Image Compression
 pub const JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.70",
     "JPEG Lossless, Non-Hierarchical, First-Order Prediction",
 );
+/// **Stub descriptor:** JPEG-LS Lossless Image Compression
 pub const JPEG_LS_LOSSLESS_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.80",
     "JPEG-LS Lossless Image Compression",
 );
+/// **Stub descriptor:** JPEG-LS Lossy (Near-Lossless) Image Compression
 pub const JPEG_LS_LOSSY_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.81",
     "JPEG-LS Lossy (Near-Lossless) Image Compression",
 );
+/// **Stub descriptor:** JPEG 2000 Image Compression (Lossless Only)
 pub const JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.90",
     "JPEG 2000 Image Compression (Lossless Only)",
 );
+/// **Stub descriptor:** JPEG 2000 Image Compression
 pub const JPEG_2000_IMAGE_COMPRESSION: Ts =
     create_ts_stub("1.2.840.10008.1.2.4.91", "JPEG 2000 Image Compression");
+/// **Stub descriptor:** JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)
 pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.92",
     "JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)",
 );
+/// **Stub descriptor:** JPEG 2000 Part 2 Multi-component Image Compression
 pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.93",
     "JPEG 2000 Part 2 Multi-component Image Compression",
 );
+/// **Stub descriptor:** JPIP Referenced
 pub const JPIP_REFERENCED: Ts = create_ts_stub("1.2.840.10008.1.2.4.94", "JPIP Referenced");
+
+/// **Stub descriptor:** MPEG2 Main Profile / Main Level
 pub const MPEG2_MAIN_PROFILE_MAIN_LEVEL: Ts =
     create_ts_stub("1.2.840.10008.1.2.4.100", "MPEG2 Main Profile / Main Level");
+/// **Stub descriptor:** MPEG2 Main Profile / High Level
 pub const MPEG2_MAIN_PROFILE_HIGH_LEVEL: Ts =
     create_ts_stub("1.2.840.10008.1.2.4.101", "MPEG2 Main Profile / High Level");
+/// **Stub descriptor:** MPEG-4 AVC/H.264 High Profile / Level 4.1
 pub const MPEG4_AVC_H264_HIGH_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.102",
     "MPEG-4 AVC/H.264 High Profile / Level 4.1",
 );
+/// **Stub descriptor:** MPEG-4 AVC/H.264 BD-Compatible High Profile / Level 4.1
 pub const MPEG4_AVC_H264_BD_COMPATIBLE_HIGH_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.103",
     "MPEG-4 AVC/H.264 BD-Compatible High Profile / Level 4.1",
 );
+/// **Stub descriptor:** MPEG-4 AVC/H.264 High Profile / Level 4.2 For 2D Video
 pub const MPEG4_AVC_H264_HIGH_PROFILE_FOR_2D_VIDEO: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.104",
     "MPEG-4 AVC/H.264 High Profile / Level 4.2 For 2D Video",
 );
+/// **Stub descriptor:** MPEG-4 AVC/H.264 High Profile / Level 4.2 For 3D Video
 pub const MPEG4_AVC_H264_HIGH_PROFILE_FOR_3D_VIDEO: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.105",
     "MPEG-4 AVC/H.264 High Profile / Level 4.2 For 3D Video",
 );
+/// **Stub descriptor:** MPEG-4 AVC/H.264 High Profile / Level 4.2
 pub const MPEG4_AVC_H264_STEREO_HIGH_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.106",
     "MPEG-4 AVC/H.264 Stereo High Profile / Level 4.2",
 );
+/// **Stub descriptor:** HEVC/H.265 Main Profile / Level 5.1
 pub const HEVC_H265_MAIN_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.107",
     "HEVC/H.265 Main Profile / Level 5.1",
 );
+/// **Stub descriptor:** HEVC/H.265 Main 10 Profile / Level 5.1
 pub const HEVC_H265_MAIN_10_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.108",
     "HEVC/H.265 Main 10 Profile / Level 5.1",
 );
+/// **Stub descriptor:** RLE Lossless
 pub const RLE_LOSSLESS: Ts = create_ts_stub("1.2.840.10008.1.2.5", "RLE Lossless");
+/// **Stub descriptor:** SMPTE ST 2110-20 Uncompressed Progressive Active Video
+pub const SMPTE_ST_2110_20_UNCOMPRESSED_PROGRESSIVE: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.7.1",
+    "SMPTE ST 2110-20 Uncompressed Progressive Active Video",
+);
+/// **Stub descriptor:** SMPTE ST 2110-20 Uncompressed Interlaced Active Video
+pub const SMPTE_ST_2110_20_UNCOMPRESSED_INTERLACED: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.7.2",
+    "SMPTE ST 2110-20 Uncompressed Interlaced Active Video",
+);
+/// **Stub descriptor:** SMPTE ST 2110-30 PCM Digital Audio
+pub const SMPTE_ST_2110_30_PCM: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.7.3",
+    "SMPTE ST 2110-30 PCM Digital Audio",
+);

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -1,4 +1,21 @@
-//! Compiled transfer syntax specifiers.
+//! A list of compiled transfer syntax specifiers.
+//!
+//! The constants exported here refer to the library's built-in support
+//! for DICOM transfer syntaxes.
+//! 
+//! **Fully implemented** means that the default transfer syntax registry
+//! provides built-in support for reading and writing data sets,
+//! as well as for encoding and decoding encapsulated pixel data,
+//! if applicable.
+//! **Stub descriptors** serve to provide information about
+//! the transfer syntax,
+//! and may provide partial support.
+//! In most cases it will be possible to read and write data sets,
+//! but not encode or decode encapsulated pixel data.
+//! 
+//! Other crates may be developed to replace stubs,
+//! hence expanding support for those transfer syntaxes
+//! to the registry.
 
 use crate::create_ts_stub;
 use byteordered::Endianness;

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -1,3 +1,10 @@
+#![deny(trivial_numeric_casts, unsafe_code, unstable_features)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    unused_qualifications,
+    unused_import_braces
+)]
 //! This crate contains the DICOM transfer syntax registry.
 //! The transfer syntax registry maps a DICOM UID of a transfer syntax into the
 //! respective transfer syntax specifier. In the default implementation, the
@@ -94,6 +101,7 @@ impl TransferSyntaxRegistryImpl {
 }
 
 impl TransferSyntaxIndex for TransferSyntaxRegistryImpl {
+    #[inline]
     fn get(&self, uid: &str) -> Option<&TransferSyntax> {
         Self::get(self, uid)
     }
@@ -104,13 +112,14 @@ impl TransferSyntaxIndex for TransferSyntaxRegistryImpl {
 pub struct TransferSyntaxRegistry;
 
 impl TransferSyntaxIndex for TransferSyntaxRegistry {
+    #[inline]
     fn get(&self, uid: &str) -> Option<&TransferSyntax> {
         get_registry().get(uid)
     }
 }
 
 lazy_static! {
-    static ref BUILT_IN_TS: [TransferSyntax; 26] = {
+    static ref BUILT_IN_TS: [TransferSyntax; 29] = {
         use self::entries::*;
         [
             IMPLICIT_VR_LITTLE_ENDIAN.erased(),
@@ -118,7 +127,7 @@ lazy_static! {
             EXPLICIT_VR_BIG_ENDIAN.erased(),
 
             DEFLATED_EXPLICIT_VR_LITTLE_ENDIAN.erased(),
-            JPIP_DEREFERENCED_DEFLATE.erased(),
+            JPIP_REFERENCED_DEFLATE.erased(),
             JPEG_BASELINE.erased(),
             JPEG_EXTENDED.erased(),
             JPEG_LOSSLESS_NON_HIERARCHICAL.erased(),
@@ -140,6 +149,9 @@ lazy_static! {
             HEVC_H265_MAIN_PROFILE.erased(),
             HEVC_H265_MAIN_10_PROFILE.erased(),
             RLE_LOSSLESS.erased(),
+            SMPTE_ST_2110_20_UNCOMPRESSED_PROGRESSIVE.erased(),
+            SMPTE_ST_2110_20_UNCOMPRESSED_INTERLACED.erased(),
+            SMPTE_ST_2110_30_PCM.erased(),
         ]
     };
 
@@ -174,6 +186,7 @@ fn inventory_populate(_: &mut TransferSyntaxRegistryImpl) {
 }
 
 /// Retrieve a reference to the global codec registry.
+#[inline]
 pub(crate) fn get_registry() -> &'static TransferSyntaxRegistryImpl {
     &REGISTRY
 }

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -20,6 +20,17 @@
 //! higher level APIs, which should learn to negotiate and resolve the expected
 //! transfer syntax automatically.
 //!
+//! ## Transfer Syntax descriptors
+//!
+//! This crate encompasses the basic DICOM level of conformance:
+//! _Implicit VR Little Endian_,
+//! _Explicit VR Little Endian_,
+//! and _Explicit VR Big Endian_ are built-in.
+//! Transfer syntaxes which are not supported,
+//! or which rely on encapsulated pixel data,
+//! are only listed as _stubs_ to be replaced by separate libraries.
+//! The full list is available in the [`entries`](entries) module.
+//! 
 //! [inventory]: https://docs.rs/inventory/0.1.4/inventory
 
 use byteordered::Endianness;


### PR DESCRIPTION
- Rename `JPIP_DEREFERENCED_DEFLATE`
  to `JPIP_REFERENCED_DEFLATE`
  (was a typo)
- Add more transfer syntaxes
  as described in DICOM PS3.6 2020b Table A-1
- Add more linting directives
- Mark more methods as inline