### PR TITLE
Decode encapsulated pixel data frame offset table

### DIFF
--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -57,7 +57,7 @@ pub enum Value<I = EmptyObject, P = [u8; 0]> {
     /// An encapsulated pixel data sequence.
     PixelSequence {
         /// The value contents of the offset table.
-        offset_table: C<u8>,
+        offset_table: C<u32>,
         /// The sequence of compressed fragments.
         fragments: C<P>,
     },
@@ -69,7 +69,7 @@ impl<P> Value<EmptyObject, P> {
     ///
     /// Note: This function does not validate the offset table
     /// against the fragments.
-    pub fn new_pixel_sequence<T>(offset_table: C<u8>, fragments: T) -> Self
+    pub fn new_pixel_sequence<T>(offset_table: C<u32>, fragments: T) -> Self
     where
         T: Into<C<P>>,
     {
@@ -153,7 +153,7 @@ impl<I, P> Value<I, P> {
     }
 
     /// Gets a reference to the encapsulated pixel data's offset table.
-    pub fn offset_table(&self) -> Option<&[u8]> {
+    pub fn offset_table(&self) -> Option<&[u32]> {
         match self {
             Value::PixelSequence { offset_table, .. } => Some(&offset_table),
             _ => None,

--- a/dcmdump/src/main.rs
+++ b/dcmdump/src/main.rs
@@ -378,10 +378,10 @@ where
             let byte_len = offset_table.len();
             writeln!(
                 to,
-                "  {} pi ({:>3} bytes, 1 Item): {:48}",
+                "  {} offset table ({:>3} bytes, 1 Item): {:48}",
                 DumpValue::TagNum("(FFFE,E000)"),
                 byte_len,
-                item_value_summary(&offset_table, width.saturating_sub(38 + depth * 2)),
+                offset_table_summary(&offset_table, width.saturating_sub(38 + depth * 2)),
             )?;
 
             // write compressed fragments
@@ -565,6 +565,18 @@ fn item_value_summary(data: &[u8], max_characters: u32) -> DumpValue<String> {
         max_characters,
         false,
     ))
+}
+
+fn offset_table_summary(data: &[u32], max_characters: u32) -> String {
+    if data.is_empty() {
+        format!("{}", "(empty)".italic())
+    } else {
+        format_value_list(
+            data.iter().map(|n| format!("{:02X}", n)),
+            max_characters,
+            false,
+        )
+    }
 }
 
 fn format_value_list<I>(values: I, max_characters: u32, quoted: bool) -> String

--- a/encoding/src/encode/explicit_be.rs
+++ b/encoding/src/encode/explicit_be.rs
@@ -170,6 +170,16 @@ impl Encode for ExplicitVRBigEndianEncoder {
     {
         self.basic.encode_primitive(to, value)
     }
+
+    fn encode_offset_table<W>(&self, mut to: W, offset_table: &[u32]) -> Result<usize>
+    where
+        W: Write
+    {
+        for v in offset_table {
+            self.basic.encode_ul(&mut to, *v).context(WriteOffsetTable)?;
+        }
+        Ok(offset_table.len() * 4)
+    }
 }
 
 #[cfg(test)]

--- a/encoding/src/encode/explicit_le.rs
+++ b/encoding/src/encode/explicit_le.rs
@@ -165,6 +165,16 @@ impl Encode for ExplicitVRLittleEndianEncoder {
     {
         self.basic.encode_primitive(to, value)
     }
+
+    fn encode_offset_table<W>(&self, mut to: W, offset_table: &[u32]) -> Result<usize>
+    where
+        W: Write
+    {
+        for v in offset_table {
+            self.basic.encode_ul(&mut to, *v).context(WriteOffsetTable)?;
+        }
+        Ok(offset_table.len() * 4)
+    }
 }
 
 #[cfg(test)]

--- a/encoding/src/encode/implicit_le.rs
+++ b/encoding/src/encode/implicit_le.rs
@@ -136,6 +136,16 @@ impl Encode for ImplicitVRLittleEndianEncoder {
     {
         self.basic.encode_primitive(to, value)
     }
+
+    fn encode_offset_table<W>(&self, mut to: W, offset_table: &[u32]) -> Result<usize>
+    where
+        W: Write
+    {
+        for v in offset_table {
+            self.basic.encode_ul(&mut to, *v).context(WriteOffsetTable)?;
+        }
+        Ok(offset_table.len() * 4)
+    }
 }
 
 #[cfg(test)]

--- a/encoding/src/encode/mod.rs
+++ b/encoding/src/encode/mod.rs
@@ -85,9 +85,14 @@ pub enum Error {
         backtrace: Backtrace,
         source: io::Error,
     },
+    #[snafu(display("Failed to write pixel data offset table"))]
+    WriteOffsetTable {
+        backtrace: Backtrace,
+        source: io::Error,
+    },
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Type trait for an encoder of basic data properties.
 /// Unlike `Encode` (and similar to `BasicDecode`), this trait is not object
@@ -323,6 +328,15 @@ pub trait Encode {
     fn encode_primitive<W>(&self, to: W, value: &PrimitiveValue) -> Result<usize>
     where
         W: Write;
+    
+    /// Encode and write a DICOM pixel data offset table
+    /// to the given destination.
+    ///
+    // Note that offset tables might not apply to all forms of encoding,
+    // but this method needs to exist nevertheless.
+    fn encode_offset_table<W>(&self, to: W, offset_table: &[u32]) -> Result<usize>
+    where
+        W: Write;
 }
 
 impl<T: ?Sized> Encode for &T
@@ -369,6 +383,13 @@ where
         W: Write,
     {
         (**self).encode_primitive(to, value)
+    }
+
+    fn encode_offset_table<W>(&self, to: W, offset_table: &[u32]) -> Result<usize>
+    where
+        W: Write
+    {
+        (**self).encode_offset_table(to, offset_table)
     }
 }
 
@@ -417,6 +438,13 @@ where
     {
         (**self).encode_primitive(to, value)
     }
+
+    fn encode_offset_table<W>(&self, to: W, offset_table: &[u32]) -> Result<usize>
+    where
+        W: Write
+    {
+        (**self).encode_offset_table(to, offset_table)
+    }
 }
 
 /// Type trait for a data element encoder to a single known writer type `W`.
@@ -451,6 +479,15 @@ pub trait EncodeTo<W: ?Sized> {
 
     /// Encode and write a primitive DICOM value to the given destination.
     fn encode_primitive(&self, to: &mut W, value: &PrimitiveValue) -> Result<usize>
+    where
+        W: Write;
+
+    /// Encode and write a DICOM pixel data offset table
+    /// to the given destination.
+    ///
+    // Note that offset tables might not apply to all forms of encoding,
+    // but this method needs to exist nevertheless.
+    fn encode_offset_table(&self, to: &mut W, offset_table: &[u32]) -> Result<usize>
     where
         W: Write;
 }
@@ -501,6 +538,13 @@ where
     {
         (**self).encode_primitive(to, value)
     }
+
+    fn encode_offset_table(&self, to: &mut W, offset_table: &[u32]) -> Result<usize>
+    where
+        W: Write
+    {
+        (**self).encode_offset_table(to, offset_table)
+    }
 }
 
 impl<T: ?Sized, W: ?Sized> EncodeTo<W> for Box<T>
@@ -548,6 +592,13 @@ where
         W: Write,
     {
         (**self).encode_primitive(to, value)
+    }
+
+    fn encode_offset_table(&self, to: &mut W, offset_table: &[u32]) -> Result<usize>
+    where
+        W: Write
+    {
+        (**self).encode_offset_table(to, offset_table)
     }
 }
 
@@ -683,6 +734,10 @@ where
 
     fn encode_primitive(&self, to: &mut W, value: &PrimitiveValue) -> Result<usize> {
         self.inner.encode_primitive(to, value)
+    }
+
+    fn encode_offset_table(&self, to: &mut W, offset_table: &[u32]) -> Result<usize> {
+        self.inner.encode_offset_table(to, offset_table)
     }
 }
 

--- a/encoding/src/encode/mod.rs
+++ b/encoding/src/encode/mod.rs
@@ -332,6 +332,8 @@ pub trait Encode {
     /// Encode and write a DICOM pixel data offset table
     /// to the given destination.
     ///
+    /// For convenience, returns the number of bytes written on success,
+    /// equivalent to `offset_table.len() * 4`.
     // Note that offset tables might not apply to all forms of encoding,
     // but this method needs to exist nevertheless.
     fn encode_offset_table<W>(&self, to: W, offset_table: &[u32]) -> Result<usize>

--- a/encoding/src/encode/mod.rs
+++ b/encoding/src/encode/mod.rs
@@ -487,6 +487,8 @@ pub trait EncodeTo<W: ?Sized> {
     /// Encode and write a DICOM pixel data offset table
     /// to the given destination.
     ///
+    /// For convenience, returns the number of bytes written on success,
+    /// equivalent to `offset_table.len() * 4`.
     // Note that offset tables might not apply to all forms of encoding,
     // but this method needs to exist nevertheless.
     fn encode_offset_table(&self, to: &mut W, offset_table: &[u32]) -> Result<usize>

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -627,19 +627,18 @@ where
 
         while let Some(token) = dataset.next() {
             match token.context(ReadToken)? {
+                DataToken::OffsetTable(table) => {
+                    offset_table = Some(table);
+                }
                 DataToken::ItemValue(data) => {
-                    if offset_table.is_none() {
-                        offset_table = Some(data.into());
-                    } else {
-                        fragments.push(data);
-                    }
+                    fragments.push(data);
                 }
                 DataToken::ItemEnd => {
                     // at the end of the first item ensure the presence of
                     // an empty offset_table here, so that the next items
                     // are seen as compressed fragments
                     if offset_table.is_none() {
-                        offset_table = Some(C::new())
+                        offset_table = Some(Vec::new())
                     }
                 }
                 DataToken::ItemStart { len: _ } => { /* no-op */ }
@@ -659,7 +658,7 @@ where
 
         Ok(Value::PixelSequence {
             fragments,
-            offset_table: offset_table.unwrap_or_default(),
+            offset_table: offset_table.unwrap_or_default().into(),
         })
     }
 

--- a/object/tests/integration_test.rs
+++ b/object/tests/integration_test.rs
@@ -13,7 +13,11 @@ fn test_ob_value_with_unknown_length() {
     let element = object.element_by_name("PixelData").unwrap();
 
     match element.value() {
-        Value::PixelSequence { fragments, .. } => {
+        Value::PixelSequence { fragments, offset_table } => {
+
+            // check offset table
+            assert_eq!(offset_table.len(), 0);
+
             // check if the leading and trailing bytes look right
             assert_eq!(fragments.len(), 1);
             let fragment = &fragments[0];

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -51,7 +51,7 @@ pub enum DataToken {
     /// An owned piece of raw data representing an item's value.
     ///
     /// This variant is used to represent
-    /// the value of a compressed fragment.
+    /// the value of an encoded fragment.
     /// It should not be used to represent nested data sets.
     ItemValue(Vec<u8>),
     /// An owned sequence of unsigned 32 bit integers

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -59,8 +59,8 @@ pub enum DataToken {
     ///
     /// This variant is used to represent
     /// the byte offsets to the first byte of the Item tag of the first fragment
-    /// for each frame in the sequence of items
-    /// (as per PS 3.5, Section A.4)
+    /// for each frame in the sequence of items,
+    /// as per PS 3.5, Section A.4.
     OffsetTable(Vec<u32>),
 }
 

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -181,7 +181,7 @@ where
                 });
                 self.write_impl(&token)
             }
-            token @ DataToken::ItemValue(_) | token @ DataToken::PrimitiveValue(_) => {
+            token @ DataToken::ItemValue(_) | token @ DataToken::PrimitiveValue(_) | token @ DataToken::OffsetTable(_) => {
                 self.write_impl(&token)
             }
         }
@@ -228,6 +228,9 @@ where
                     .encode_primitive(last_de, value)
                     .context(WriteValue)?;
                 self.last_de = None;
+            }
+            DataToken::OffsetTable(table) => {
+                self.printer.encode_offset_table(table).context(WriteValue)?;
             }
             DataToken::ItemValue(data) => {
                 self.printer.write_bytes(&data).context(WriteValue)?;

--- a/parser/src/stateful/encode.rs
+++ b/parser/src/stateful/encode.rs
@@ -38,7 +38,7 @@ pub enum Error {
         source: dicom_encoding::text::EncodeTextError,
     },
 
-    #[snafu(display("Could not write value data to writer"))]
+    #[snafu(display("Could not write value data at position {}", position))]
     WriteValueData {
         position: u64,
         source: std::io::Error,
@@ -164,6 +164,16 @@ where
     /// Retrieve the number of bytes written so far by this printer.
     pub fn bytes_written(&self) -> u64 {
         self.bytes_written
+    }
+
+    /// Encode and write the values of a pixel data offset table.
+    pub fn encode_offset_table(&mut self, table: &[u32]) -> Result<()> {
+        self.encoder.encode_offset_table(&mut self.to, table).context(EncodeData {
+            position: self.bytes_written,
+        })?;
+
+        self.bytes_written += table.len() as u64 * 4;
+        Ok(())
     }
 
     /// Encode and write a primitive value. Where applicable, this


### PR DESCRIPTION
- [core] modify Value prototype so that `offset_table` is a sequence of `u32`, as specified in the standard
- [encoding] add methods for encoding offset tables
- [parser] add methods for decoding and encoding offset tables
- [parser] raise error on undefined pixel fragment item instead of panicking
- [parser] add OffsetTable variant to data token
   - note that this does not apply to the lazy data set token because here the table is not read eagerly
- [parser] change dataset reader and writer so that they assume an offset table token on first item value instead of `ItemValue`
- [object] change in-memory DICOM object constructor to assume offset table data token
- [object] check offset table in integration test
- [dcmdump] update tool to present human readable offset table