### PR TITLE
Fix AssociationRJResult::from

### DIFF
--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -43,15 +43,15 @@ impl PresentationContextResultReason {
 
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
 pub enum AssociationRJResult {
-    Permanent,
-    Transient,
+    Permanent = 1,
+    Transient = 2,
 }
 
 impl AssociationRJResult {
     fn from(value: u8) -> Option<AssociationRJResult> {
         match value {
-            0 => Some(AssociationRJResult::Permanent),
-            1 => Some(AssociationRJResult::Transient),
+            1 => Some(AssociationRJResult::Permanent),
+            2 => Some(AssociationRJResult::Transient),
             _ => None,
         }
     }


### PR DESCRIPTION
As per [part 8, section 9.3.4](http://dicom.nema.org/medical/dicom/current/output/chtml/part08/sect_9.3.4.html), `1` is for rejected-permanent and `2` is for rejected-transient.