### PR TITLE
[parser] Fix tokenization of explicit length items

### DIFF
--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -82,7 +82,7 @@ pub trait Header: HasLength {
 /// This type implements `HasLength`, but cannot be instantiated.
 /// This makes it so that `Value<EmptyObject>` is sure to be either a primitive
 /// value or a sequence with no items.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub enum EmptyObject {}
 
 impl HasLength for EmptyObject {


### PR DESCRIPTION
This fixes a bug detected while working on DICOM modification tools.
The implementation of `IntoTokens` should transfer information
about the items' length, otherwise they would be printed with an implicit length
and the actual number of bytes written would not match the explicit length indicated by the respective sequence.

Other minor improvements:

- [core] derive more traits for the immaterial utility type `EmptyObject`
- improve information in errors when reading and writing data sets
- fix mistake in the root documentation of `dataset::write` (this module is for the writer, not the reader)
- increase crate test coverage