### PR TITLE
Update itertools (0.10)

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ repository = "Enet4/dicom-rs"
 
 [dependencies]
 chrono = "0.4.6"
-itertools = "0.9.0"
+itertools = "0.10"
 num-traits = "0.2.12"
 safe-transmute = "0.11.0"
 smallvec = "1.0.0"

--- a/dcmdump/Cargo.toml
+++ b/dcmdump/Cargo.toml
@@ -19,6 +19,6 @@ default = ['dicom/inventory-registry', 'dicom/backtraces']
 [dependencies]
 dicom = { path = "../parent/", version = "0.3.0", default-features = false }
 term_size = "0.3.2"
-itertools = "0.9.0"
+itertools = "0.10"
 snafu = "0.6.8"
 colored = "2.0.0"

--- a/object/Cargo.toml
+++ b/object/Cargo.toml
@@ -23,7 +23,7 @@ dicom-encoding = { path = "../encoding", version = "0.3.0" }
 dicom-parser = { path = "../parser", version = "0.3.0" }
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.3.0" }
 dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry", version = "0.3.0" }
-itertools = "0.9.0"
+itertools = "0.10"
 byteordered = "0.5.0"
 smallvec = "1.0.0"
 snafu = "0.6.8"

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -342,7 +342,7 @@ where
     where
         I: IntoIterator<Item = Result<InMemElement<D>>>,
     {
-        let entries: Result<_> = iter.into_iter().map_results(|e| (e.tag(), e)).collect();
+        let entries: Result<_> = iter.into_iter().map_ok(|e| (e.tag(), e)).collect();
         Ok(InMemDicomObject {
             entries: entries?,
             dict,


### PR DESCRIPTION
- itertools 0.10
- replace deprecated method call