### PR TITLE
[pixeldata] reexport public dependencies

### DIFF
--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -61,6 +61,9 @@ use snafu::OptionExt;
 use snafu::{ResultExt, Snafu};
 use std::borrow::Cow;
 
+pub use image;
+pub use ndarray;
+
 #[cfg(feature = "gdcm")]
 mod gdcm;
 


### PR DESCRIPTION
`image` and `ndarray` are part of the API, so the crate should re-export them.