### PR TITLE
New crate: dicom-toimage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ members = [
     "scpproxy",
     "echoscu",
     "storescu",
-    "pixeldata"
+    "pixeldata",
+    "toimage"
 ]

--- a/toimage/Cargo.toml
+++ b/toimage/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "dicom-toimage"
+version = "0.1.0"
+edition = "2018"
+authors = ["Eduardo Pinho <enet4mikeenet@gmail.com>"]
+description = "A CLI tool for converting DICOM files into general purpose image files"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/Enet4/dicom-rs"
+categories = ["command-line-utilities"]
+keywords = ["cli", "dicom", "image", "image-conversion"]
+readme = "README.md"
+
+[features]
+default = ['dicom/inventory-registry', 'dicom/backtraces']
+
+[dependencies]
+dicom = { path = "../parent/" }
+dicom-pixeldata = { path = "../pixeldata/" }
+snafu = "0.6.10"
+structopt = "0.3.23"

--- a/toimage/README.md
+++ b/toimage/README.md
@@ -1,0 +1,27 @@
+# DICOM-rs `toimage`
+
+[![CratesIO](https://img.shields.io/crates/v/dicom-toimage.svg)](https://crates.io/crates/dicom-toimage)
+[![Documentation](https://docs.rs/dicom-toimage/badge.svg)](https://docs.rs/dicom-toimage)
+
+A command line utility for converting DICOM image files
+into general purpose image files (e.g. PNG).
+
+This tool is part of the [DICOM-rs](https://github.com/Enet4/dicom-rs) project.
+
+## Usage
+
+```none
+    dicom-toimage [FLAGS] [OPTIONS] <file>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+    -v, --verbose    Print more information about the image and the output file
+
+OPTIONS:
+    -F, --frame <frame-number>    Frame number (0-indexed) [default: 0]
+    -o, --out <output>            Path to the output image (default is to replace input extension with `.png`)
+
+ARGS:
+    <file>    Path to the DICOM file to read
+```

--- a/toimage/src/main.rs
+++ b/toimage/src/main.rs
@@ -1,0 +1,111 @@
+//! A CLI tool for converting a DICOM image file
+//! into a general purpose image file (e.g. PNG).
+use std::path::PathBuf;
+
+use dicom::object::open_file;
+use dicom_pixeldata::PixelDecoder;
+use snafu::ErrorCompat;
+use structopt::StructOpt;
+
+/// Convert a DICOM file into an image
+#[derive(Debug, StructOpt)]
+struct App {
+    /// Path to the DICOM file to read
+    file: PathBuf,
+    /// Path to the output image
+    /// (default is to replace input extension with `.png`)
+    #[structopt(short = "o", long = "out")]
+    output: Option<PathBuf>,
+    /// Frame number (0-indexed)
+    #[structopt(short = "F", long = "frame", default_value = "0")]
+    frame_number: u16,
+    /// Print more information about the image and the output file
+    #[structopt(short="v", long="verbose")]
+    verbose: bool
+}
+
+
+fn report<E: 'static>(err: &E)
+where
+    E: std::error::Error,
+{
+    eprintln!("[ERROR] {}", err);
+    if let Some(source) = err.source() {
+        eprintln!();
+        eprintln!("Caused by:");
+        for (i, e) in std::iter::successors(Some(source), |e| e.source()).enumerate() {
+            eprintln!("   {}: {}", i, e);
+        }
+    }
+}
+
+fn report_backtrace<E: 'static>(err: &E)
+where
+    E: std::error::Error,
+    E: ErrorCompat,
+{
+    let env_backtrace = std::env::var("RUST_BACKTRACE").unwrap_or_default();
+    let env_lib_backtrace = std::env::var("RUST_LIB_BACKTRACE").unwrap_or_default();
+    if env_lib_backtrace == "1" || (env_backtrace == "1" && env_lib_backtrace != "0") {
+        if let Some(backtrace) = ErrorCompat::backtrace(&err) {
+            eprintln!();
+            eprintln!("Backtrace:");
+            eprintln!("{}", backtrace);
+        }
+    }
+}
+
+fn report_with_backtrace<E: 'static>(err: E)
+where
+    E: std::error::Error,
+    E: ErrorCompat,
+{
+    report(&err);
+    report_backtrace(&err);
+}
+
+
+fn main() {
+    let App {
+        file,
+        output,
+        frame_number,
+        verbose,
+    } = App::from_args();
+
+    let output = output.unwrap_or_else(|| {
+        let mut path = file.clone();
+        path.set_extension("png");
+        path
+    });
+
+    let obj = open_file(&file).unwrap_or_else(|e| {
+        report_with_backtrace(e);
+        std::process::exit(-1);
+    });
+
+    let pixel = obj.decode_pixel_data().unwrap_or_else(|e| {
+        report_with_backtrace(e);
+        std::process::exit(-2);
+    });
+
+    if verbose {
+        println!("{}x{}x{} image, {}-bit", pixel.cols, pixel.rows, pixel.samples_per_pixel, pixel.bits_stored);
+    }
+
+    let image = pixel.to_dynamic_image(frame_number).unwrap_or_else(|e| {
+        report_with_backtrace(e);
+        std::process::exit(-3);
+    });
+
+    let image = image.brighten(i32::from(pixel.rescale_intercept)).adjust_contrast(pixel.rescale_slope);
+
+    image.save(&output).unwrap_or_else(|e| {
+        report(&e);
+        std::process::exit(-4);
+    });
+
+    if verbose {
+        println!("Image saved to {}", output.display());
+    }
+}


### PR DESCRIPTION
This is a baseline implementation of a CLI tool for converting DICOM files into image files.
It works fairly well in simple cases, especially those with the RGB photometric interpretation or those without heavy LUT function transformations. Better handling of transformation functions is pending on the resolution of #122.