### PR TITLE
Clippy fix

### DIFF
--- a/core/src/value/deserialize.rs
+++ b/core/src/value/deserialize.rs
@@ -200,7 +200,7 @@ where
     if text.is_empty() || text.len() > 9 {
         return InvalidNumberLength { len: text.len() }.fail();
     }
-    if let Some(c) = text.iter().cloned().find(|&b| b < b'0' || b > b'9') {
+    if let Some(c) = text.iter().cloned().find(|b| !(b'0'..=b'9').contains(b)) {
         return InvalidNumberToken { value: c }.fail();
     }
 

--- a/dictionary-builder/src/main.rs
+++ b/dictionary-builder/src/main.rs
@@ -225,7 +225,7 @@ where
     )?;
 
     for line in preamble.split('\n') {
-        write!(f, "//! {}\n", line)?;
+        writeln!(f, "//! {}", line)?;
     }
 
     f.write_all(b"\n\
@@ -274,7 +274,7 @@ where
 
         let (vr1, vr2) = e.vr.split_at(2);
 
-        let second_vr = if vr2 != "" {
+        let second_vr = if vr2.is_empty() {
             format!(" /*{} */", vr2)
         } else {
             vr2.to_string()

--- a/encoding/src/text.rs
+++ b/encoding/src/text.rs
@@ -301,7 +301,7 @@ pub fn validate_iso_8859(text: &[u8]) -> TextValidationOutcome {
 /// Check whether the given byte slice contains only valid characters for a
 /// Date value representation.
 pub fn validate_da(text: &[u8]) -> TextValidationOutcome {
-    if text.iter().cloned().all(|c| c >= b'0' && c <= b'9') {
+    if text.iter().cloned().all(|c| (b'0'..=b'9').contains(&c)) {
         TextValidationOutcome::Ok
     } else {
         TextValidationOutcome::NotOk
@@ -313,7 +313,7 @@ pub fn validate_da(text: &[u8]) -> TextValidationOutcome {
 pub fn validate_tm(text: &[u8]) -> TextValidationOutcome {
     if text.iter().cloned().all(|c| match c {
         b'\\' | b'.' | b'-' | b' ' => true,
-        c => c >= b'0' && c <= b'9',
+        c => (b'0'..=b'9').contains(&c),
     }) {
         TextValidationOutcome::Ok
     } else {
@@ -326,7 +326,7 @@ pub fn validate_tm(text: &[u8]) -> TextValidationOutcome {
 pub fn validate_dt(text: &[u8]) -> TextValidationOutcome {
     if text.iter().cloned().all(|c| match c {
         b'.' | b'-' | b'+' | b' ' | b'\\' => true,
-        c => c >= b'0' && c <= b'9',
+        c => (b'0'..=b'9').contains(&c),
     }) {
         TextValidationOutcome::Ok
     } else {
@@ -339,7 +339,7 @@ pub fn validate_dt(text: &[u8]) -> TextValidationOutcome {
 pub fn validate_cs(text: &[u8]) -> TextValidationOutcome {
     if text.iter().cloned().all(|c| match c {
         b' ' | b'_' => true,
-        c => (c >= b'0' && c <= b'9') || (c >= b'A' && c <= b'Z'),
+        c => (b'0'..=b'9').contains(&c) || (b'A'..=b'Z').contains(&c),
     }) {
         TextValidationOutcome::Ok
     } else {

--- a/encoding/src/transfer_syntax/mod.rs
+++ b/encoding/src/transfer_syntax/mod.rs
@@ -273,19 +273,16 @@ impl<A> TransferSyntax<A> {
     /// Check whether this transfer syntax specifier provides a complete
     /// implementation.
     pub fn fully_supported(&self) -> bool {
-        match self.codec {
-            Codec::None | Codec::Dataset(_) | Codec::PixelData(_) => true,
-            _ => false,
-        }
+        matches!(
+            self.codec,
+            Codec::None | Codec::Dataset(_) | Codec::PixelData(_),
+        )
     }
 
     /// Check whether reading and writing of data sets is unsupported.
     /// If this is `true`, encoding and decoding will not be available.
     pub fn unsupported(&self) -> bool {
-        match self.codec {
-            Codec::Unsupported => true,
-            _ => false,
-        }
+        matches!(self.codec, Codec::Unsupported)
     }
 
     /// Check whether reading and writing the pixel data is unsupported.
@@ -293,10 +290,7 @@ impl<A> TransferSyntax<A> {
     /// be possible, but the pixel data will only be available in its
     /// encapsulated form.
     pub fn unsupported_pixel_encapsulation(&self) -> bool {
-        match self.codec {
-            Codec::Unsupported | Codec::EncapsulatedPixelData => true,
-            _ => false,
-        }
+        matches!(self.codec, Codec::Unsupported | Codec::EncapsulatedPixelData)
     }
 
     /// Retrieve the appropriate data element decoder for this transfer syntax.

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -103,19 +103,13 @@ impl DataToken {
     /// Check whether this token represents the start of a sequence
     /// of nested data sets.
     pub fn is_sequence_start(&self) -> bool {
-        match self {
-            DataToken::SequenceStart { .. } => true,
-            _ => false,
-        }
+        matches!(self, DataToken::SequenceStart { .. })
     }
 
     /// Check whether this token represents the end of a sequence
     /// or the end of an encapsulated element.
     pub fn is_sequence_end(&self) -> bool {
-        match self {
-            DataToken::SequenceEnd => true,
-            _ => false,
-        }
+        matches!(self, DataToken::SequenceEnd)
     }
 }
 
@@ -269,7 +263,7 @@ where
                 // pixel data fragments next
                 let fragments = fragments.take().unwrap();
                 let tokens: dicom_core::value::C<_> =
-                    fragments.into_iter().map(|o| ItemValue(o)).collect();
+                    fragments.into_iter().map(ItemValue).collect();
                 *self = DataElementTokens::PixelDataFragments(tokens.into_tokens());
                 // recursive call to ensure the retrieval of a data token
                 return self.next();

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -94,7 +94,7 @@ where
     R: Read,
 {
     ensure!(
-        max_pdu_length >= MINIMUM_PDU_SIZE && max_pdu_length <= MAXIMUM_PDU_SIZE,
+        (MINIMUM_PDU_SIZE..=MAXIMUM_PDU_SIZE).contains(&max_pdu_length),
         InvalidMaxPdu { max_pdu_length }
     );
 

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -229,21 +229,21 @@ where
                 // the value received in the same field of the A-ASSOCIATE-RQ PDU, but its value
                 // shall not be tested when received. TODO: write AE title
                 writer
-                    .write_all(&[0 as u8; 16])
+                    .write_all(&[0; 16])
                     .context(WriteReserved { bytes: 16_u32 })?;
 
                 // 27-42 - Reserved - This reserved field shall be sent with a value identical to
                 // the value received in the same field of the A-ASSOCIATE-RQ PDU, but its value
                 // shall not be tested when received. TODO: write AE title
                 writer
-                    .write_all(&[0 as u8; 16])
+                    .write_all(&[0; 16])
                     .context(WriteReserved { bytes: 16_u32 })?;
 
                 // 43-74 - Reserved - This reserved field shall be sent with a value identical to
                 // the value received in the same field of the A-ASSOCIATE-RQ PDU, but its value
                 // shall not be tested when received.
                 writer
-                    .write_all(&[0 as u8; 32])
+                    .write_all(&[0; 32])
                     .context(WriteReserved { bytes: 32_u32 })?;
 
                 // 75-xxx - Variable items - This variable field shall contain the following items:


### PR DESCRIPTION
- range contains impl
- use matches! where possible
- redundant `as u8`