### PR TITLE
Preserve string values on data set reading

### DIFF
--- a/dcmdump/src/main.rs
+++ b/dcmdump/src/main.rs
@@ -294,6 +294,42 @@ fn value_summary(value: &PrimitiveValue, vr: VR, max_characters: u32) -> Cow<str
         .into(),
         (U8(values), _) => format_value_list(values, max_characters, false).into(),
         (Tags(values), _) => format_value_list(values, max_characters, false).into(),
+        (Strs(values), VR::DA) => {
+            match value.to_multi_date() {
+                Ok(values) => {
+                    // print as reformatted date
+                    format_value_list(values, max_characters, false).into()
+                },
+                Err(_e) => {
+                    // print as text
+                    format_value_list(values, max_characters, true).into()
+                }
+            }
+        },
+        (Strs(values), VR::TM) => {
+            match value.to_multi_time() {
+                Ok(values) => {
+                    // print as reformatted date
+                    format_value_list(values, max_characters, false).into()
+                },
+                Err(_e) => {
+                    // print as text
+                    format_value_list(values, max_characters, true).into()
+                }
+            }
+        },
+        (Strs(values), VR::DT) => {
+            match value.to_multi_datetime(dicom::core::chrono::FixedOffset::east(0)) {
+                Ok(values) => {
+                    // print as reformatted date
+                    format_value_list(values, max_characters, false).into()
+                },
+                Err(_e) => {
+                    // print as text
+                    format_value_list(values, max_characters, true).into()
+                }
+            }
+        },
         (Strs(values), _) => format_value_list(values, max_characters, true).into(),
         (Date(values), _) => format_value_list(values, max_characters, true).into(),
         (Time(values), _) => format_value_list(values, max_characters, true).into(),

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -184,7 +184,7 @@ where
         // read rest of data according to metadata, feed it to object
         if let Some(ts) = ts_index.get(&meta.transfer_syntax) {
             let cs = SpecificCharacterSet::Default;
-            let mut dataset = DataSetReader::new_with_dictionary(file, dict.clone(), ts, cs)
+            let mut dataset = DataSetReader::new_with_dictionary(file, dict.clone(), ts, cs, Default::default())
                 .context(CreateParser)?;
 
             Ok(RootDicomObject {
@@ -233,7 +233,7 @@ where
         // read rest of data according to metadata, feed it to object
         if let Some(ts) = ts_index.get(&meta.transfer_syntax) {
             let cs = SpecificCharacterSet::Default;
-            let mut dataset = DataSetReader::new_with_dictionary(file, dict.clone(), ts, cs)
+            let mut dataset = DataSetReader::new_with_dictionary(file, dict.clone(), ts, cs, Default::default())
                 .context(CreateParser)?;
             let obj = InMemDicomObject::build_object(&mut dataset, dict, false, Length::UNDEFINED)?;
             Ok(RootDicomObject { meta, obj })


### PR DESCRIPTION
This resolves #9. It introduces configurable value reading strategies (`ValueReadStrategy`) at data set reading level and makes `Preserve` the default one. Quoting from the documentation:

> Values will be stored without decoding dates or textual numbers.
> Word-sized binary values are read according to the expected byte order.
> Date-time values and numbers are kept in their original string representation as string objects.
> All text is still decoded into Rust string values, in accordance to the standard, unless its value representation is unknown to the decoder.

With #56 already present, working with `PrimitiveValue` should be easy enough, performing the conversions to binary numbers and date/time/datetime only when necessary via the methods added there.

Note also that this does not exclude the eventual **attribute** abstraction, which will exist at the object level and even work with values which are not necessarily in memory. Everything should hopefully fit like puzzle pieces once this one is done.