### PR TITLE
Extend core types with more access methods

### DIFF
--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -2,11 +2,13 @@
 //! It comprises a variety of basic data types, such as the DICOM attribute tag, the
 //! element header, and element composite types.
 
-use crate::value::{PrimitiveValue, Value};
+use crate::value::{CastValueError, ConvertValueError, PrimitiveValue, Value};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt;
 use std::str::{from_utf8, FromStr};
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveTime};
+use num_traits::NumCast;
 use snafu::{Backtrace, Snafu};
 
 /// Error type for issues constructing a sequence item header.
@@ -250,8 +252,48 @@ where
     }
 
     /// Retrieve the element's value as a single string.
-    pub fn to_str(&self) -> Result<Cow<str>, crate::value::CastValueError> {
+    pub fn to_str(&self) -> Result<Cow<str>, CastValueError> {
         self.value.to_str()
+    }
+
+    /// Convert the full primitive value into raw bytes.
+    ///
+    /// String values already encoded with the `Str` and `Strs` variants
+    /// are provided in UTF-8.
+    ///
+    /// Returns an error if the value is not primitive.
+    pub fn to_bytes(&self) -> Result<Cow<[u8]>, CastValueError> {
+        self.value().to_bytes()
+    }
+
+    /// Convert the full value of the data element into a sequence of strings.
+    ///
+    /// If the value is a primitive, it will be converted into
+    /// a vector of strings as described in [`PrimitiveValue::to_multi_str`].
+    ///
+    /// Returns an error if the value is not primitive.
+    ///
+    /// [`PrimitiveValue::to_multi_str`]: ../enum.PrimitiveValue#to_multi_str
+    pub fn to_multi_str(&self) -> Result<Cow<[String]>, CastValueError> {
+        self.value().to_multi_str()
+    }
+
+    /// Retrieve and convert the value of the data element into an integer.
+    ///
+    /// If the value is a primitive,
+    /// it will be converted into an integer
+    /// as described in [`PrimitiveValue::to_int`].
+    ///
+    /// Returns an error if the value is not primitive.
+    ///
+    /// [`PrimitiveValue::to_int`]: ../enum.PrimitiveValue#to_int
+    pub fn to_int<T>(&self) -> Result<T, ConvertValueError>
+    where
+        T: Clone,
+        T: NumCast,
+        T: FromStr<Err = std::num::ParseIntError>,
+    {
+        self.value().to_int()
     }
 }
 
@@ -282,6 +324,73 @@ where
     pub fn value(&self) -> &Value<I, P> {
         &self.value
     }
+}
+
+/// Macro for implementing getters to single and multi-values,
+/// by delegating to `Value`.
+///
+/// Should be placed inside `DataElement`'s impl block.
+macro_rules! impl_primitive_getters {
+    ($name_single: ident, $name_multi: ident, $variant: ident, $ret: ty) => {        
+        /// Get a single value of the requested type.
+        ///
+        /// If it contains multiple values,
+        /// only the first one is returned.
+        /// An error is returned if the variant is not compatible.
+        pub fn $name_single(&self) -> Result<$ret, CastValueError> {
+            self.value().$name_single()
+        }
+
+        /// Get a sequence of values of the requested type without copying.
+        ///
+        /// An error is returned if the variant is not compatible.
+        pub fn $name_multi(&self) -> Result<&[$ret], CastValueError> {
+            self.value().$name_multi()
+        }
+    };
+}
+
+impl<I, P> DataElement<I, P> {
+    /// Get a single string value.
+    ///
+    /// If it contains multiple strings,
+    /// only the first one is returned.
+    ///
+    /// An error is returned if the variant is not compatible.
+    ///
+    /// To enable conversions of other variants to a textual representation,
+    /// see [`to_str()`] instead.
+    ///
+    /// [`to_str()`]: #method.to_str
+    pub fn string(&self) -> Result<&str, CastValueError> {
+        self.value().string()
+    }
+
+    /// Get the inner sequence of string values
+    /// if the variant is either `Str` or `Strs`.
+    ///
+    /// An error is returned if the variant is not compatible.
+    ///
+    /// To enable conversions of other variants to a textual representation,
+    /// see [`to_str()`] instead.
+    ///
+    /// [`to_str()`]: #method.to_str
+    pub fn strings(&self) -> Result<&[String], CastValueError> {
+        self.value().strings()
+    }
+
+    impl_primitive_getters!(date, dates, Date, NaiveDate);
+    impl_primitive_getters!(time, times, Time, NaiveTime);
+    impl_primitive_getters!(datetime, datetimes, DateTime, DateTime<FixedOffset>);
+    impl_primitive_getters!(uint8, uint8_slice, U8, u8);
+    impl_primitive_getters!(uint16, uint16_slice, U16, u16);
+    impl_primitive_getters!(int16, int16_slice, I16, i16);
+    impl_primitive_getters!(uint32, uint32_slice, U32, u32);
+    impl_primitive_getters!(int32, int32_slice, I32, i32);
+    impl_primitive_getters!(int64, int64_slice, I64, i64);
+    impl_primitive_getters!(uint64, uint64_slice, U64, u64);
+    impl_primitive_getters!(float32, float32_slice, F32, f32);
+    impl_primitive_getters!(float64, float64_slice, F64, f64);
 }
 
 /// A data structure for a data element header, containing

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -296,6 +296,21 @@ where
         self.value().to_int()
     }
 
+    /// Retrieve and convert the value of the data element
+    /// into a sequence of integers.
+    ///
+    /// If the value is a primitive, it will be converted into
+    /// a vector of integers as described in [PrimitiveValue::to_multi_int].
+    ///
+    /// [PrimitiveValue::to_multi_int]: ../enum.PrimitiveValue#to_multi_int
+    pub fn to_multi_int<T>(&self) -> Result<Vec<T>, ConvertValueError>
+    where
+        T: Clone,
+        T: NumCast,
+        T: FromStr<Err = std::num::ParseIntError>,
+    {
+        self.value().to_multi_int()
+    }
 
     /// Retrieve and convert the value of the data element
     /// into a single-precision floating point number.

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -295,6 +295,59 @@ where
     {
         self.value().to_int()
     }
+
+
+    /// Retrieve and convert the value of the data element
+    /// into a single-precision floating point number.
+    ///
+    /// If the value is a primitive, it will be converted into
+    /// a number as described in [`PrimitiveValue::to_float32`].
+    ///
+    /// Returns an error if the value is not primitive.
+    ///
+    /// [`PrimitiveValue::to_float32`]: ../enum.PrimitiveValue#to_float32
+    pub fn to_float32(&self) -> Result<f32, ConvertValueError> {
+        self.value().to_float32()
+    }
+
+    /// Retrieve and convert the value of the data element
+    /// into a sequence of single-precision floating point numbers.
+    ///
+    /// If the value is a primitive, it will be converted into
+    /// a vector of numbers as described in [`PrimitiveValue::to_multi_float32`].
+    ///
+    /// Returns an error if the value is not primitive.
+    ///
+    /// [`PrimitiveValue::to_multi_float32`]: ../enum.PrimitiveValue#to_multi_float32
+    pub fn to_multi_float32(&self) -> Result<Vec<f32>, ConvertValueError> {
+        self.value().to_multi_float32()
+    }
+
+    /// Retrieve and convert the value of the data element
+    /// into a double-precision floating point number.
+    ///
+    /// If the value is a primitive, it will be converted into
+    /// a number as described in [`PrimitiveValue::to_float64`].
+    ///
+    /// Returns an error if the value is not primitive.
+    ///
+    /// [`PrimitiveValue::to_float64`]: ../enum.PrimitiveValue#to_float64
+    pub fn to_float64(&self) -> Result<f64, ConvertValueError> {
+        self.value().to_float64()
+    }
+
+    /// Retrieve and convert the value of the data element
+    /// into a sequence of double-precision floating point numbers.
+    ///
+    /// If the value is a primitive, it will be converted into
+    /// a vector of numbers as described in [`PrimitiveValue::to_multi_float64`].
+    ///
+    /// Returns an error if the value is not primitive.
+    ///
+    /// [`PrimitiveValue::to_multi_float64`]: ../enum.PrimitiveValue#to_multi_float64
+    pub fn to_multi_float64(&self) -> Result<Vec<f64>, ConvertValueError> {
+        self.value().to_multi_float64()
+    }
 }
 
 impl<'v, I, P> DataElementRef<'v, I, P>

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -97,9 +97,11 @@ impl HasLength for EmptyObject {
     }
 }
 
-/// A data type that represents and owns a DICOM data element. Unlike
-/// [`PrimitiveDataElement`], this type may contain multiple data elements
-/// through the item sequence VR (where each item contains an object of type `I`),
+/// A data type that represents and owns a DICOM data element.
+///
+/// This type is capable of representing any data element fully in memory,
+/// whether it be a primitive value,
+/// a nested data set (where each item contains an object of type `I`),
 /// or an encapsulated pixel data sequence (each item of type `P`).
 #[derive(Debug, PartialEq, Clone)]
 pub struct DataElement<I, P> {
@@ -273,7 +275,7 @@ where
     ///
     /// Returns an error if the value is not primitive.
     ///
-    /// [`PrimitiveValue::to_multi_str`]: ../enum.PrimitiveValue#to_multi_str
+    /// [`PrimitiveValue::to_multi_str`]: ../enum.PrimitiveValue.html#to_multi_str
     pub fn to_multi_str(&self) -> Result<Cow<[String]>, CastValueError> {
         self.value().to_multi_str()
     }
@@ -286,7 +288,7 @@ where
     ///
     /// Returns an error if the value is not primitive.
     ///
-    /// [`PrimitiveValue::to_int`]: ../enum.PrimitiveValue#to_int
+    /// [`PrimitiveValue::to_int`]: ../enum.PrimitiveValue.html#to_int
     pub fn to_int<T>(&self) -> Result<T, ConvertValueError>
     where
         T: Clone,
@@ -302,7 +304,7 @@ where
     /// If the value is a primitive, it will be converted into
     /// a vector of integers as described in [PrimitiveValue::to_multi_int].
     ///
-    /// [PrimitiveValue::to_multi_int]: ../enum.PrimitiveValue#to_multi_int
+    /// [PrimitiveValue::to_multi_int]: ../enum.PrimitiveValue.html#to_multi_int
     pub fn to_multi_int<T>(&self) -> Result<Vec<T>, ConvertValueError>
     where
         T: Clone,
@@ -320,7 +322,7 @@ where
     ///
     /// Returns an error if the value is not primitive.
     ///
-    /// [`PrimitiveValue::to_float32`]: ../enum.PrimitiveValue#to_float32
+    /// [`PrimitiveValue::to_float32`]: ../enum.PrimitiveValue.html#to_float32
     pub fn to_float32(&self) -> Result<f32, ConvertValueError> {
         self.value().to_float32()
     }
@@ -333,7 +335,7 @@ where
     ///
     /// Returns an error if the value is not primitive.
     ///
-    /// [`PrimitiveValue::to_multi_float32`]: ../enum.PrimitiveValue#to_multi_float32
+    /// [`PrimitiveValue::to_multi_float32`]: ../enum.PrimitiveValue.html#to_multi_float32
     pub fn to_multi_float32(&self) -> Result<Vec<f32>, ConvertValueError> {
         self.value().to_multi_float32()
     }
@@ -346,7 +348,7 @@ where
     ///
     /// Returns an error if the value is not primitive.
     ///
-    /// [`PrimitiveValue::to_float64`]: ../enum.PrimitiveValue#to_float64
+    /// [`PrimitiveValue::to_float64`]: ../enum.PrimitiveValue.html#to_float64
     pub fn to_float64(&self) -> Result<f64, ConvertValueError> {
         self.value().to_float64()
     }
@@ -359,7 +361,7 @@ where
     ///
     /// Returns an error if the value is not primitive.
     ///
-    /// [`PrimitiveValue::to_multi_float64`]: ../enum.PrimitiveValue#to_multi_float64
+    /// [`PrimitiveValue::to_multi_float64`]: ../enum.PrimitiveValue.html#to_multi_float64
     pub fn to_multi_float64(&self) -> Result<Vec<f64>, ConvertValueError> {
         self.value().to_multi_float64()
     }

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -244,6 +244,20 @@ where
         }
     }
 
+    /// Retrieves the primitive value as a sequence of unsigned bytes
+    /// without conversions.
+    #[deprecated(note = "use `uint8_slice` instead")]
+    pub fn as_u8(&self) -> Result<&[u8], CastValueError> {
+        self.uint8_slice()
+    }
+
+    /// Retrieves the primitive value as a sequence of signed 32-bit integers
+    /// without conversions.
+    #[deprecated(note = "use `int32_slice` instead")]
+    pub fn as_i32(&self) -> Result<&[i32], CastValueError> {
+        self.int32_slice()
+    }
+
     /// Retrieve and convert the primitive value into an integer.
     ///
     /// If the value is a primitive, it will be converted into

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -217,7 +217,7 @@ where
     ///
     /// Returns an error if the value is not primitive.
     ///
-    /// [`PrimitiveValue::to_multi_str`]: ../enum.PrimitiveValue#to_multi_str
+    /// [`PrimitiveValue::to_multi_str`]: ../enum.PrimitiveValue.html#to_multi_str
     pub fn to_multi_str(&self) -> Result<Cow<[String]>, CastValueError> {
         match self {
             Value::Primitive(prim) => Ok(prim.to_multi_str()),
@@ -263,7 +263,7 @@ where
     /// If the value is a primitive, it will be converted into
     /// an integer as described in [`PrimitiveValue::to_int`].
     ///
-    /// [`PrimitiveValue::to_int`]: ../enum.PrimitiveValue#to_int
+    /// [`PrimitiveValue::to_int`]: ../enum.PrimitiveValue.html#to_int
     pub fn to_int<T>(&self) -> Result<T, ConvertValueError>
     where
         T: Clone,
@@ -285,7 +285,7 @@ where
     /// If the value is a primitive, it will be converted into
     /// a vector of integers as described in [PrimitiveValue::to_multi_int].
     ///
-    /// [PrimitiveValue::to_multi_int]: ../enum.PrimitiveValue#to_multi_int
+    /// [PrimitiveValue::to_multi_int]: ../enum.PrimitiveValue.html#to_multi_int
     pub fn to_multi_int<T>(&self) -> Result<Vec<T>, ConvertValueError>
     where
         T: Clone,
@@ -308,7 +308,7 @@ where
     /// If the value is a primitive, it will be converted into
     /// a number as described in [`PrimitiveValue::to_float32`].
     ///
-    /// [`PrimitiveValue::to_float32`]: ../enum.PrimitiveValue#to_float32
+    /// [`PrimitiveValue::to_float32`]: ../enum.PrimitiveValue.html#to_float32
     pub fn to_float32(&self) -> Result<f32, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_float32(),
@@ -326,7 +326,7 @@ where
     /// If the value is a primitive, it will be converted into
     /// a vector of numbers as described in [`PrimitiveValue::to_multi_float32`].
     ///
-    /// [`PrimitiveValue::to_multi_float32`]: ../enum.PrimitiveValue#to_multi_float32
+    /// [`PrimitiveValue::to_multi_float32`]: ../enum.PrimitiveValue.html#to_multi_float32
     pub fn to_multi_float32(&self) -> Result<Vec<f32>, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_multi_float32(),
@@ -344,7 +344,7 @@ where
     /// If the value is a primitive, it will be converted into
     /// a number as described in [`PrimitiveValue::to_float64`].
     ///
-    /// [`PrimitiveValue::to_float64`]: ../enum.PrimitiveValue#to_float64
+    /// [`PrimitiveValue::to_float64`]: ../enum.PrimitiveValue.html#to_float64
     pub fn to_float64(&self) -> Result<f64, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_float64(),
@@ -362,7 +362,7 @@ where
     /// If the value is a primitive, it will be converted into
     /// a vector of numbers as described in [`PrimitiveValue::to_multi_float64`].
     ///
-    /// [`PrimitiveValue::to_multi_float64`]: ../enum.PrimitiveValue#to_multi_float64
+    /// [`PrimitiveValue::to_multi_float64`]: ../enum.PrimitiveValue.html#to_multi_float64
     pub fn to_multi_float64(&self) -> Result<Vec<f64>, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_multi_float64(),

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -593,6 +593,13 @@ mod tests {
             NaiveDate::from_ymd(2014, 10, 12),
         );
 
+        assert_eq!(
+            Value::new(PrimitiveValue::Date(smallvec![NaiveDate::from_ymd(2014, 10, 12); 5]))
+                .dates()
+                .unwrap(),
+            &[NaiveDate::from_ymd(2014, 10, 12); 5]
+        );
+
         assert!(matches!(
             Value::new(PrimitiveValue::Date(smallvec![NaiveDate::from_ymd(2014, 10, 12)]))
                 .time(),

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -44,7 +44,7 @@ pub trait DicomValueType: HasLength {
 ///
 /// [`HasLength`]: ../header/trait.HasLength.html
 #[derive(Debug, Clone, PartialEq)]
-pub enum Value<I, P> {
+pub enum Value<I = EmptyObject, P = [u8; 0]> {
     /// Primitive value.
     Primitive(PrimitiveValue),
     /// A complex sequence of items.

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -4,7 +4,7 @@
 
 use super::DicomValueType;
 use crate::header::{HasLength, Length, Tag};
-use chrono::{Datelike, FixedOffset, Timelike};
+use chrono::{FixedOffset, Timelike};
 use itertools::Itertools;
 use num_traits::NumCast;
 use safe_transmute::to_bytes::transmute_to_bytes;


### PR DESCRIPTION
This adds more methods to the DICOM `Value` and `DataElement` types, making them easier to use and more intuitive. Often one won't have to fetch the `PrimitiveValue` first.

- add new constructor functions `new_sequence`, `new_pixel_sequence`, and `new` (primitive) to `Value`
- add `PrimitiveValue::to_multi_str`
- replicate more `to_*` conversion methods from `PrimitiveValue` into `Value` and `DataElement`
- deprecate Value `as_*` methods and provide getters with the same names as the ones in `PrimitiveValue`
- extend these access methods to `DataElement`