### PR TITLE
[pixeldata] Fetch the first frame of native pixel data on decode_pixel_data

### DIFF
--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -71,8 +71,12 @@ where
                 decoded_frame.to_vec()
             }
             Value::Primitive(p) => {
-                // Non-encoded, just return the pixel data
-                p.to_bytes().to_vec()
+                // Non-encoded, just return the pixel data of the first frame
+                let total_bytes = rows as usize
+                    * cols as usize
+                    * samples_per_pixel as usize
+                    * (bits_allocated as usize / 8);
+                p.to_bytes()[0..total_bytes].to_vec()
             }
             Value::Sequence { items: _, size: _ } => InvalidPixelData.fail()?,
         };

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -378,8 +378,12 @@ where
                 fragments[0].to_vec()
             }
             Value::Primitive(p) => {
-                // Non-encoded, just return the pixel data
-                p.to_bytes().to_vec()
+                // Non-encoded, just return the pixel data of the first frame
+                let total_bytes = rows as usize
+                    * cols as usize
+                    * samples_per_pixel as usize
+                    * (bits_allocated as usize / 8);
+                p.to_bytes()[0..total_bytes].to_vec()
             }
             Value::Sequence { items: _, size: _ } => InvalidPixelData.fail()?,
         };


### PR DESCRIPTION
The bytes of native pixel data need to be sliced so that it contains only the bytes of the first slice.

Should resolve #146 (CC @bastien-solutions).