### PR TITLE
[dump] Fix set_virtual_terminal call on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,20 @@ jobs:
           command: test
       - run: cargo test --package dicom-pixeldata --features gdcm
 
+  check_windows:
+    name: Check (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/dcmdump/src/main.rs
+++ b/dcmdump/src/main.rs
@@ -12,7 +12,7 @@ const ERROR_PRINT: i32 = -3;
 
 #[cfg(windows)]
 fn os_compatibility() -> Result<(), ()> {
-    control::set_virtual_terminal(true)
+    colored::control::set_virtual_terminal(true)
 }
 
 #[cfg(not(windows))]

--- a/dump/src/main.rs
+++ b/dump/src/main.rs
@@ -14,7 +14,7 @@ const ERROR_PRINT: i32 = -3;
 
 #[cfg(windows)]
 fn os_compatibility() -> Result<(), ()> {
-    control::set_virtual_terminal(true)
+    colored::control::set_virtual_terminal(true)
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
- Qualify use of `set_virtual_terminal` properly
- add CI job for checking all crate code on Windows