### PR TITLE
UTC offset parsing in DT

### DIFF
--- a/core/src/value/deserialize.rs
+++ b/core/src/value/deserialize.rs
@@ -249,14 +249,13 @@ pub fn parse_datetime(buf: &[u8], dt_utc_offset: FixedOffset) -> Result<DateTime
             let tz_sign = buf[0];
             let buf = &buf[1..];
             let (tz_h, tz_m) = match buf.len() {
-                1 => (i32::from(buf[0]) - Z, 0),
-                2 => return UnexpectedEndOfElement.fail(),
-                _ => {
+                4 => {
                     let (h_buf, m_buf) = buf.split_at(2);
-                    let tz_h = read_number(h_buf)?;
-                    let tz_m = read_number(&m_buf[0..usize::min(2, m_buf.len())])?;
+                    let tz_h : i32 = read_number(h_buf)?;
+                    let tz_m : i32 = read_number(m_buf)?;
                     (tz_h, tz_m)
-                }
+                },
+                _ => return UnexpectedEndOfElement.fail(),
             };
             let s = (tz_h * 60 + tz_m) * 60;
             match tz_sign {

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -28,5 +28,5 @@ dicom-test-files = "0.2.0"
 rstest = "0.10.0"
 
 [features]
-default = []
+default = ["gdcm"]
 gdcm = ["gdcm-rs"]

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -28,5 +28,5 @@ dicom-test-files = "0.2.0"
 rstest = "0.10.0"
 
 [features]
-default = ["gdcm"]
+default = []
 gdcm = ["gdcm-rs"]


### PR DESCRIPTION
Hello, so I was looking further into your library and found this UTC offtset parsing.
The original line 252 is unreachable code because of line 247
I think that the parsing was intended to do:
+1 = 01:00
+01 = Err
+011 = 01:01
Instead of changing line 247 I suggest simplifying it to always force a 4 digit input for the offset , as even the DICOM standard says "The optional suffix is not considered as a component." - so probably should not be shortened ?
Thanks for considering ! 
It is great to learn Rust from reading your code.