### PR TITLE
[dump] Remove control code in text value

### DIFF
--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -737,7 +737,7 @@ where
     let len = values.len();
     let mut pieces = values.take(64).map(|piece| {
         let mut piece = piece.to_string();
-        piece.retain(|c| !c.is_control());
+        piece = piece.replace(|c: char| c.is_control(), "�");
         if quoted {
             piece = piece.replace("\"", "\\\"");
             piece.insert(0, '"');

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -736,18 +736,14 @@ where
     let values = values.into_iter();
     let len = values.len();
     let mut pieces = values.take(64).map(|piece| {
+        let mut piece = piece.to_string();
+        piece.retain(|c| !c.is_control());
         if quoted {
-            let mut piece = piece.to_string();
-            if piece.contains('\"') {
-                format!("\"{}\"", piece.replace("\"", "\\\""))
-            } else {
-                piece.insert(0, '"');
-                piece.push('"');
-                piece
-            }
-        } else {
-            piece.to_string()
+            piece = piece.replace("\"", "\\\"");
+            piece.insert(0, '"');
+            piece.push('"');
         }
+        piece
     });
     let mut pieces = pieces.join(", ");
     if len > 1 {


### PR DESCRIPTION
Fix #187

Removes control code (Cc) in text value e.g. NUL, LF, CR and more.