### PR TITLE
[parser] Fix data set sequence reading routine for deeply nested data sets

### DIFF
--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -314,12 +314,16 @@ where
                             // closed an item
                             self.seq_delimiters.pop();
                             self.in_sequence = true;
+                            // sequences can end after an item delimiter
+                            self.delimiter_check_pending = true;
                             Some(Ok(DataToken::ItemEnd))
                         }
                         SequenceItemHeader::SequenceDelimiter => {
                             // closed a sequence
                             self.seq_delimiters.pop();
                             self.in_sequence = false;
+                            // items can end after a nested sequence ends
+                            self.delimiter_check_pending = true;
                             Some(Ok(DataToken::SequenceEnd))
                         }
                     }
@@ -446,6 +450,10 @@ where
                     ..
                 }) => {
                     self.in_sequence = true;
+                    // pop item delimiter
+                    self.seq_delimiters.pop();
+                    // sequences can end after this token
+                    self.delimiter_check_pending = true;
                     Some(Ok(DataToken::ItemEnd))
                 }
                 Ok(header) if header.is_encapsulated_pixeldata() => {
@@ -611,7 +619,7 @@ mod tests {
         while let Some((res, gt_token)) = iter.next() {
             let token = res.expect("should parse without an error");
             eprintln!("Next token: {:2?} ; Expected: {:2?}", token, gt_token);
-            assert_eq!(token, gt_token);
+            assert_eq!(token, gt_token, "Got token {:2?} ; but expected {:2?}", token, gt_token);
         }
 
         assert_eq!(
@@ -619,7 +627,10 @@ mod tests {
             0,            // we have already read all of them
             "unexpected number of tokens remaining"
         );
-        assert_eq!(dset_reader.parser.position(), data.len() as u64);
+        assert_eq!(
+            dset_reader.parser.position(), data.len() as u64,
+            "Decoder position did not match end of data",
+        );
     }
 
     #[test]
@@ -968,5 +979,102 @@ mod tests {
         ];
 
         validate_dataset_reader_explicit_vr(DATA, ground_truth);
+    }
+
+    #[test]
+    fn read_dataset_in_dataset() {
+
+        #[rustfmt::skip]
+        const DATA: &'static [u8; 138] = &[
+            // 0: (2001, 9000) private sequence
+            0x01, 0x20, 0x00, 0x90, //
+            // length: undefined
+            0xFF, 0xFF, 0xFF, 0xFF, //
+            // 8: Item start
+            0xFE, 0xFF, 0x00, 0xE0, //
+            // Item length explicit (114 bytes)
+            0x72, 0x00, 0x00, 0x00, //
+            // 16: (0008,1115) ReferencedSeriesSequence
+            0x08, 0x00, 0x15, 0x11, //
+            // length: undefined
+            0xFF, 0xFF, 0xFF, 0xFF, //
+            // 24: Item start
+            0xFE, 0xFF, 0x00, 0xE0, //
+            // Item length undefined
+            0xFF, 0xFF, 0xFF, 0xFF, //
+            // 32: (0008,1140) ReferencedImageSequence
+            0x08, 0x00, 0x40, 0x11, //
+            // length: undefined
+            0xFF, 0xFF, 0xFF, 0xFF, //
+            // 40: Item start
+            0xFE, 0xFF, 0x00, 0xE0, //
+            // Item length undefined
+            0xFF, 0xFF, 0xFF, 0xFF, //
+            // 48: (0008,1150) ReferencedSOPClassUID
+            0x08, 0x00, 0x50, 0x11, //
+            // length: 26
+            0x1a, 0x00, 0x00, 0x00, //
+            // Value: "1.2.840.10008.5.1.4.1.1.7\0" (SecondaryCaptureImageStorage)
+            b'1', b'.', b'2', b'.', b'8', b'4', b'0', b'.', b'1', b'0', b'0', b'0', b'8', b'.',
+            b'5', b'.', b'1', b'.', b'4', b'.', b'1', b'.', b'1', b'.', b'7', b'\0',
+            // 82: Item End (ReferencedImageSequence)
+            0xFE, 0xFF, 0x0D, 0xE0, //
+            0x00, 0x00, 0x00, 0x00, //
+            // 90: Sequence End (ReferencedImageSequence)
+            0xFE, 0xFF, 0xDD, 0xE0, //
+            0x00, 0x00, 0x00, 0x00, //
+            // 98: Item End (ReferencedSeriesSequence)
+            0xFE, 0xFF, 0x0D, 0xE0, //
+            0x00, 0x00, 0x00, 0x00, //
+            // 106: Sequence End (ReferencedSeriesSequence)
+            0xFE, 0xFF, 0xDD, 0xE0, //
+            0x00, 0x00, 0x00, 0x00, //
+            // 114: (2050,0020) PresentationLUTShape (CS)
+            0x50, 0x20, 0x20, 0x00, //
+            // length: 8
+            0x08, 0x00, 0x00, 0x00, //
+            b'I', b'D', b'E', b'N', b'T', b'I', b'T', b'Y', //
+            // 130: Sequence end
+            0xFE, 0xFF, 0xDD, 0xE0, //
+            0x00, 0x00, 0x00, 0x00, //
+        ];
+
+        let ground_truth = vec![
+            DataToken::SequenceStart {
+                tag: Tag(0x2001, 0x9000),
+                len: Length::UNDEFINED,
+            },
+            DataToken::ItemStart { len: Length(114) },
+            DataToken::SequenceStart {
+                tag: Tag(0x0008, 0x1115),
+                len: Length::UNDEFINED,
+            },
+            DataToken::ItemStart { len: Length::UNDEFINED },
+            DataToken::SequenceStart {
+                tag: Tag(0x0008, 0x1140),
+                len: Length::UNDEFINED,
+            },
+            DataToken::ItemStart { len: Length::UNDEFINED },
+            DataToken::ElementHeader(DataElementHeader {
+                tag: Tag(0x0008, 0x1150),
+                vr: VR::UI,
+                len: Length(26),
+            }),
+            DataToken::PrimitiveValue(PrimitiveValue::from("1.2.840.10008.5.1.4.1.1.7\0")),
+            DataToken::ItemEnd,
+            DataToken::SequenceEnd,
+            DataToken::ItemEnd,
+            DataToken::SequenceEnd,
+            DataToken::ElementHeader(DataElementHeader {
+                tag: Tag(0x2050, 0x0020),
+                vr: VR::CS,
+                len: Length(8),
+            }),
+            DataToken::PrimitiveValue(PrimitiveValue::from("IDENTITY")),
+            DataToken::ItemEnd, // inserted automatically
+            DataToken::SequenceEnd,
+        ];
+
+        validate_dataset_reader_implicit_vr(DATA, ground_truth);
     }
 }


### PR DESCRIPTION
There was a bug in the data set reader which led the program to think that it had not exited a sequence item, resulting in a premature end of data set when constructing a DICOM object. This could only be encountered when parsing deeply nested data sets (a sequence inside another sequence).

Summary:

- Add test to stateful decoder which covers decoding deeply nested data sets and counting byte positions correctly in such cases.
- Fix delimiter checks  in `DataSetReader` and `LazyDataSetReader` so that an item/sequence end is always recognized when necessary.

Resolves #167 (CC @troelsarvin).