### PR TITLE
[object] Mark pixeldata module as bad

### DIFF
--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -95,6 +95,7 @@ pub mod file;
 pub mod loader;
 pub mod mem;
 pub mod meta;
+#[deprecated(since = "0.5.0", note = "This is a stub, use the `dicom-pixeldata` crate instead")]
 pub mod pixeldata;
 pub mod tokens;
 

--- a/object/src/pixeldata.rs
+++ b/object/src/pixeldata.rs
@@ -1,8 +1,9 @@
 //! Module for the pixel data trait and implementations.
 //!
-//! In order to facilitate typical pixel data manipulation, this crate
-//! provides a common interface for retrieving that content as an image
-//! or a multi-dimensional array.
+//! **Note:** This module is deprecated and obsolete.
+//! Please check out the [`dicom-pixeldata` crate][1] instead.
+//!
+//! [1]: https://docs.rs/dicom-pixeldata
 use snafu::{Backtrace, Snafu};
 use std::marker::PhantomData;
 


### PR DESCRIPTION
I had created a `pixeldata` module to start crafting some ideas, but it never turned into something useful.
As such, it is best to mark it for removal and recommend to use the `dicom-pixeldata` crate instead.