### PR TITLE
[dcmdump] Increase default output width

### DIFF
--- a/dcmdump/src/main.rs
+++ b/dcmdump/src/main.rs
@@ -88,7 +88,7 @@ fn dump_file(obj: DefaultDicomObject) -> IoResult<()> {
     let width = if let Some((width, _)) = term_size::dimensions() {
         width as u32
     } else {
-        48
+        120
     };
 
     meta_dump(&mut to, &meta, width)?;


### PR DESCRIPTION
As `width` is relative to the full dimensions of the terminal, this number needs to be larger for the tool to present the values.