### PR TITLE
Remove Travis badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # DICOM-rs
 
-[![Build Status](https://travis-ci.org/Enet4/dicom-rs.svg?branch=master)](https://travis-ci.org/Enet4/dicom-rs)
+[![DICOM-rs on crates.io](https://img.shields.io/crates/v/dicom.svg)](https://crates.io/crates/dicom)
+[![continuous integration](https://github.com/Enet4/dicom-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/Enet4/dicom-rs/actions/workflows/rust.yml)
 ![Minimum Rust Version Stable](https://img.shields.io/badge/Minimum%20Rust%20Version-stable-green.svg)
 [![dependency status](https://deps.rs/repo/github/Enet4/dicom-rs/status.svg)](https://deps.rs/repo/github/Enet4/dicom-rs)
 [![Gitter](https://badges.gitter.im/dicom-rs/community.svg)](https://gitter.im/dicom-rs/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![CratesIO](https://img.shields.io/crates/v/dicom.svg)](https://crates.io/crates/dicom)
 [![Documentation](https://docs.rs/dicom/badge.svg)](https://docs.rs/dicom)
 
 An ecosystem of library and tools for [DICOM](https://dicomstandard.org) compliant systems.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,9 +9,6 @@ repository = "https://github.com/Enet4/dicom-rs"
 keywords = ["dicom"]
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/dicom-rs"
-
 [dependencies]
 chrono = "0.4.6"
 itertools = "0.10"

--- a/dcmdump/Cargo.toml
+++ b/dcmdump/Cargo.toml
@@ -10,9 +10,6 @@ categories = ["command-line-utilities"]
 keywords = ["cli", "dicom", "dump"]
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/dicom-rs"
-
 [features]
 default = ['dicom/inventory-registry', 'dicom/backtraces']
 

--- a/dictionary-builder/Cargo.toml
+++ b/dictionary-builder/Cargo.toml
@@ -10,9 +10,6 @@ categories = ["command-line-utilities"]
 keywords = ["dicom"]
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/dicom-rs"
-
 [[bin]]
 name = "dicom-dictionary-builder"
 path = "src/main.rs"

--- a/dictionary-std/Cargo.toml
+++ b/dictionary-std/Cargo.toml
@@ -9,9 +9,6 @@ repository = "https://github.com/Enet4/dicom-rs"
 keywords = ["dicom", "dictionary"]
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/dicom-rs"
-
 [dependencies]
 dicom-core = { path = "../core", version = "0.3.0" }
 lazy_static = "1.2.0"

--- a/echoscu/Cargo.toml
+++ b/echoscu/Cargo.toml
@@ -10,9 +10,6 @@ categories = ["command-line-utilities"]
 keywords = ["dicom"]
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/dicom-rs"
-
 [dependencies]
 structopt = "0.3.21"
 dicom-ul = { path = "../ul" }

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -10,9 +10,6 @@ categories = ["encoding"]
 keywords = ["dicom"]
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/dicom-rs"
-
 [features]
 default = []
 inventory-registry = ['inventory']

--- a/object/Cargo.toml
+++ b/object/Cargo.toml
@@ -9,9 +9,6 @@ description = "A high-level API for reading and manipulating DICOM objects"
 keywords = ["dicom", "object", "attributes"]
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/dicom-rs"
-
 [features]
 default = []
 inventory-registry = ['dicom-encoding/inventory-registry', 'dicom-transfer-syntax-registry/inventory-registry']

--- a/parent/Cargo.toml
+++ b/parent/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Enet4/dicom-rs"
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/dicom-rs"
+[badges]
+maintenance = { status = "actively-developed" }
 
 [features]
 default = ['inventory-registry']

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -10,9 +10,6 @@ categories = ["parser-implementations"]
 keywords = ["dicom", "parser"]
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/dicom-rs"
-
 [dependencies]
 dicom-core = { path = "../core", version = "0.3.0" }
 dicom-encoding = { path = "../encoding", version = "0.3.0" }

--- a/scpproxy/Cargo.toml
+++ b/scpproxy/Cargo.toml
@@ -10,9 +10,6 @@ categories = ["command-line-utilities"]
 keywords = ["dicom"]
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/dicom-rs"
-
 [dependencies]
 clap = "2.33.0"
 dicom-ul = { path = "../ul/", version = "0.2.0" }

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -9,9 +9,6 @@ repository = "https://github.com/Enet4/dicom-rs"
 keywords = ["dicom"]
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/travis-ci"
-
 [features]
 default = []
 inventory-registry = ['dicom-encoding/inventory-registry', 'inventory']

--- a/ul/Cargo.toml
+++ b/ul/Cargo.toml
@@ -10,9 +10,6 @@ categories = ["network-programming"]
 keywords = ["dicom", "network"]
 readme = "README.md"
 
-[badges.travis-ci]
-repository = "Enet4/dicom-rs"
-
 [dependencies]
 byteordered = "0.5.0"
 dicom-encoding = { path = "../encoding/", version = "0.3.0" }


### PR DESCRIPTION
- replace root readme Travis badge with GitHub Actions CI badge
- remove travis badge description from Cargo manifests
   - the feature has been removed anyway
- add maintenance badge to parent crate
   - actively developed