### PR TITLE
Add take_element methods for InMemoryDicomObject

### DIFF
--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -594,7 +594,13 @@ mod tests {
         obj.put(another_patient_name.clone());
         let elem1 = obj.take_element(Tag(0x0010, 0x0010)).unwrap();
         assert_eq!(elem1, another_patient_name);
-        assert!(obj.take_element(Tag(0x0010, 0x0010)).is_err());
+        assert!(matches!(
+            obj.take_element(Tag(0x0010, 0x0010)),
+            Err(Error::NoSuchDataElementTag {
+                tag: Tag(0x0010, 0x0010),
+                ..
+            })
+        ));
     }
 
     #[test]
@@ -608,7 +614,14 @@ mod tests {
         obj.put(another_patient_name.clone());
         let elem1 = obj.take_element_by_name("PatientName").unwrap();
         assert_eq!(elem1, another_patient_name);
-        assert!(obj.take_element_by_name("PatientName").is_err());
+        assert!(matches!(
+            obj.take_element_by_name("PatientName"),
+            Err(Error::NoSuchDataElementAlias {
+                tag: Tag(0x0010, 0x0010),
+                alias,
+                ..
+            }) if alias == "PatientName")
+        );
     }
 
     #[test]

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -346,7 +346,12 @@ where
     /// Removes and returns a particular DICOM element by its name.
     pub fn take_element_by_name(&mut self, name: &str) -> Result<InMemElement<D>> {
         let tag = self.lookup_name(name)?;
-        self.take_element(tag)
+        self.entries
+            .remove(&tag)
+            .with_context(|| NoSuchDataElementAlias {
+                tag,
+                alias: name.to_string(),
+            })
     }
 
     // private methods
@@ -532,6 +537,7 @@ impl<D> Iterator for Iter<D> {
 mod tests {
 
     use super::*;
+    use crate::Error;
     use dicom_core::header::{DataElementHeader, Length, VR};
     use dicom_core::value::PrimitiveValue;
     use dicom_parser::dataset::IntoTokens;
@@ -620,8 +626,7 @@ mod tests {
                 tag: Tag(0x0010, 0x0010),
                 alias,
                 ..
-            }) if alias == "PatientName")
-        );
+            }) if alias == "PatientName"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #78. Adds `take_element` and `take_element_by_name` on `InMemoryDicomObject` to take elements from an object and remove them. I based the doc comments and tests on the `element` method. Let me know if I should make any changes, thanks!