### PR TITLE
[storescu] Orthanc PACS interoperability

### DIFF
--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -8,7 +8,7 @@ use std::io::{Cursor, ErrorKind, Read, Seek, SeekFrom};
 pub const DEFAULT_MAX_PDU: u32 = 16_384;
 pub const MINIMUM_PDU_SIZE: u32 = 4_096;
 pub const MAXIMUM_PDU_SIZE: u32 = 131_072;
-
+pub const PDU_HEADER_SIZE: u32 = 12;
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
 pub enum Error {


### PR DESCRIPTION
Sending dicom files to [Orthanc](https://www.orthanc-server.com/) PACS was broken, so after a quick check with [wireshark](https://www.wireshark.org/) against [pynetdicom](https://github.com/pydicom/pynetdicom) I came to this patch.

* Send only fully assembled PDUs on wire
* Don't use scu.send_pdata (could not debug why It was broken)

Regards,
Charbel