### PR TITLE
Add Code of Conduct and Contributing documents

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team.
+The current single project team member of the project is Eduardo Pinho: <enet4mikeenet@gmail.com>.
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to DICOM-rs
+
+The DICOM-rs project is open for external contributions
+in the form of issues, pull requests, and otherwise constructive discussion
+about design concerns and future perspectives of the project.
+Although this project combines two major domains of expertize,
+namely the DICOM standard and the Rust programming language,
+it is acceptable for a contributor of DICOM-rs
+to only possess basic knowledge in either one.
+
+Please do not forget to follow the [Code of Conduct](CODE_OF_CONDUCT.md)
+in all interactions through the given project communication venues.
+
+## Contributing with code
+
+Please check out the list of existing issues in the [GitHub issue tracker].
+Should you be interested in helping but not know where to begin,
+please look for issues tagged `help wanted` and `good first issue`.
+Announcing your interest in pursuing an issue is recommended.
+This will prevent people from concurrently working on the same issue,
+and you may also receive some guidance along the way.
+No need to be shy!
+
+Pull requests are likely to be subjected to constructive and careful reviewing,
+and it may take some time before they are accepted and merged.
+Please do not be discouraged to contribute when not facing the expected outcome,
+or feeling that your work or proposal goes unheard.
+The project is maintained by volunteers outside of work hours.
+
+[GitHub issue tracker]: https://github.com/Enet4/dicom-rs/issues
+
+### Building the project
+As a pure Rust ecosystem,
+Cargo is the main tool for building all crates in DICOM-rs.
+[Rustup] is the recommended way to set up a development environment
+for working with Rust.
+DICOM-rs expects the latest stable toolchain.
+
+Currently, all crates are gathered in the same workspace,
+which means that running the command below
+at the root of the repository will build all crates:
+
+```sh
+cargo build
+```
+
+This will also build the CLI and helper tools of the project,
+such as the dictionary builder and `dcmdump`.
+To build only the library crates,
+you can build the parent package named `dicom`:
+
+```sh
+cargo build -p dicom
+```
+
+Please ensure that all tests pass before sending your contribution.
+Writing tests for your own contributions is greatly appreciated as well.
+
+```sh
+cargo test
+```
+
+We also recommend formatting your code before submitting,
+to prevent discrepancies in code style.
+
+```sh
+cargo fmt
+```
+
+[Rustup]: https://rustup.rs
+
+## Discussion and roadmapping
+If you have more long-termed ideas about what DICOM-rs should include next,
+please have a look at the [roadmap] and look into existing issues to provide feedback.
+You can also have a chat at the official [Gitter room].
+
+If you have any further questions or concerns,
+or would like to be deeper involved in the project,
+please reach out to the project maintainers.
+
+[roadmap]: https://github.com/Enet4/dicom-rs/wiki/Roadmap
+[Gitter room]: https://gitter.im/dicom-rs/community
+
+## Project team and governance
+DICOM-rs is currently led by Eduardo Pinho ([**@Enet4**](https://github.com/Enet4), <enet4mikeenet@gmail.com>).


### PR DESCRIPTION
In preparation for Hacktoberfest and for future evolutions of the project, I have decided that it is best to have a code of conduct sooner than laying one after something bad happens. This will not change the way the project is moderated and maintained, but should hopefully set up the right expectations clearly, while keeping poor intentions at bay.

I also took this opportunity to rewrite the *Contributing* page, previously found in the wiki, but was under-specified and was not very helpful.