### PR TITLE
Support RGB, YBR_FULL and YBR_FULL_422 PhotoMetricInterpretation

### DIFF
--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -20,6 +20,7 @@ image = "0.23.14"
 gdcm-rs = "0.2.0"
 rayon = "1.5.0"
 ndarray = "0.15.1"
+ndarray-stats = "0.5"
 num-traits = "0.2.12"
 
 [dev-dependencies]

--- a/pixeldata/README.md
+++ b/pixeldata/README.md
@@ -15,9 +15,3 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 ```
-
-## Supported features
-- [x] JPEG2000, JPG Lossless, JPEG Lossy conversion to `DynamicImage`
-- [ ] Multi-frame dicoms
-- [ ] RGB and other color spaces
-- [ ] LUT, Modality LUT and VOI Lut transformations

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -161,7 +161,7 @@ impl DecodedPixelData<'_> {
                 let image_buffer: ImageBuffer<Luma<u16>, Vec<u16>> =
                     ImageBuffer::from_raw(self.cols, self.rows, pixel_array.into_raw_vec())
                         .context(InvalidImageBuffer)?;
-                return Ok(DynamicImage::ImageLuma16(image_buffer));
+                Ok(DynamicImage::ImageLuma16(image_buffer))
             }
             3 => {
                 // RGB, YBR_FULL or YBR_FULL_422 colors
@@ -180,7 +180,7 @@ impl DecodedPixelData<'_> {
                         let image_buffer: ImageBuffer<Rgb<u8>, Vec<u8>> =
                             ImageBuffer::from_raw(self.cols, self.rows, pixel_array)
                                 .context(InvalidImageBuffer)?;
-                        return Ok(DynamicImage::ImageRgb8(image_buffer));
+                        Ok(DynamicImage::ImageRgb8(image_buffer))
                     }
                     16 => {
                         let mut pixel_array = vec![0; self.data.len() / 2];
@@ -198,7 +198,7 @@ impl DecodedPixelData<'_> {
                         let image_buffer: ImageBuffer<Rgb<u16>, Vec<u16>> =
                             ImageBuffer::from_raw(self.cols, self.rows, pixel_array)
                                 .context(InvalidImageBuffer)?;
-                        return Ok(DynamicImage::ImageRgb16(image_buffer));
+                        Ok(DynamicImage::ImageRgb16(image_buffer))
                     }
                     _ => InvalidBitsAllocated.fail()?,
                 }

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -145,7 +145,7 @@ impl DecodedPixelData<'_> {
                     (v * self.rescale_slope as f64) + self.rescale_intercept as f64
                 });
 
-                // Apply VOI LUT
+                // TODO: Apply VOI LUT
 
                 // Normalize to u16
                 let min = pixel_array.min().unwrap();

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -145,7 +145,7 @@ impl DecodedPixelData<'_> {
                     (v * self.rescale_slope as f64) + self.rescale_intercept as f64
                 });
 
-                // TODO: Apply VOI LUT
+                // TODO(#122): Apply VOI LUT
 
                 // Normalize to u16
                 let min = pixel_array.min().unwrap();


### PR DESCRIPTION
Hi @Enet4 

This PR adds support for `RGB`, `YBR_FULL` and `YBR_FULL_422` as PhotoMetricInterpretation.

It works by converting `YBR_FULL` and `YBR_FULL_422` color spaces to RGB.

Now that I read through this PR, I think it might be a better option to do this:

1. Read as `ndarray`.
2. Optional Apply modality LUT and make it a public method under the `utilities` module.
3. Optional Convert color space and make it a public method under the `utilities` module.
4. Convert to `DynamicImage`

What do you think? 

Closes: https://github.com/Enet4/dicom-rs/issues/119