### PR TITLE
[dcmdump] add option --color=(auto|always|never)

### DIFF
--- a/dcmdump/src/main.rs
+++ b/dcmdump/src/main.rs
@@ -20,6 +20,7 @@ use dicom::transfer_syntax::TransferSyntaxRegistry;
 use snafu::ErrorCompat;
 use std::borrow::Cow;
 use std::fmt;
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use std::io::{stdout, ErrorKind, Result as IoResult, Write};
 use std::path::PathBuf;

--- a/dcmdump/src/main.rs
+++ b/dcmdump/src/main.rs
@@ -58,12 +58,12 @@ impl FromStr for Coloring {
     }
 }
 
-impl ToString for Coloring {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Coloring {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Coloring::Never => "never".into(),
-            Coloring::Auto => "auto".into(),
-            Coloring::Always => "always".into(),
+            Coloring::Never => f.write_str("never"),
+            Coloring::Auto => f.write_str("auto"),
+            Coloring::Always => f.write_str("always"),
         }
     }
 }

--- a/dcmdump/src/main.rs
+++ b/dcmdump/src/main.rs
@@ -40,11 +40,13 @@ enum Coloring {
     Always,
 }
 
-impl ToString for ColoringError {
-    fn to_string(&self) -> String {
-        "invalid color mode".into()
+impl Display for ColoringError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("invalid color mode")
     }
 }
+
+impl std::error::Error for Coloring {}
 
 impl FromStr for Coloring {
     type Err = ColoringError;


### PR DESCRIPTION
Useful, so you can do, for instance

```bash
dcmdump --color=always your.dcm | less -r
```

