### PR TITLE
Enhanced pixeldata and pixel data encoding

### DIFF
--- a/encoding/src/adapters/mod.rs
+++ b/encoding/src/adapters/mod.rs
@@ -54,12 +54,14 @@ pub struct RawPixelData {
 /// A DICOM object trait to be interpreted as pixel data.
 /// 
 /// This trait extends the concept of DICOM object
-/// as defined in [`dicom_object`](::dicom_object),
+/// as defined in [`dicom_object`],
 /// in order to retrieve important pieces of the object
 /// for pixel data decoding into images or multi-dimensional arrays.
 /// 
 /// It is defined in this crate so that
 /// transfer syntax implementers only have to depend on `dicom_encoding`.
+/// 
+/// [`dicom_object`]: https://docs.rs/dicom_object
 pub trait PixelDataObject {
     /// Return the Rows attribute or None if it is not found
     fn rows(&self) -> Option<u16>;

--- a/encoding/src/adapters/mod.rs
+++ b/encoding/src/adapters/mod.rs
@@ -89,6 +89,29 @@ pub trait PixelDataObject {
     fn raw_pixel_data(&self) -> Option<RawPixelData>;
 }
 
+/// Custom options when encoding pixel data into an encapsulated form.
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct EncodeOptions {
+    /// The quality of the output image as a number between 0 and 100,
+    /// where 100 is the best quality that the encapsulated form can achieve
+    /// and smaller values represent smaller data size
+    /// with an increasingly higher error.
+    /// It is ignored if the transfer syntax only supports lossless compression.
+    /// If it does support however,
+    /// it is expected that a quality of 100 results in a lossless encoding.
+    ///
+    /// If this option is not specified,
+    /// the output quality is decided automatically by the underlying adapter.
+    pub quality: Option<u8>,
+}
+
+impl EncodeOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 /// Trait object responsible for decoding and encoding
 /// pixel data based on the Transfersyntax.
 /// 
@@ -124,7 +147,7 @@ pub trait PixelRWAdapter {
     /// Implementers leave the default method implementation
     /// for this behavior.
     #[allow(unused_variables)]
-    fn encode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> EncodeResult<()> {
+    fn encode(&self, src: &dyn PixelDataObject, options: EncodeOptions, dst: &mut Vec<u8>) -> EncodeResult<()> {
         Err(EncodeError::NotImplemented)
     }
 }
@@ -141,7 +164,7 @@ impl PixelRWAdapter for NeverPixelAdapter {
         unreachable!();
     }
 
-    fn encode(&self, _src: &dyn PixelDataObject, _dst: &mut Vec<u8>) -> EncodeResult<()> {
+    fn encode(&self, _src: &dyn PixelDataObject, _options: EncodeOptions, _dst: &mut Vec<u8>) -> EncodeResult<()> {
         unreachable!();
     }
 }

--- a/encoding/src/adapters/mod.rs
+++ b/encoding/src/adapters/mod.rs
@@ -110,12 +110,21 @@ pub struct EncodeOptions {
     /// and smaller values represent smaller data size
     /// with an increasingly higher error.
     /// It is ignored if the transfer syntax only supports lossless compression.
-    /// If it does support however,
+    /// If it does support lossless compression,
     /// it is expected that a quality of 100 results in a lossless encoding.
     ///
     /// If this option is not specified,
     /// the output quality is decided automatically by the underlying adapter.
     pub quality: Option<u8>,
+
+    /// The amount of effort that the encoder may take to encode the pixel data,
+    /// as a number between 0 and 100.
+    /// If supported, higher values result in better compression,
+    /// at the expense of more processing time.
+    /// Encoders are not required to support this option.
+    /// If this option is not specified,
+    /// the actual effort is decided by the underlying adapter.
+    pub effort: Option<u8>,
 }
 
 impl EncodeOptions {

--- a/encoding/src/adapters/mod.rs
+++ b/encoding/src/adapters/mod.rs
@@ -7,9 +7,19 @@ pub mod rle_lossless;
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
 pub enum DecodeError {
-    /// A custom error when decoding fails
+    /// A custom error occurred when decoding,
+    /// reported as a dynamic error value
+    #[snafu(display("Error decoding pixel data"))]
+    Custom {
+        source: Box<dyn std::error::Error + Send + 'static>,
+    },
+
+    /// A custom error occurred when decoding,
+    /// reported as a static message
     #[snafu(display("Error decoding pixel data: {}", message))]
-    CustomDecodeError { message: &'static str },
+    CustomMessage {
+        message: &'static str,
+    },
 
     /// Input pixel data is not encapsulated
     NotEncapsulated,

--- a/encoding/src/adapters/rle_lossless.rs
+++ b/encoding/src/adapters/rle_lossless.rs
@@ -9,10 +9,10 @@
 use byteordered::byteorder::{ByteOrder, LittleEndian};
 use snafu::OptionExt;
 
-use crate::adapters::{DecodeResult, EncodeResult, PixelDataObject, PixelRWAdapter};
+use crate::adapters::{DecodeResult, PixelDataObject, PixelRWAdapter};
 use std::io::{self, Read, Seek};
 
-use super::{CustomDecodeSnafu, MissingAttributeSnafu, NotImplementedSnafu};
+use super::{CustomDecodeSnafu, MissingAttributeSnafu};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RLELosslessAdapter;
@@ -101,9 +101,7 @@ impl PixelRWAdapter for RLELosslessAdapter {
         Ok(())
     }
 
-    fn encode(&self, _src: &[u8], _dst: &mut Vec<u8>) -> EncodeResult<()> {
-        NotImplementedSnafu {}.fail()?
-    }
+    // TODO(#125) implement `encode`
 }
 
 // Read the RLE header and return the offsets

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -19,21 +19,21 @@ where
 
         let photometric_interpretation = photometric_interpretation(self)?;
         let pi_type = GDCMPhotometricInterpretation::from_str(&photometric_interpretation)
-            .map_err(|_| Error::UnsupportedPhotometricInterpretation {
+            .map_err(|_| UnsupportedPhotometricInterpretation {
                 pi: photometric_interpretation.clone(),
-            })?;
+            }.build())?;
 
         let transfer_syntax = &self.meta().transfer_syntax;
         let registry =
             TransferSyntaxRegistry
                 .get(&&transfer_syntax)
-                .context(UnsupportedTransferSyntaxSnafu {
-                    ts: transfer_syntax,
+                .context(UnknownTransferSyntaxSnafu {
+                    ts_uid: transfer_syntax,
                 })?;
         let ts_type = GDCMTransferSyntax::from_str(&registry.uid()).map_err(|_| {
-            Error::UnsupportedTransferSyntax {
+            UnsupportedTransferSyntax {
                 ts: transfer_syntax.clone(),
-            }
+            }.build()
         })?;
 
         let samples_per_pixel = samples_per_pixel(self)?;
@@ -139,101 +139,6 @@ mod tests {
         "pydicom/color-pl.dcm",
         "pydicom/color-px.dcm",
         "pydicom/SC_ybr_full_uncompressed.dcm",
-
-    // "pydicom/RG1_J2KI.dcm",
-    // "pydicom/RG1_J2KR.dcm",
-    // "pydicom/RG1_UNCI.dcm",
-    // "pydicom/RG1_UNCR.dcm",
-    // "pydicom/RG3_J2KI.dcm",
-    // "pydicom/RG3_J2KR.dcm",
-    // "pydicom/RG3_UNCI.dcm",
-    // "pydicom/RG3_UNCR.dcm",
-    // "pydicom/ExplVR_BigEnd.dcm",
-    // "pydicom/ExplVR_BigEndNoMeta.dcm",
-    // "pydicom/ExplVR_LitEndNoMeta.dcm",
-    // "pydicom/JPEG-LL.dcm",                       // More than 1 fragment
-    // "pydicom/MR-SIEMENS-DICOM-WithOverlays.dcm", // Overlays not supported
-    // "pydicom/MR2_J2KI.dcm",  // Multi-frame
-    // "pydicom/MR2_J2KR.dcm",
-    // "pydicom/MR2_UNCI.dcm",
-    // "pydicom/MR2_UNCR.dcm",
-    // "pydicom/MR_small_padded.dcm",
-    // "pydicom/MR_truncated.dcm",
-    // "pydicom/OBXXXX1A.dcm",
-    // "pydicom/OBXXXX1A_2frame.dcm",
-    // "pydicom/OBXXXX1A_expb.dcm",
-    // "pydicom/OBXXXX1A_expb_2frame.dcm",
-    // "pydicom/OBXXXX1A_rle.dcm",
-    // "pydicom/OBXXXX1A_rle_2frame.dcm",
-    // "pydicom/OT-PAL-8-face.dcm",
-    // "pydicom/SC_rgb_16bit_2frame.dcm",
-    // "pydicom/SC_rgb_2frame.dcm",
-    // "pydicom/SC_rgb_32bit.dcm",
-    // "pydicom/SC_rgb_32bit_2frame.dcm",
-    // "pydicom/SC_rgb_dcmtk_+eb+cy+n1.dcm",
-    // "pydicom/SC_rgb_dcmtk_+eb+cy+n2.dcm",
-    // "pydicom/SC_rgb_dcmtk_+eb+cy+np.dcm",
-    // "pydicom/SC_rgb_dcmtk_+eb+cy+s2.dcm",
-    // "pydicom/SC_rgb_dcmtk_+eb+cy+s4.dcm",
-    // "pydicom/SC_rgb_dcmtk_ebcr_dcmd.dcm",
-    // "pydicom/SC_rgb_dcmtk_ebcyn1_dcmd.dcm",
-    // "pydicom/SC_rgb_dcmtk_ebcyn2_dcmd.dcm",
-    // "pydicom/SC_rgb_dcmtk_ebcynp_dcmd.dcm",
-    // "pydicom/SC_rgb_dcmtk_ebcys2_dcmd.dcm",
-    // "pydicom/SC_rgb_dcmtk_ebcys4_dcmd.dcm",
-    // "pydicom/SC_rgb_expb_16bit_2frame.dcm",
-    // "pydicom/SC_rgb_expb_2frame.dcm",
-    // "pydicom/SC_rgb_expb_32bit.dcm",
-    // "pydicom/SC_rgb_expb_32bit_2frame.dcm",
-    // "pydicom/SC_rgb_rle_16bit_2frame.dcm",
-    // "pydicom/SC_rgb_rle_2frame.dcm",
-    // "pydicom/SC_rgb_rle_32bit.dcm",
-    // "pydicom/SC_rgb_rle_32bit_2frame.dcm",
-    // "pydicom/SC_rgb_small_odd.dcm",
-    // "pydicom/SC_rgb_small_odd_jpeg.dcm",
-    // "pydicom/SC_rgb_jpeg_dcmtk.dcm",
-    // "pydicom/SC_ybr_full_422_uncompressed.dcm",
-    // "pydicom/US1_J2KI.dcm",
-    // "pydicom/US1_J2KR.dcm",
-    // "pydicom/US1_UNCI.dcm",
-    // "pydicom/US1_UNCR.dcm",
-    // "pydicom/badVR.dcm",
-    // "pydicom/bad_sequence.dcm",
-    // "pydicom/color3d_jpeg_baseline.dcm",
-    // "pydicom/eCT_Supplemental.dcm",
-    // "pydicom/empty_charset_LEI.dcm",
-    // "pydicom/emri_small.dcm",
-    // "pydicom/emri_small_RLE.dcm",
-    // "pydicom/emri_small_big_endian.dcm",
-    // "pydicom/emri_small_jpeg_2k_lossless.dcm",
-    // "pydicom/emri_small_jpeg_2k_lossless_too_short.dcm",
-    // "pydicom/emri_small_jpeg_ls_lossless.dcm",
-    // "pydicom/gdcm-US-ALOKA-16.dcm",
-    // "pydicom/gdcm-US-ALOKA-16_big.dcm",
-    // "pydicom/image_dfl.dcm",
-    // "pydicom/liver.dcm",
-    // "pydicom/liver_1frame.dcm",
-    // "pydicom/liver_expb.dcm",
-    // "pydicom/liver_expb_1frame.dcm",
-    // "pydicom/meta_missing_tsyntax.dcm",
-    // "pydicom/mlut_18.dcm",
-    // "pydicom/nested_priv_SQ.dcm",
-    // "pydicom/no_meta.dcm",
-    // "pydicom/no_meta_group_length.dcm",
-    // "pydicom/priv_SQ.dcm",
-    // "pydicom/reportsi.dcm",
-    // "pydicom/reportsi_with_empty_number_tags.dcm",
-    // "pydicom/rtdose.dcm",
-    // "pydicom/rtdose_1frame.dcm",
-    // "pydicom/rtdose_expb.dcm",
-    // "pydicom/rtdose_expb_1frame.dcm",
-    // "pydicom/rtdose_rle.dcm",
-    // "pydicom/rtdose_rle_1frame.dcm",
-    // "pydicom/rtplan.dcm",
-    // "pydicom/rtplan_truncated.dcm",
-    // "pydicom/rtstruct.dcm",
-    // "pydicom/test-SR.dcm",
-    // "pydicom/vlut_04.dcm",
 ])]
     fn test_parse_dicom_pixel_data(value: &str) {
         let test_file = dicom_test_files::path(value).unwrap();

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -534,12 +534,12 @@ where
         let transfer_syntax = &self.meta().transfer_syntax;
         let ts = TransferSyntaxRegistry
             .get(transfer_syntax)
-            .with_context(|| UnknownTransferSyntax {
+            .with_context(|| UnknownTransferSyntaxSnafu {
                 ts_uid: transfer_syntax,
             })?;
         
         if !ts.fully_supported() {
-            return UnsupportedTransferSyntax {
+            return UnsupportedTransferSyntaxSnafu {
                 ts: transfer_syntax,
             }.fail();
         }

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -461,7 +461,12 @@ where
         let number_of_frames = number_of_frames(self);
 
         let transfer_syntax = &self.meta().transfer_syntax;
-        let registry = TransferSyntaxRegistry.get(transfer_syntax).unwrap();
+        let registry = TransferSyntaxRegistry
+            .get(transfer_syntax)
+            .filter(|ts| ts.fully_supported())
+            .context(UnsupportedTransferSyntax {
+                ts: transfer_syntax,
+            })?;
 
         // Try decoding it using a native Rust decoder
         if let Codec::PixelData(decoder) = registry.codec() {


### PR DESCRIPTION
- [break] change signature of `PixelRWAdapter::encode`. This was necessary, otherwise the encoder would not have enough information to do its job.
- Check that the transfer syntax is fully supported before trying to decode it.
- Add pixel data encoding options, so that consumers may specify output quality for example.
- improve and readjust errors related to pixel data
- improve documentation
