### PR TITLE
[parser] Fix encoder padding for even length data

### DIFF
--- a/encoding/src/encode/mod.rs
+++ b/encoding/src/encode/mod.rs
@@ -458,6 +458,10 @@ pub trait EncodeTo<W: ?Sized> {
 
     /// Encode and write a data element header to the given destination.
     /// Returns the number of bytes effectively written on success.
+    ///
+    /// Note that data element header should be encoded as is,
+    /// regardless of the given value length.
+    /// Any eventual padding logic should be done at a higher level.
     fn encode_element_header(&self, to: &mut W, de: DataElementHeader) -> Result<usize>
     where
         W: Write;

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -1,4 +1,11 @@
 //! Module for the data set writer
+//!
+//! This module contains a mid-level abstraction for printing DICOM data sets
+//! sequentially.
+//! The [`DataSetWriter`] receieves data tokens to be encoded and written
+//! to a writer.
+//! In this process, the writer will also adapt values
+//! to the necessary DICOM encoding rules.
 use crate::dataset::*;
 use crate::stateful::encode::StatefulEncoder;
 use dicom_core::{DataElementHeader, Length, VR};


### PR DESCRIPTION
- encode the right length in headers according to eventual padding
- tweak stateful encoder to add padding whenever necessary
- add private function even_len
- apply '\0' padding when VR = UI
- add tests covering these cases
