### PR TITLE
simplify UTC offset parsing

### DIFF
--- a/core/src/value/deserialize.rs
+++ b/core/src/value/deserialize.rs
@@ -474,5 +474,8 @@ mod tests {
         assert!(parse_datetime(b"20151130161445. +0000", default_offset).is_err());
         assert!(parse_datetime(b"20100423164000.001+3", default_offset).is_err());
         assert!(parse_datetime(b"200809112945*1000", default_offset).is_err());
+        assert!(parse_datetime(b"20171130101010.204+1", default_offset).is_err());
+        assert!(parse_datetime(b"20171130101010.204+01", default_offset).is_err());
+        assert!(parse_datetime(b"20171130101010.204+011", default_offset).is_err());
     }
 }

--- a/core/src/value/deserialize.rs
+++ b/core/src/value/deserialize.rs
@@ -243,28 +243,21 @@ pub fn parse_datetime(buf: &[u8], dt_utc_offset: FixedOffset) -> Result<DateTime
                 .single()
                 .context(InvalidDateTimeZone);
             return Ok(dt?);
-        }
-        1 | 2 => return UnexpectedEndOfElement.fail(),
-        _ => {
+        },
+        5 => {
             let tz_sign = buf[0];
             let buf = &buf[1..];
-            let (tz_h, tz_m) = match buf.len() {
-                1 => (i32::from(buf[0]) - Z, 0),
-                2 => return UnexpectedEndOfElement.fail(),
-                _ => {
-                    let (h_buf, m_buf) = buf.split_at(2);
-                    let tz_h = read_number(h_buf)?;
-                    let tz_m = read_number(&m_buf[0..usize::min(2, m_buf.len())])?;
-                    (tz_h, tz_m)
-                }
-            };
+            let (h_buf, m_buf) = buf.split_at(2);
+            let tz_h : i32 = read_number(h_buf)?;
+            let tz_m : i32 = read_number(m_buf)?;
             let s = (tz_h * 60 + tz_m) * 60;
             match tz_sign {
                 b'+' => FixedOffset::east(s),
                 b'-' => FixedOffset::west(s),
                 c => return InvalidTimeZoneSignToken { value: c }.fail(),
             }
-        }
+        },
+        _ => return UnexpectedEndOfElement.fail()
     };
 
     offset


### PR DESCRIPTION
Hello, so I was looking further into your library and found this UTC offtset parsing.
The original line 252 is unreachable code because of line 247
I think that the parsing was intended to do:
+1 = 01:00
+01 = Err
+011 = 01:01
I suggest simplifying it to always force a 4 digit input for the offset , as even the DICOM standard says "The optional suffix is not considered as a component." - so probably should not be shortened ?
Thanks for considering !
It is great to learn Rust from reading your code.