### PR TITLE
Make DataElement::new generic

### DIFF
--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -98,7 +98,7 @@ impl HasLength for EmptyObject {
 /// a nested data set (where each item contains an object of type `I`),
 /// or an encapsulated pixel data sequence (each item of type `P`).
 #[derive(Debug, PartialEq, Clone)]
-pub struct DataElement<I, P> {
+pub struct DataElement<I = EmptyObject, P = [u8; 0]> {
     header: DataElementHeader,
     value: Value<I, P>,
 }
@@ -236,7 +236,11 @@ where
     ///
     /// This method will not check whether the value representation is
     /// compatible with the given value.
-    pub fn new(tag: Tag, vr: VR, value: Value<I, P>) -> Self {
+    pub fn new<T>(tag: Tag, vr: VR, value: T) -> Self
+    where
+        T: Into<Value<I, P>>,
+    {
+        let value = value.into();
         DataElement {
             header: DataElementHeader {
                 tag,
@@ -1165,5 +1169,16 @@ mod tests {
             data_element.to_date().unwrap(),
             NaiveDate::from_ymd(1994, 10, 12),
         );
+    }
+
+    #[test]
+    fn create_data_element_from_primitive() {
+        let data_element: DataElement<EmptyObject, [u8; 0]> = DataElement::new(
+            Tag(0x0028, 0x3002),
+            VR::US,
+            crate::dicom_value!(U16, [256, 0, 16]),
+        );
+
+        assert_eq!(data_element.uint16_slice().unwrap(), &[256, 0, 16]);
     }
 }

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -724,7 +724,7 @@ mod tests {
         let patient_name = DataElement::new(
             Tag(0x0010, 0x0010),
             VR::PN,
-            dicom_value!(Strs, ["Doe^John"]).into(),
+            dicom_value!(Strs, ["Doe^John"]),
         );
         gt.put(patient_name);
 
@@ -750,7 +750,7 @@ mod tests {
         let patient_name = DataElement::new(
             Tag(0x0010, 0x0010),
             VR::PN,
-            dicom_value!(Strs, ["Doe^John"]).into(),
+            dicom_value!(Strs, ["Doe^John"]),
         );
         gt.put(patient_name);
 
@@ -764,7 +764,7 @@ mod tests {
         let patient_name = DataElement::new(
             Tag(0x0010, 0x0010),
             VR::PN,
-            dicom_value!(Str, "Doe^John").into(),
+            dicom_value!(Str, "Doe^John"),
         );
         obj.put(patient_name);
 
@@ -792,7 +792,7 @@ mod tests {
         let patient_name = DataElement::new(
             Tag(0x0010, 0x0010),
             VR::PN,
-            dicom_value!(Str, "Doe^John").into(),
+            dicom_value!(Str, "Doe^John"),
         );
         obj.put(patient_name);
 
@@ -818,7 +818,7 @@ mod tests {
         let another_patient_name = DataElement::new(
             Tag(0x0010, 0x0010),
             VR::PN,
-            PrimitiveValue::Str("Doe^John".to_string()).into(),
+            PrimitiveValue::Str("Doe^John".to_string()),
         );
         let mut obj = InMemDicomObject::create_empty();
         obj.put(another_patient_name.clone());
@@ -831,7 +831,7 @@ mod tests {
         let another_patient_name = DataElement::new(
             Tag(0x0010, 0x0010),
             VR::PN,
-            PrimitiveValue::Str("Doe^John".to_string()).into(),
+            PrimitiveValue::Str("Doe^John".to_string()),
         );
         let mut obj = InMemDicomObject::create_empty();
         obj.put(another_patient_name.clone());
@@ -844,7 +844,7 @@ mod tests {
         let another_patient_name = DataElement::new(
             Tag(0x0010, 0x0010),
             VR::PN,
-            PrimitiveValue::Str("Doe^John".to_string()).into(),
+            PrimitiveValue::Str("Doe^John".to_string()),
         );
         let mut obj = InMemDicomObject::create_empty();
         obj.put(another_patient_name.clone());
@@ -864,7 +864,7 @@ mod tests {
         let another_patient_name = DataElement::new(
             Tag(0x0010, 0x0010),
             VR::PN,
-            PrimitiveValue::Str("Doe^John".to_string()).into(),
+            PrimitiveValue::Str("Doe^John".to_string()),
         );
         let mut obj = InMemDicomObject::create_empty();
         obj.put(another_patient_name.clone());
@@ -907,12 +907,12 @@ mod tests {
             DataElement::new(
                 Tag(0x0010, 0x0010),
                 VR::PN,
-                PrimitiveValue::Str("Doe^John".to_string()).into(),
+                PrimitiveValue::Str("Doe^John".to_string()),
             ),
             DataElement::new(
                 Tag(0x0008, 0x0060),
                 VR::CS,
-                PrimitiveValue::Str("MG".to_string()).into(),
+                PrimitiveValue::Str("MG".to_string()),
             ),
         ]);
 
@@ -932,12 +932,12 @@ mod tests {
         let patient_name = DataElement::new(
             Tag(0x0010, 0x0010),
             VR::PN,
-            PrimitiveValue::Str("Doe^John".to_string()).into(),
+            PrimitiveValue::Str("Doe^John".to_string()),
         );
         let modality = DataElement::new(
             Tag(0x0008, 0x0060),
             VR::CS,
-            PrimitiveValue::Str("MG".to_string()).into(),
+            PrimitiveValue::Str("MG".to_string()),
         );
         let mut obj = InMemDicomObject::create_empty();
         obj.put(patient_name);

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -840,9 +840,9 @@ mod tests {
 
         let gt = vec![
             // Information Group Length
-            DataElement::new(Tag(0x0002, 0x0000), VR::UL, dicom_value!(U32, 200).into()),
+            DataElement::new(Tag(0x0002, 0x0000), VR::UL, dicom_value!(U32, 200)),
             // Information Version
-            DataElement::new(Tag(0x0002, 0x0001), VR::OB, dicom_value!(U8, [0, 1]).into()),
+            DataElement::new(Tag(0x0002, 0x0001), VR::OB, dicom_value!(U8, [0, 1])),
             // Media Storage SOP Class UID
             DataElement::new(
                 Tag(0x0002, 0x0002),


### PR DESCRIPTION
This is an attempt at making the data element type slightly more ergonomic.

- automatically converts primitive values,
  so that calling `.into()` is no longer required (should be removed)
- add defaults to type parameters of `DataElement`
   - same as the ones in `DicomValue`