### PR TITLE
Update byteordered to v0.6

### DIFF
--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -18,6 +18,6 @@ inventory-registry = ['inventory']
 dicom-core = { path = "../core", version = "0.4.0" }
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.4.0" }
 encoding = "0.2.33"
-byteordered = "0.5.0"
+byteordered = "0.6"
 inventory = { version = "0.1.4", optional = true }
 snafu = "0.6.8"

--- a/encoding/src/decode/basic.rs
+++ b/encoding/src/decode/basic.rs
@@ -304,11 +304,25 @@ impl BasicDecode for BasicDecoder {
         for_both!(self, |e| e.decode_us(source))
     }
 
+    fn decode_us_into<S>(&self, source: S, target: &mut [u16]) -> Result<()>
+    where
+        S: Read,
+    {
+        for_both!(self, |e| e.decode_us_into(source, target))
+    }
+
     fn decode_ul<S>(&self, source: S) -> Result<u32>
     where
         S: Read,
     {
         for_both!(self, |e| e.decode_ul(source))
+    }
+
+    fn decode_ul_into<S>(&self, source: S, target: &mut [u32]) -> Result<()>
+    where
+        S: Read,
+    {
+        for_both!(self, |e| e.decode_ul_into(source, target))
     }
 
     fn decode_uv<S>(&self, source: S) -> Result<u64>
@@ -318,11 +332,25 @@ impl BasicDecode for BasicDecoder {
         for_both!(self, |e| e.decode_uv(source))
     }
 
+    fn decode_uv_into<S>(&self, source: S, target: &mut [u64]) -> Result<()>
+    where
+        S: Read,
+    {
+        for_both!(self, |e| e.decode_uv_into(source, target))
+    }
+
     fn decode_ss<S>(&self, source: S) -> Result<i16>
     where
         S: Read,
     {
         for_both!(self, |e| e.decode_ss(source))
+    }
+
+    fn decode_ss_into<S>(&self, source: S, target: &mut [i16]) -> Result<()>
+    where
+        S: Read,
+    {
+        for_both!(self, |e| e.decode_ss_into(source, target))
     }
 
     fn decode_sl<S>(&self, source: S) -> Result<i32>
@@ -332,11 +360,25 @@ impl BasicDecode for BasicDecoder {
         for_both!(self, |e| e.decode_sl(source))
     }
 
+    fn decode_sl_into<S>(&self, source: S, target: &mut [i32]) -> Result<()>
+    where
+        S: Read,
+    {
+        for_both!(self, |e| e.decode_sl_into(source, target))
+    }
+
     fn decode_sv<S>(&self, source: S) -> Result<i64>
     where
         S: Read,
     {
         for_both!(self, |e| e.decode_sv(source))
+    }
+
+    fn decode_sv_into<S>(&self, source: S, target: &mut [i64]) -> Result<()>
+    where
+        S: Read,
+    {
+        for_both!(self, |e| e.decode_sv_into(source, target))
     }
 
     fn decode_fl<S>(&self, source: S) -> Result<f32>
@@ -346,11 +388,25 @@ impl BasicDecode for BasicDecoder {
         for_both!(self, |e| e.decode_fl(source))
     }
 
+    fn decode_fl_into<S>(&self, source: S, target: &mut [f32]) -> Result<()>
+    where
+        S: Read,
+    {
+        for_both!(self, |e| e.decode_fl_into(source, target))
+    }
+
     fn decode_fd<S>(&self, source: S) -> Result<f64>
     where
         S: Read,
     {
         for_both!(self, |e| e.decode_fd(source))
+    }
+
+    fn decode_fd_into<S>(&self, source: S, target: &mut [f64]) -> Result<()>
+    where
+        S: Read,
+    {
+        for_both!(self, |e| e.decode_fd_into(source, target))
     }
 }
 

--- a/encoding/src/decode/basic.rs
+++ b/encoding/src/decode/basic.rs
@@ -23,11 +23,25 @@ impl BasicDecode for LittleEndianBasicDecoder {
         ByteOrdered::le(source).read_u16().map_err(Into::into)
     }
 
+    fn decode_us_into<S>(&self, source: S, target: &mut [u16]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::le(source).read_u16_into(target).map_err(Into::into)
+    }
+
     fn decode_ul<S>(&self, source: S) -> Result<u32>
     where
         S: Read,
     {
         ByteOrdered::le(source).read_u32().map_err(Into::into)
+    }
+
+    fn decode_ul_into<S>(&self, source: S, target: &mut [u32]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::le(source).read_u32_into(target).map_err(Into::into)
     }
 
     fn decode_uv<S>(&self, source: S) -> Result<u64>
@@ -37,11 +51,25 @@ impl BasicDecode for LittleEndianBasicDecoder {
         ByteOrdered::le(source).read_u64().map_err(Into::into)
     }
 
+    fn decode_uv_into<S>(&self, source: S, target: &mut [u64]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::le(source).read_u64_into(target).map_err(Into::into)
+    }
+
     fn decode_ss<S>(&self, source: S) -> Result<i16>
     where
         S: Read,
     {
         ByteOrdered::le(source).read_i16().map_err(Into::into)
+    }
+
+    fn decode_ss_into<S>(&self, source: S, target: &mut [i16]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::le(source).read_i16_into(target).map_err(Into::into)
     }
 
     fn decode_sl<S>(&self, source: S) -> Result<i32>
@@ -51,11 +79,25 @@ impl BasicDecode for LittleEndianBasicDecoder {
         ByteOrdered::le(source).read_i32().map_err(Into::into)
     }
 
+    fn decode_sl_into<S>(&self, source: S, target: &mut [i32]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::le(source).read_i32_into(target).map_err(Into::into)
+    }
+
     fn decode_sv<S>(&self, source: S) -> Result<i64>
     where
         S: Read,
     {
         ByteOrdered::le(source).read_i64().map_err(Into::into)
+    }
+
+    fn decode_sv_into<S>(&self, source: S, target: &mut [i64]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::le(source).read_i64_into(target).map_err(Into::into)
     }
 
     fn decode_fl<S>(&self, source: S) -> Result<f32>
@@ -65,11 +107,25 @@ impl BasicDecode for LittleEndianBasicDecoder {
         ByteOrdered::le(source).read_f32().map_err(Into::into)
     }
 
+    fn decode_fl_into<S>(&self, source: S, target: &mut [f32]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::le(source).read_f32_into(target).map_err(Into::into)
+    }
+
     fn decode_fd<S>(&self, source: S) -> Result<f64>
     where
         S: Read,
     {
         ByteOrdered::le(source).read_f64().map_err(Into::into)
+    }
+
+    fn decode_fd_into<S>(&self, source: S, target: &mut [f64]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::le(source).read_f64_into(target).map_err(Into::into)
     }
 }
 
@@ -89,11 +145,25 @@ impl BasicDecode for BigEndianBasicDecoder {
         ByteOrdered::be(source).read_u16().map_err(Into::into)
     }
 
+    fn decode_us_into<S>(&self, source: S, target: &mut [u16]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::be(source).read_u16_into(target).map_err(Into::into)
+    }
+
     fn decode_ul<S>(&self, source: S) -> Result<u32>
     where
         S: Read,
     {
         ByteOrdered::be(source).read_u32().map_err(Into::into)
+    }
+
+    fn decode_ul_into<S>(&self, source: S, target: &mut [u32]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::be(source).read_u32_into(target).map_err(Into::into)
     }
 
     fn decode_uv<S>(&self, source: S) -> Result<u64>
@@ -103,11 +173,25 @@ impl BasicDecode for BigEndianBasicDecoder {
         ByteOrdered::be(source).read_u64().map_err(Into::into)
     }
 
+    fn decode_uv_into<S>(&self, source: S, target: &mut [u64]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::be(source).read_u64_into(target).map_err(Into::into)
+    }
+
     fn decode_ss<S>(&self, source: S) -> Result<i16>
     where
         S: Read,
     {
         ByteOrdered::be(source).read_i16().map_err(Into::into)
+    }
+
+    fn decode_ss_into<S>(&self, source: S, target: &mut [i16]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::be(source).read_i16_into(target).map_err(Into::into)
     }
 
     fn decode_sl<S>(&self, source: S) -> Result<i32>
@@ -117,11 +201,25 @@ impl BasicDecode for BigEndianBasicDecoder {
         ByteOrdered::be(source).read_i32().map_err(Into::into)
     }
 
+    fn decode_sl_into<S>(&self, source: S, target: &mut [i32]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::be(source).read_i32_into(target).map_err(Into::into)
+    }
+
     fn decode_sv<S>(&self, source: S) -> Result<i64>
     where
         S: Read,
     {
         ByteOrdered::be(source).read_i64().map_err(Into::into)
+    }
+
+    fn decode_sv_into<S>(&self, source: S, target: &mut [i64]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::be(source).read_i64_into(target).map_err(Into::into)
     }
 
     fn decode_fl<S>(&self, source: S) -> Result<f32>
@@ -131,11 +229,25 @@ impl BasicDecode for BigEndianBasicDecoder {
         ByteOrdered::be(source).read_f32().map_err(Into::into)
     }
 
+    fn decode_fl_into<S>(&self, source: S, target: &mut [f32]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::be(source).read_f32_into(target).map_err(Into::into)
+    }
+
     fn decode_fd<S>(&self, source: S) -> Result<f64>
     where
         S: Read,
     {
         ByteOrdered::be(source).read_f64().map_err(Into::into)
+    }
+
+    fn decode_fd_into<S>(&self, source: S, target: &mut [f64]) -> Result<()>
+    where
+        S: Read,
+    {
+        ByteOrdered::be(source).read_f64_into(target).map_err(Into::into)
     }
 }
 
@@ -270,5 +382,48 @@ mod tests {
         assert_eq!(be.decode_ul(data).unwrap(), 0xC33C33CC);
         assert_eq!(le.decode_uv(data).unwrap(), 0xAA55AA55_CC333CC3);
         assert_eq!(be.decode_uv(data).unwrap(), 0xC33C33CC_55AA55AA);
+    }
+
+    #[test]
+    fn test_read_integers_into() {
+        let data: &[u8] = &[0xC3, 0x3C, 0x33, 0xCC, 0x55, 0xAA, 0x55, 0xAA];
+
+        let le = LittleEndianBasicDecoder;
+        let be = BigEndianBasicDecoder;
+
+        let mut out_le = [0; 4];
+        le.decode_us_into(data, &mut out_le).unwrap();
+        assert_eq!(out_le, [0x3CC3, 0xCC33, 0xAA55, 0xAA55]);
+
+        let mut out_be = [0; 4];
+        be.decode_us_into(data, &mut out_be).unwrap();
+        assert_eq!(out_be, [0xC33C, 0x33CC, 0x55AA, 0x55AA]);
+
+        let mut out_le = [0; 2];
+        le.decode_ul_into(data, &mut out_le).unwrap();
+        assert_eq!(out_le, [0xCC33_3CC3, 0xAA55_AA55]);
+
+        let mut out_be = [0; 2];
+        be.decode_ul_into(data, &mut out_be).unwrap();
+        assert_eq!(out_be, [0xC33C_33CC, 0x55AA_55AA]);
+
+        let le = BasicDecoder::new(Endianness::Little);
+        let be = BasicDecoder::new(Endianness::Big);
+
+        let mut out_le = [0; 4];
+        le.decode_us_into(data, &mut out_le).unwrap();
+        assert_eq!(out_le, [0x3CC3, 0xCC33, 0xAA55, 0xAA55]);
+
+        let mut out_be = [0; 4];
+        be.decode_us_into(data, &mut out_be).unwrap();
+        assert_eq!(out_be, [0xC33C, 0x33CC, 0x55AA, 0x55AA]);
+
+        let mut out_le = [0; 2];
+        le.decode_ul_into(data, &mut out_le).unwrap();
+        assert_eq!(out_le, [0xCC33_3CC3, 0xAA55_AA55]);
+
+        let mut out_be = [0; 2];
+        be.decode_ul_into(data, &mut out_be).unwrap();
+        assert_eq!(out_be, [0xC33C_33CC, 0x55AA_55AA]);
     }
 }

--- a/encoding/src/decode/mod.rs
+++ b/encoding/src/decode/mod.rs
@@ -96,41 +96,145 @@ pub trait BasicDecode {
     fn decode_us<S>(&self, source: S) -> std::io::Result<u16>
     where
         S: Read;
+    
+    /// Decode a sequence of unsigned shorts value from the given source
+    /// into the given destination.
+    fn decode_us_into<S>(&self, mut source: S, dst: &mut [u16]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        for v in dst.iter_mut() {
+            *v = self.decode_us(&mut source)?;
+        }
+
+        Ok(())
+    }
 
     /// Decode an unsigned long value from the given source.
     fn decode_ul<S>(&self, source: S) -> std::io::Result<u32>
     where
         S: Read;
 
+    /// Decode a sequence of unsigned long values from the given source
+    /// into the given destination.
+    fn decode_ul_into<S>(&self, mut source: S, dst: &mut [u32]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        for v in dst.iter_mut() {
+            *v = self.decode_ul(&mut source)?;
+        }
+
+        Ok(())
+    }
+
     /// Decode an unsigned very long value from the given source.
     fn decode_uv<S>(&self, source: S) -> std::io::Result<u64>
     where
         S: Read;
+
+    /// Decode a sequence of unsigned very long values from the given source
+    /// into the given destination.
+    fn decode_uv_into<S>(&self, mut source: S, dst: &mut [u64]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        for v in dst.iter_mut() {
+            *v = self.decode_uv(&mut source)?;
+        }
+
+        Ok(())
+    }
 
     /// Decode a signed short value from the given source.
     fn decode_ss<S>(&self, source: S) -> std::io::Result<i16>
     where
         S: Read;
 
+    /// Decode a sequence of signed short values from the given source
+    /// into the given destination.
+    fn decode_ss_into<S>(&self, mut source: S, dst: &mut [i16]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        for v in dst.iter_mut() {
+            *v = self.decode_ss(&mut source)?;
+        }
+
+        Ok(())
+    }
+
     /// Decode a signed long value from the given source.
     fn decode_sl<S>(&self, source: S) -> std::io::Result<i32>
     where
         S: Read;
+
+    /// Decode a sequence of signed long values from the given source
+    /// into the given destination.
+    fn decode_sl_into<S>(&self, mut source: S, dst: &mut [i32]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        for v in dst.iter_mut() {
+            *v = self.decode_sl(&mut source)?;
+        }
+
+        Ok(())
+    }
 
     /// Decode a signed very long value from the given source.
     fn decode_sv<S>(&self, source: S) -> std::io::Result<i64>
     where
         S: Read;
 
+    /// Decode a sequence of signed very long values from the given source
+    /// into the given destination.
+    fn decode_sv_into<S>(&self, mut source: S, dst: &mut [i64]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        for v in dst.iter_mut() {
+            *v = self.decode_sv(&mut source)?;
+        }
+
+        Ok(())
+    }
+
     /// Decode a single precision float value from the given source.
     fn decode_fl<S>(&self, source: S) -> std::io::Result<f32>
     where
         S: Read;
 
+    /// Decode a sequence of single precision float values from the given source
+    /// into the given destination.
+    fn decode_fl_into<S>(&self, mut source: S, dst: &mut [f32]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        for v in dst.iter_mut() {
+            *v = self.decode_fl(&mut source)?;
+        }
+
+        Ok(())
+    }
+
     /// Decode a double precision float value from the given source.
     fn decode_fd<S>(&self, source: S) -> std::io::Result<f64>
     where
         S: Read;
+
+    /// Decode a sequence of double precision float values from the given source
+    /// into the given destination.
+    fn decode_fd_into<S>(&self, mut source: S, dst: &mut [f64]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        for v in dst.iter_mut() {
+            *v = self.decode_fd(&mut source)?;
+        }
+
+        Ok(())
+    }
 
     /// Decode a DICOM attribute tag from the given source.
     fn decode_tag<S>(&self, mut source: S) -> std::io::Result<Tag>
@@ -148,7 +252,7 @@ where
     T: BasicDecode,
 {
     fn endianness(&self) -> Endianness {
-        self.as_ref().endianness()
+        (**self).endianness()
     }
 
     fn decode_us<S>(&self, source: S) -> std::io::Result<u16>
@@ -158,11 +262,25 @@ where
         (**self).decode_us(source)
     }
 
+    fn decode_us_into<S>(&self, source: S, dst: &mut [u16]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_us_into(source, dst)
+    }
+
     fn decode_ul<S>(&self, source: S) -> std::io::Result<u32>
     where
         S: Read,
     {
         (**self).decode_ul(source)
+    }
+
+    fn decode_ul_into<S>(&self, source: S, dst: &mut [u32]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_ul_into(source, dst)
     }
 
     fn decode_uv<S>(&self, source: S) -> std::io::Result<u64>
@@ -172,11 +290,25 @@ where
         (**self).decode_uv(source)
     }
 
+    fn decode_uv_into<S>(&self, source: S, dst: &mut [u64]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_uv_into(source, dst)
+    }
+
     fn decode_ss<S>(&self, source: S) -> std::io::Result<i16>
     where
         S: Read,
     {
         (**self).decode_ss(source)
+    }
+
+    fn decode_ss_into<S>(&self, source: S, dst: &mut [i16]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_ss_into(source, dst)
     }
 
     fn decode_sl<S>(&self, source: S) -> std::io::Result<i32>
@@ -186,11 +318,25 @@ where
         (**self).decode_sl(source)
     }
 
+    fn decode_sl_into<S>(&self, source: S, dst: &mut [i32]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_sl_into(source, dst)
+    }
+
     fn decode_sv<S>(&self, source: S) -> std::io::Result<i64>
     where
         S: Read,
     {
         (**self).decode_sv(source)
+    }
+
+    fn decode_sv_into<S>(&self, source: S, dst: &mut [i64]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_sv_into(source, dst)
     }
 
     fn decode_fl<S>(&self, source: S) -> std::io::Result<f32>
@@ -200,11 +346,25 @@ where
         (**self).decode_fl(source)
     }
 
+    fn decode_fl_into<S>(&self, source: S, dst: &mut [f32]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_fl_into(source, dst)
+    }
+
     fn decode_fd<S>(&self, source: S) -> std::io::Result<f64>
     where
         S: Read,
     {
         (**self).decode_fd(source)
+    }
+
+    fn decode_fd_into<S>(&self, source: S, dst: &mut [f64]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_fd_into(source, dst)
     }
 
     fn decode_tag<S>(&self, source: S) -> std::io::Result<Tag>
@@ -220,7 +380,7 @@ where
     T: BasicDecode,
 {
     fn endianness(&self) -> Endianness {
-        (*self).endianness()
+        (**self).endianness()
     }
 
     fn decode_us<S>(&self, source: S) -> std::io::Result<u16>
@@ -230,11 +390,25 @@ where
         (**self).decode_us(source)
     }
 
+    fn decode_us_into<S>(&self, source: S, dst: &mut [u16]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_us_into(source, dst)
+    }
+
     fn decode_ul<S>(&self, source: S) -> std::io::Result<u32>
     where
         S: Read,
     {
         (**self).decode_ul(source)
+    }
+
+    fn decode_ul_into<S>(&self, source: S, dst: &mut [u32]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_ul_into(source, dst)
     }
 
     fn decode_uv<S>(&self, source: S) -> std::io::Result<u64>
@@ -244,11 +418,25 @@ where
         (**self).decode_uv(source)
     }
 
+    fn decode_uv_into<S>(&self, source: S, dst: &mut [u64]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_uv_into(source, dst)
+    }
+
     fn decode_ss<S>(&self, source: S) -> std::io::Result<i16>
     where
         S: Read,
     {
         (**self).decode_ss(source)
+    }
+
+    fn decode_ss_into<S>(&self, source: S, dst: &mut [i16]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_ss_into(source, dst)
     }
 
     fn decode_sl<S>(&self, source: S) -> std::io::Result<i32>
@@ -258,11 +446,25 @@ where
         (**self).decode_sl(source)
     }
 
+    fn decode_sl_into<S>(&self, source: S, dst: &mut [i32]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_sl_into(source, dst)
+    }
+
     fn decode_sv<S>(&self, source: S) -> std::io::Result<i64>
     where
         S: Read,
     {
         (**self).decode_sv(source)
+    }
+
+    fn decode_sv_into<S>(&self, source: S, dst: &mut [i64]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_sv_into(source, dst)
     }
 
     fn decode_fl<S>(&self, source: S) -> std::io::Result<f32>
@@ -272,11 +474,25 @@ where
         (**self).decode_fl(source)
     }
 
+    fn decode_fl_into<S>(&self, source: S, dst: &mut [f32]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_fl_into(source, dst)
+    }
+
     fn decode_fd<S>(&self, source: S) -> std::io::Result<f64>
     where
         S: Read,
     {
         (**self).decode_fd(source)
+    }
+
+    fn decode_fd_into<S>(&self, source: S, dst: &mut [f64]) -> std::io::Result<()>
+    where
+        S: Read,
+    {
+        (**self).decode_fd_into(source, dst)
     }
 
     fn decode_tag<S>(&self, source: S) -> std::io::Result<Tag>

--- a/object/Cargo.toml
+++ b/object/Cargo.toml
@@ -21,7 +21,7 @@ dicom-parser = { path = "../parser", version = "0.4.0" }
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.4.0" }
 dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry", version = "0.4.0" }
 itertools = "0.10"
-byteordered = "0.5.0"
+byteordered = "0.6"
 smallvec = "1.6.1"
 snafu = "0.6.8"
 

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -449,30 +449,25 @@ where
         let len = self.require_known_length(header)?;
 
         let n = len >> 1;
-        let vec: Result<_> = n_times(n)
-            .map(|_| {
-                self.basic.decode_ss(&mut self.from).context(ReadValueData {
-                    position: self.position,
-                })
-            })
-            .collect();
+        let mut vec = smallvec![0; n];
+        self.basic.decode_ss_into(&mut self.from, &mut vec[..]).context(ReadValueData {
+            position: self.position,
+        })?;
+
         self.position += len as u64;
-        Ok(PrimitiveValue::I16(vec?))
+        Ok(PrimitiveValue::I16(vec))
     }
 
     fn read_value_fl(&mut self, header: &DataElementHeader) -> Result<PrimitiveValue> {
         let len = self.require_known_length(header)?;
         // sequence of 32-bit floats
         let n = len >> 2;
-        let vec: Result<_> = n_times(n)
-            .map(|_| {
-                self.basic.decode_fl(&mut self.from).context(ReadValueData {
-                    position: self.position,
-                })
-            })
-            .collect();
+        let mut vec = smallvec![0.; n];
+        self.basic.decode_fl_into(&mut self.from, &mut vec[..]).context(ReadValueData {
+            position: self.position,
+        })?;
         self.position += len as u64;
-        Ok(PrimitiveValue::F32(vec?))
+        Ok(PrimitiveValue::F32(vec))
     }
 
     fn read_value_da(&mut self, header: &DataElementHeader) -> Result<PrimitiveValue> {
@@ -656,15 +651,12 @@ where
         let len = self.require_known_length(header)?;
         // sequence of 64-bit floats
         let n = len >> 3;
-        let vec: Result<_> = n_times(n)
-            .map(|_| {
-                self.basic.decode_fd(&mut self.from).context(ReadValueData {
-                    position: self.position,
-                })
-            })
-            .collect();
+        let mut vec = smallvec![0.; n];
+        self.basic.decode_fd_into(&mut self.from, &mut vec[..]).context(ReadValueData {
+            position: self.position,
+        })?;
         self.position += len as u64;
-        Ok(PrimitiveValue::F64(vec?))
+        Ok(PrimitiveValue::F64(vec))
     }
 
     fn read_value_ul(&mut self, header: &DataElementHeader) -> Result<PrimitiveValue> {
@@ -672,25 +664,21 @@ where
         // sequence of 32-bit unsigned integers
 
         let n = len >> 2;
-        let vec: Result<_> = n_times(n)
-            .map(|_| {
-                self.basic.decode_ul(&mut self.from).context(ReadValueData {
-                    position: self.position,
-                })
-            })
-            .collect();
+        let mut vec = smallvec![0u32; n];
+        self.basic.decode_ul_into(&mut self.from, &mut vec[..]).context(ReadValueData {
+            position: self.position,
+        })?;
         self.position += len as u64;
-        Ok(PrimitiveValue::U32(vec?))
+        Ok(PrimitiveValue::U32(vec))
     }
 
     fn read_u32(&mut self, n: usize, vec: &mut Vec<u32>) -> Result<()> {
-        vec.reserve(n);
-        for _ in 0..n {
-            let v = self.basic.decode_ul(&mut self.from).context(ReadValueData {
-                    position: self.position,
-            })?;
-            vec.push(v);
-        }
+        let base = vec.len();
+        vec.resize(base + n, 0);
+
+        self.basic.decode_ul_into(&mut self.from, &mut vec[base..]).context(ReadValueData {
+            position: self.position,
+        })?;
         self.position += n as u64 * 4;
         Ok(())
     }
@@ -700,15 +688,13 @@ where
         // sequence of 16-bit unsigned integers
 
         let n = len >> 1;
-        let vec: Result<_> = n_times(n)
-            .map(|_| {
-                self.basic.decode_us(&mut self.from).context(ReadValueData {
-                    position: self.position,
-                })
-            })
-            .collect();
+        let mut vec = smallvec![0; n];
+        self.basic.decode_us_into(&mut self.from, &mut vec[..]).context(ReadValueData {
+            position: self.position,
+        })?;
+
         self.position += len as u64;
-        Ok(PrimitiveValue::U16(vec?))
+        Ok(PrimitiveValue::U16(vec))
     }
 
     fn read_value_uv(&mut self, header: &DataElementHeader) -> Result<PrimitiveValue> {
@@ -716,15 +702,12 @@ where
         // sequence of 64-bit unsigned integers
 
         let n = len >> 3;
-        let vec: Result<_> = n_times(n)
-            .map(|_| {
-                self.basic.decode_uv(&mut self.from).context(ReadValueData {
-                    position: self.position,
-                })
-            })
-            .collect();
+        let mut vec = smallvec![0; n];
+        self.basic.decode_uv_into(&mut self.from, &mut vec[..]).context(ReadValueData {
+            position: self.position,
+        })?;
         self.position += len as u64;
-        Ok(PrimitiveValue::U64(vec?))
+        Ok(PrimitiveValue::U64(vec))
     }
 
     fn read_value_sl(&mut self, header: &DataElementHeader) -> Result<PrimitiveValue> {
@@ -732,15 +715,12 @@ where
         // sequence of 32-bit signed integers
 
         let n = len >> 2;
-        let vec: Result<_> = n_times(n)
-            .map(|_| {
-                self.basic.decode_sl(&mut self.from).context(ReadValueData {
-                    position: self.position,
-                })
-            })
-            .collect();
+        let mut vec = smallvec![0; n];
+        self.basic.decode_sl_into(&mut self.from, &mut vec[..]).context(ReadValueData {
+            position: self.position,
+        })?;
         self.position += len as u64;
-        Ok(PrimitiveValue::I32(vec?))
+        Ok(PrimitiveValue::I32(vec))
     }
 
     fn read_value_sv(&mut self, header: &DataElementHeader) -> Result<PrimitiveValue> {
@@ -748,15 +728,12 @@ where
         // sequence of 64-bit signed integers
 
         let n = len >> 3;
-        let vec: Result<_> = n_times(n)
-            .map(|_| {
-                self.basic.decode_sv(&mut self.from).context(ReadValueData {
-                    position: self.position,
-                })
-            })
-            .collect();
+        let mut vec = smallvec![0; n];
+        self.basic.decode_sv_into(&mut self.from, &mut vec[..]).context(ReadValueData {
+            position: self.position,
+        })?;
         self.position += len as u64;
-        Ok(PrimitiveValue::I64(vec?))
+        Ok(PrimitiveValue::I64(vec))
     }
 }
 

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -18,5 +18,5 @@ dicom-core = { path = "../core", version = "0.4.0" }
 dicom-encoding = { path = "../encoding", version = "0.4.0" }
 lazy_static = "1.2.0"
 encoding = "0.2.33"
-byteordered = "0.5.0"
+byteordered = "0.6"
 inventory = { version = "0.1.4", optional = true }

--- a/ul/Cargo.toml
+++ b/ul/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["dicom", "network"]
 readme = "README.md"
 
 [dependencies]
-byteordered = "0.5.0"
+byteordered = "0.6"
 dicom-encoding = { path = "../encoding/", version = "0.4.0" }
 snafu = "0.6.8"
 dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.4.0" }


### PR DESCRIPTION
This updates `byteordered` to version 0.6 and takes advantage of the new `read_*_into` methods for implementing value readers.