### PR TITLE
[parser] Update text codec of stateful encoder

### DIFF
--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -21,11 +21,7 @@ use dicom_core::value::{Value, C};
 use dicom_core::{DataElement, Length, Tag, VR};
 use dicom_dictionary_std::StandardDataDictionary;
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
-use dicom_encoding::{
-    encode::EncodeTo,
-    text::{SpecificCharacterSet, TextCodec},
-    TransferSyntax,
-};
+use dicom_encoding::{encode::EncodeTo, text::SpecificCharacterSet, TransferSyntax};
 use dicom_parser::dataset::{DataSetReader, DataToken};
 use dicom_parser::{
     dataset::{read::Error as ParserError, DataSetWriter, IntoTokens},
@@ -463,22 +459,25 @@ where
     }
 
     /// Write this object's data set into the given writer,
-    /// with the specified encoder specifications,
+    /// with the given encoder specifications,
     /// without preamble, magic code, nor file meta group.
+    ///
+    /// The text encoding to use will be the default character set
+    /// until _Specific Character Set_ is found in the data set,
+    /// in which then that character set will be used.
     ///
     /// Note: [`write_dataset_with_ts`] and [`write_dataset_with_ts_cs`]
     /// may be easier to use.
     ///
     /// [`write_dataset_with_ts`]: #method.write_dataset_with_ts
     /// [`write_dataset_with_ts_cs`]: #method.write_dataset_with_ts_cs
-    pub fn write_dataset<W, E, T: 'static>(&self, to: W, encoder: E, text_encoder: T) -> Result<()>
+    pub fn write_dataset<W, E>(&self, to: W, encoder: E) -> Result<()>
     where
         W: Write,
         E: EncodeTo<W>,
-        T: TextCodec,
     {
         // prepare data set writer
-        let mut dset_writer = DataSetWriter::new_with_codec(to, encoder, Box::new(text_encoder) as Box<_>);
+        let mut dset_writer = DataSetWriter::new(to, encoder);
 
         // write object
         dset_writer
@@ -514,7 +513,7 @@ where
         Ok(())
     }
 
-    /// Write this object's data set into the given printer,
+    /// Write this object's data set into the given writer,
     /// with the specified transfer syntax,
     /// without preamble, magic code, nor file meta group.
     ///
@@ -762,7 +761,6 @@ mod tests {
     use dicom_encoding::{
         decode::{basic::BasicDecoder, implicit_le::ImplicitVRLittleEndianDecoder},
         encode::EncoderFor,
-        text::DefaultCharacterSetCodec,
         transfer_syntax::implicit_le::ImplicitVRLittleEndianEncoder,
     };
     use dicom_parser::{dataset::IntoTokens, StatefulDecoder};
@@ -798,7 +796,7 @@ mod tests {
         ];
 
         let decoder = ImplicitVRLittleEndianDecoder::default();
-        let text = Box::new(DefaultCharacterSetCodec) as Box<_>;
+        let text = SpecificCharacterSet::Default;
         let mut cursor = &data_in[..];
         let parser = StatefulDecoder::new(
             &mut cursor,
@@ -896,9 +894,8 @@ mod tests {
         let mut out = Vec::new();
 
         let printer = EncoderFor::new(ImplicitVRLittleEndianEncoder::default());
-        let text = DefaultCharacterSetCodec;
 
-        obj.write_dataset(&mut out, printer, text).unwrap();
+        obj.write_dataset(&mut out, printer).unwrap();
 
         assert_eq!(
             out,

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -471,14 +471,14 @@ where
     ///
     /// [`write_dataset_with_ts`]: #method.write_dataset_with_ts
     /// [`write_dataset_with_ts_cs`]: #method.write_dataset_with_ts_cs
-    pub fn write_dataset<W, E, T>(&self, to: W, encoder: E, text_encoder: T) -> Result<()>
+    pub fn write_dataset<W, E, T: 'static>(&self, to: W, encoder: E, text_encoder: T) -> Result<()>
     where
         W: Write,
         E: EncodeTo<W>,
         T: TextCodec,
     {
         // prepare data set writer
-        let mut dset_writer = DataSetWriter::new(to, encoder, text_encoder);
+        let mut dset_writer = DataSetWriter::new_with_codec(to, encoder, Box::new(text_encoder) as Box<_>);
 
         // write object
         dset_writer

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -6,7 +6,7 @@ use dicom_core::value::{PrimitiveValue, Value};
 use dicom_core::{Length, Tag, VR};
 use dicom_encoding::decode::{self, DecodeFrom};
 use dicom_encoding::encode::EncoderFor;
-use dicom_encoding::text::{self, DefaultCharacterSetCodec, TextCodec};
+use dicom_encoding::text::{self, TextCodec};
 use dicom_encoding::transfer_syntax::explicit_le::ExplicitVRLittleEndianEncoder;
 use dicom_parser::dataset::{DataSetWriter, IntoTokens};
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
@@ -413,7 +413,6 @@ impl FileMetaTable {
         let mut dset = DataSetWriter::new(
             writer,
             EncoderFor::new(ExplicitVRLittleEndianEncoder::default()),
-            DefaultCharacterSetCodec,
         );
         dset.write_sequence(
             self.clone()

--- a/parser/src/dataset/lazy_read.rs
+++ b/parser/src/dataset/lazy_read.rs
@@ -451,8 +451,7 @@ mod tests {
         header::{DataElementHeader, Length},
     };
     use dicom_core::{Tag, VR};
-    use dicom_encoding::decode::basic::LittleEndianBasicDecoder;
-    use dicom_encoding::text::DefaultCharacterSetCodec;
+    use dicom_encoding::{decode::basic::LittleEndianBasicDecoder, text::SpecificCharacterSet};
     use dicom_encoding::transfer_syntax::explicit_le::ExplicitVRLittleEndianDecoder;
     use dicom_encoding::transfer_syntax::implicit_le::ImplicitVRLittleEndianDecoder;
 
@@ -465,7 +464,7 @@ mod tests {
             &mut cursor,
             ImplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder::default(),
-            Box::new(DefaultCharacterSetCodec::default()) as Box<_>, // trait object
+            SpecificCharacterSet::Default,
         );
 
         validate_dataset_reader(data, parser, ground_truth)
@@ -480,7 +479,7 @@ mod tests {
             &mut cursor,
             ExplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder::default(),
-            Box::new(DefaultCharacterSetCodec::default()) as Box<_>, // trait object
+            SpecificCharacterSet::Default,
         );
 
         validate_dataset_reader(&data, parser, ground_truth)
@@ -1032,7 +1031,7 @@ mod tests {
             &mut cursor,
             ExplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder::default(),
-            Box::new(DefaultCharacterSetCodec::default()) as Box<_>, // trait object
+            SpecificCharacterSet::Default,
         );
 
         let mut dset_reader = LazyDataSetReader::new(parser);
@@ -1085,7 +1084,7 @@ mod tests {
             &mut cursor,
             ExplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder::default(),
-            Box::new(DefaultCharacterSetCodec::default()) as Box<_>, // trait object
+            SpecificCharacterSet::Default,
         );
 
         let mut dset_reader = LazyDataSetReader::new(parser);

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -901,8 +901,7 @@ mod tests {
 
     use dicom_encoding::{
         decode::{basic::LittleEndianBasicDecoder, explicit_le::ExplicitVRLittleEndianDecoder},
-        text::DefaultCharacterSetCodec,
-        text::DynamicTextCodec,
+        text::SpecificCharacterSet,
     };
 
     use crate::stateful::decode::StatefulDecode;
@@ -1108,7 +1107,7 @@ mod tests {
             &mut data,
             ExplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder,
-            Box::new(DefaultCharacterSetCodec) as DynamicTextCodec,
+            SpecificCharacterSet::Default,
         );
 
         is_stateful_decode(&decoder);
@@ -1138,7 +1137,7 @@ mod tests {
             &mut data,
             ExplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder,
-            Box::new(DefaultCharacterSetCodec) as DynamicTextCodec,
+            SpecificCharacterSet::Default,
         );
 
         is_stateful_decode(&decoder);
@@ -1169,7 +1168,7 @@ mod tests {
             &mut data,
             ExplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder,
-            Box::new(DefaultCharacterSetCodec) as DynamicTextCodec,
+            SpecificCharacterSet::Default,
         );
 
         is_stateful_decode(&decoder);

--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -573,7 +573,7 @@ mod tests {
     use dicom_core::value::PrimitiveValue;
     use dicom_core::{Tag, VR};
     use dicom_encoding::decode::basic::LittleEndianBasicDecoder;
-    use dicom_encoding::text::DefaultCharacterSetCodec;
+    use dicom_encoding::text::SpecificCharacterSet;
     use dicom_encoding::transfer_syntax::explicit_le::ExplicitVRLittleEndianDecoder;
     use dicom_encoding::transfer_syntax::implicit_le::ImplicitVRLittleEndianDecoder;
 
@@ -586,7 +586,7 @@ mod tests {
             &mut cursor,
             ImplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder::default(),
-            Box::new(DefaultCharacterSetCodec::default()) as Box<_>, // trait object
+            SpecificCharacterSet::Default,
         );
 
         validate_dataset_reader(data, parser, ground_truth)
@@ -601,7 +601,7 @@ mod tests {
             &mut cursor,
             ExplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder::default(),
-            Box::new(DefaultCharacterSetCodec::default()) as Box<_>, // trait object
+            SpecificCharacterSet::Default,
         );
 
         validate_dataset_reader(&data, parser, ground_truth)

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -10,7 +10,7 @@ use crate::dataset::*;
 use crate::stateful::encode::StatefulEncoder;
 use dicom_core::{DataElementHeader, Length, VR};
 use dicom_encoding::encode::EncodeTo;
-use dicom_encoding::text::{SpecificCharacterSet, TextCodec};
+use dicom_encoding::text::{DefaultCharacterSetCodec, SpecificCharacterSet, TextCodec};
 use dicom_encoding::transfer_syntax::DynEncoder;
 use dicom_encoding::TransferSyntax;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
@@ -85,7 +85,7 @@ struct SeqToken {
 /// This is analogous to the `DatasetReader` type for converting data
 /// set tokens to bytes.
 #[derive(Debug)]
-pub struct DataSetWriter<W, E, T> {
+pub struct DataSetWriter<W, E, T = Box<dyn TextCodec>> {
     printer: StatefulEncoder<W, E, T>,
     seq_tokens: Vec<SeqToken>,
     last_de: Option<DataElementHeader>,
@@ -103,12 +103,22 @@ where
         let text = charset
             .codec()
             .context(UnsupportedCharacterSet { charset })?;
-        Ok(DataSetWriter::new(to, encoder, text))
+        Ok(DataSetWriter::new_with_codec(to, encoder, text))
+    }
+}
+
+impl<W, E> DataSetWriter<W, E> {
+    pub fn new(to: W, encoder: E) -> Self {
+        DataSetWriter {
+            printer: StatefulEncoder::new(to, encoder, Box::new(DefaultCharacterSetCodec) as Box<_>),
+            seq_tokens: Vec::new(),
+            last_de: None,
+        }
     }
 }
 
 impl<W, E, T> DataSetWriter<W, E, T> {
-    pub fn new(to: W, encoder: E, text: T) -> Self {
+    pub fn new_with_codec(to: W, encoder: E, text: T) -> Self {
         DataSetWriter {
             printer: StatefulEncoder::new(to, encoder, text),
             seq_tokens: Vec::new(),
@@ -117,11 +127,10 @@ impl<W, E, T> DataSetWriter<W, E, T> {
     }
 }
 
-impl<W, E, T> DataSetWriter<W, E, T>
+impl<W, E> DataSetWriter<W, E>
 where
     W: Write,
     E: EncodeTo<W>,
-    T: TextCodec,
 {
     /// Feed the given sequence of tokens which are part of the same data set.
     #[inline]
@@ -261,7 +270,6 @@ mod tests {
         Tag, VR,
     };
     use dicom_encoding::encode::EncoderFor;
-    use dicom_encoding::text::DefaultCharacterSetCodec;
     use dicom_encoding::transfer_syntax::explicit_le::ExplicitVRLittleEndianEncoder;
 
     fn validate_dataset_writer<I>(tokens: I, ground_truth: &[u8])
@@ -270,8 +278,7 @@ mod tests {
     {
         let mut raw_out: Vec<u8> = vec![];
         let encoder = EncoderFor::new(ExplicitVRLittleEndianEncoder::default());
-        let text = DefaultCharacterSetCodec::default();
-        let mut dset_writer = DataSetWriter::new(&mut raw_out, encoder, text);
+        let mut dset_writer = DataSetWriter::new(&mut raw_out, encoder);
 
         dset_writer.write_sequence(tokens).unwrap();
 

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -1330,7 +1330,7 @@ mod tests {
             &mut cursor,
             ImplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder,
-            Box::new(DefaultCharacterSetCodec) as DynamicTextCodec,
+            SpecificCharacterSet::Default,
         );
 
         is_stateful_decoder(&decoder);

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -9,8 +9,8 @@ use dicom_encoding::decode::basic::{BasicDecoder, LittleEndianBasicDecoder};
 use dicom_encoding::decode::primitive_value::*;
 use dicom_encoding::decode::{BasicDecode, DecodeFrom};
 use dicom_encoding::text::{
-    validate_da, validate_dt, validate_tm, DefaultCharacterSetCodec, DynamicTextCodec,
-    SpecificCharacterSet, TextCodec, TextValidationOutcome,
+    validate_da, validate_dt, validate_tm, DefaultCharacterSetCodec, SpecificCharacterSet,
+    TextCodec, TextValidationOutcome,
 };
 use dicom_encoding::transfer_syntax::explicit_le::ExplicitVRLittleEndianDecoder;
 use dicom_encoding::transfer_syntax::{DynDecoder, TransferSyntax};
@@ -223,7 +223,7 @@ const PARSER_BUFFER_CAPACITY: usize = 2048;
 /// whereas `DB` is the parameter type for the basic decoder.
 /// `TC` defines the text codec used underneath.
 #[derive(Debug)]
-pub struct StatefulDecoder<D, S, BD = BasicDecoder, TC = DynamicTextCodec> {
+pub struct StatefulDecoder<D, S, BD = BasicDecoder, TC = SpecificCharacterSet> {
     from: S,
     decoder: D,
     basic: BD,
@@ -250,13 +250,22 @@ impl<S> StatefulDecoder<DynDecoder<S>, S> {
         let decoder = ts
             .decoder_for::<S>()
             .context(UnsupportedTransferSyntax { ts: ts.name() })?;
-        let text = charset
-            .codec()
-            .context(UnsupportedCharacterSet { charset })?;
 
         Ok(StatefulDecoder::new_with_position(
-            from, decoder, basic, text, position,
+            from, decoder, basic, charset, position,
         ))
+    }
+
+    /// Create a new DICOM parser for the given transfer syntax
+    /// and assumed position of the reader source.
+    ///
+    /// The default character set is assumed
+    /// until a _Specific Character Set_ attribute is found.
+    pub fn new_with_ts(from: S, ts: &TransferSyntax, position: u64) -> Result<Self>
+    where
+        S: Read,
+    {
+        Self::new_with(from, ts, SpecificCharacterSet::default(), position)
     }
 }
 
@@ -532,7 +541,7 @@ where
         let parts: Result<_> = buf
             .split(|b| *b == b'\\')
             .map(|slice| {
-                let codec = SpecificCharacterSet::Default.codec().unwrap();
+                let codec = DefaultCharacterSetCodec;
                 let txt = codec.decode(slice).context(DecodeText {
                     position: self.position,
                 })?;
@@ -601,7 +610,7 @@ where
         let parts: Result<_> = buf
             .split(|v| *v == b'\\')
             .map(|slice| {
-                let codec = SpecificCharacterSet::Default.codec().unwrap();
+                let codec = DefaultCharacterSetCodec;
                 let txt = codec.decode(slice).context(DecodeText {
                     position: self.position,
                 })?;
@@ -760,16 +769,14 @@ where
     }
 }
 
-impl<S, D, BD> StatefulDecoder<D, S, BD, DynamicTextCodec>
+impl<S, D, BD> StatefulDecoder<D, S, BD>
 where
     D: DecodeFrom<S>,
     BD: BasicDecode,
     S: Read,
 {
     fn set_character_set(&mut self, charset: SpecificCharacterSet) -> Result<()> {
-        self.text = charset
-            .codec()
-            .context(UnsupportedCharacterSet { charset })?;
+        self.text = charset;
         Ok(())
     }
 
@@ -862,7 +869,7 @@ where
     }
 }
 
-impl<D, S, BD> StatefulDecode for StatefulDecoder<D, S, BD, DynamicTextCodec>
+impl<D, S, BD> StatefulDecode for StatefulDecoder<D, S, BD>
 where
     D: DecodeFrom<S>,
     BD: BasicDecode,
@@ -1008,11 +1015,9 @@ where
         W: std::io::Write,
     {
         let length = u64::from(length);
-        std::io::copy(&mut self.from.by_ref().take(length), &mut out).context(
-            ReadValueData {
-                position: self.position,
-            },
-        )?;
+        std::io::copy(&mut self.from.by_ref().take(length), &mut out).context(ReadValueData {
+            position: self.position,
+        })?;
         self.position += length;
         Ok(())
     }
@@ -1058,7 +1063,7 @@ mod tests {
     use dicom_core::header::{DataElementHeader, HasLength, Header, Length, SequenceItemHeader};
     use dicom_core::{Tag, VR};
     use dicom_encoding::decode::basic::LittleEndianBasicDecoder;
-    use dicom_encoding::text::{DefaultCharacterSetCodec, DynamicTextCodec};
+    use dicom_encoding::text::{SpecificCharacterSet, TextCodec};
     use dicom_encoding::transfer_syntax::explicit_le::ExplicitVRLittleEndianDecoder;
     use dicom_encoding::transfer_syntax::implicit_le::ImplicitVRLittleEndianDecoder;
     use std::io::{Cursor, Seek, SeekFrom};
@@ -1095,7 +1100,7 @@ mod tests {
             &mut cursor,
             ExplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder,
-            Box::new(DefaultCharacterSetCodec) as DynamicTextCodec,
+            SpecificCharacterSet::Default,
         );
 
         is_stateful_decoder(&decoder);
@@ -1168,7 +1173,7 @@ mod tests {
             &mut cursor,
             ExplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder,
-            Box::new(DefaultCharacterSetCodec) as DynamicTextCodec,
+            SpecificCharacterSet::Default,
         );
 
         is_stateful_decoder(&decoder);
@@ -1209,7 +1214,7 @@ mod tests {
             &mut cursor,
             ExplicitVRLittleEndianDecoder::default(),
             LittleEndianBasicDecoder,
-            Box::new(DefaultCharacterSetCodec) as DynamicTextCodec,
+            SpecificCharacterSet::Default,
             128,
         );
 

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -1,7 +1,7 @@
 /// PDU reader module
 use crate::pdu::*;
 use byteordered::byteorder::{BigEndian, ReadBytesExt};
-use dicom_encoding::text::{SpecificCharacterSet, TextCodec};
+use dicom_encoding::text::{DefaultCharacterSetCodec, TextCodec};
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 use std::io::{Cursor, ErrorKind, Read, Seek, SeekFrom};
 
@@ -141,9 +141,7 @@ where
 
     let bytes = read_n(reader, pdu_length as usize).context(ReadPdu)?;
     let mut cursor = Cursor::new(bytes);
-    let codec = SpecificCharacterSet::Default
-        .codec()
-        .expect("Support for the default character set is mandatory");
+    let codec = DefaultCharacterSetCodec;
 
     match pdu_type {
         0x01 => {


### PR DESCRIPTION
This resolves #155 , but due to the hard dependency on a monomorphized text codec `T`, it is too inconvenient to fix this without a breaking change.

- [BREAKING] restrict critical methods of `StatefulEncoder` for `T = SpecificCharacterSet`
   - so that the text codec can mutate easily
   - propagate restriction to data set writer
   - give `T` this type as default
- [BREAKING] change `DataSetWriter::new` function
   - to get rid of text codec parameter
   - create new_with_codec as alternative
- [BREAKING] rename `SpecificCharacterSet::GB18030` to `SpecificCharacterSet::Gb18030`, to follow variant naming conventions
- [BREAKING] [object] remove parameter `text` and type parameter `T` for `InMemDicomObject::write_dataset`
   - hopefully this is not severe, as `write_dataset_with_ts` and `write_dataset_with_ts_cs` are more commonly used and easier to use
- [BREAKING] replace text codec type parameter in stateful decoder/encoder and dataset readers/writer: it is now `SpecificCharacterSet` instead of `DynamicTextCodec`.
- Deprecate `DynamicTextCodec`
- Deprecate `SpecificCharacterSet::codec`: no longer necessary because the value can be used as a text codec directly
- Implement `TextCodec` for `SpecificCharacterSet` directly
- [ul] replace use of dynamic text codec with statically defined text codec
- add test for updating encoder character set