### PR TITLE
Make transfer syntax registry more flexible against UIDs with null characters

### DIFF
--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -63,14 +63,9 @@ impl fmt::Debug for TransferSyntaxRegistryImpl {
 impl TransferSyntaxRegistryImpl {
     /// Obtain a DICOM codec by transfer syntax UID.
     fn get<U: AsRef<str>>(&self, uid: U) -> Option<&'static TransferSyntax> {
-        let ts_uid = {
-            let uid = uid.as_ref();
-            if uid.as_bytes().last().cloned() == Some(b'\0') || uid.ends_with(' ') {
-                &uid[..uid.len() - 1]
-            } else {
-                &uid
-            }
-        };
+        let ts_uid = uid
+            .as_ref()
+            .trim_end_matches(|c: char| c.is_whitespace() || c == '\0');
         self.m.get(ts_uid).copied()
     }
 

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -65,7 +65,7 @@ impl TransferSyntaxRegistryImpl {
     fn get<U: AsRef<str>>(&self, uid: U) -> Option<&'static TransferSyntax> {
         let ts_uid = {
             let uid = uid.as_ref();
-            if uid.as_bytes().last().cloned() == Some(b'\0') {
+            if uid.as_bytes().last().cloned() == Some(b'\0') || uid.ends_with(' ') {
                 &uid[..uid.len() - 1]
             } else {
                 &uid


### PR DESCRIPTION
Suppress trailing space and nil char in transfer syntax UID.

Resolves #148 