### PR TITLE
Collect transfer syntax factory - inventory 0.2

### DIFF
--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -19,5 +19,5 @@ dicom-core = { path = "../core", version = "0.5.0-rc.1" }
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.5.0-rc.1" }
 encoding = "0.2.33"
 byteordered = "0.6"
-inventory = { version = "0.1.4", optional = true }
+inventory = { version = "0.2.2", optional = true }
 snafu = "0.7.0"

--- a/encoding/src/adapters/mod.rs
+++ b/encoding/src/adapters/mod.rs
@@ -1,3 +1,5 @@
+//! Module for built-in pixel data adapters.
+
 use dicom_core::value::C;
 use snafu::Snafu;
 

--- a/encoding/src/lib.rs
+++ b/encoding/src/lib.rs
@@ -21,7 +21,12 @@ pub mod encode;
 pub mod text;
 pub mod transfer_syntax;
 
+pub use adapters::NeverPixelAdapter;
 pub use decode::Decode;
 pub use encode::Encode;
+pub use byteordered::Endianness;
 pub use transfer_syntax::Codec;
+pub use transfer_syntax::DataRWAdapter;
+pub use transfer_syntax::NeverAdapter;
 pub use transfer_syntax::TransferSyntax;
+pub use transfer_syntax::TransferSyntaxIndex;

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -19,4 +19,4 @@ dicom-encoding = { path = "../encoding", version = "0.5.0-rc.1" }
 lazy_static = "1.2.0"
 encoding = "0.2.33"
 byteordered = "0.6"
-inventory = { version = "0.1.4", optional = true }
+inventory = { version = "0.2.2", optional = true }

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -54,6 +54,17 @@ pub const EXPLICIT_VR_BIG_ENDIAN: Ts = Ts::new(
     Codec::None,
 );
 
+// -- transfer syntaxes with pixel data adapters, fully supported --
+
+/// **Fully supported:** RLE Lossless
+pub const RLE_LOSSLESS: TransferSyntax<NeverAdapter, RLELosslessAdapter> = TransferSyntax::new(
+    "1.2.840.10008.1.2.5",
+    "RLE Lossless",
+    Endianness::Little,
+    true,
+    Codec::PixelData(RLELosslessAdapter),
+);
+
 // --- stub transfer syntaxes, known but not supported ---
 
 /// **Stub descriptor:** Deflated Explicit VR Little Endian
@@ -164,14 +175,6 @@ pub const HEVC_H265_MAIN_PROFILE: Ts = create_ts_stub(
 pub const HEVC_H265_MAIN_10_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.108",
     "HEVC/H.265 Main 10 Profile / Level 5.1",
-);
-/// **Stub descriptor:** RLE Lossless
-pub const RLE_LOSSLESS: TransferSyntax<NeverAdapter, RLELosslessAdapter> = TransferSyntax::new(
-    "1.2.840.10008.1.2.5",
-    "RLE Lossless",
-    Endianness::Little,
-    true,
-    Codec::PixelData(RLELosslessAdapter {}),
 );
 /// **Stub descriptor:** SMPTE ST 2110-20 Uncompressed Progressive Active Video
 pub const SMPTE_ST_2110_20_UNCOMPRESSED_PROGRESSIVE: Ts = create_ts_stub(

--- a/transfer-syntax-registry/tests/submit_dataset.rs
+++ b/transfer-syntax-registry/tests/submit_dataset.rs
@@ -1,12 +1,12 @@
-//! Independent test for testing that submitting a TS in a separate crate work.
+//! Independent test for submission of a dummy TS implementation
+//! with a dummy data set adapter.
 //!
 //! Only applicable to the inventory-based registry.
 #![cfg(feature = "inventory-registry")]
 
-use dicom_encoding::adapters::rle_lossless::RLELosslessAdapter;
-use dicom_encoding::submit_transfer_syntax;
-use dicom_encoding::transfer_syntax::{
-    Codec, DataRWAdapter, Endianness, TransferSyntax, TransferSyntaxIndex,
+use dicom_encoding::{
+    submit_transfer_syntax, Codec, DataRWAdapter, Endianness, NeverPixelAdapter, TransferSyntax,
+    TransferSyntaxIndex,
 };
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use std::io::{Read, Write};
@@ -15,43 +15,43 @@ use std::io::{Read, Write};
 #[derive(Debug)]
 struct DummyCodecAdapter;
 
-impl<R, W> DataRWAdapter<R, W> for DummyCodecAdapter {
+impl<R: 'static, W: 'static> DataRWAdapter<R, W> for DummyCodecAdapter {
     type Reader = Box<dyn Read>;
     type Writer = Box<dyn Write>;
 
-    fn adapt_reader(&self, _reader: R) -> Self::Reader
+    fn adapt_reader(&self, reader: R) -> Self::Reader
     where
         R: Read,
     {
-        unimplemented!()
+        Box::new(reader) as Box<_>
     }
 
-    fn adapt_writer(&self, _writer: W) -> Self::Writer
+    fn adapt_writer(&self, writer: W) -> Self::Writer
     where
         W: Write,
     {
-        unimplemented!()
+        Box::new(writer) as Box<_>
     }
 }
 
 // install this dummy as a private transfer syntax
 submit_transfer_syntax! {
     TransferSyntax::new(
-        "1.2.840.10008.9999.9999",
+        "1.2.840.10008.9999.9999.1",
         "Dummy Explicit VR Little Endian",
         Endianness::Little,
         true,
-        Codec::Dataset::<_, RLELosslessAdapter>(DummyCodecAdapter)
+        Codec::Dataset::<_, NeverPixelAdapter>(DummyCodecAdapter)
     )
 }
 
 #[test]
 fn contains_dummy_ts() {
     // contains our dummy TS, and claims to be fully supported
-    let ts = TransferSyntaxRegistry.get("1.2.840.10008.9999.9999");
+    let ts = TransferSyntaxRegistry.get("1.2.840.10008.9999.9999.1");
     assert!(ts.is_some());
     let ts = ts.unwrap();
-    assert_eq!(ts.uid(), "1.2.840.10008.9999.9999");
+    assert_eq!(ts.uid(), "1.2.840.10008.9999.9999.1");
     assert_eq!(ts.name(), "Dummy Explicit VR Little Endian");
     assert!(ts.fully_supported());
 }

--- a/transfer-syntax-registry/tests/submit_pixel.rs
+++ b/transfer-syntax-registry/tests/submit_pixel.rs
@@ -1,0 +1,52 @@
+//! Independent test for submission of a dummy TS implementation
+//! with a pixel data adapter.
+//!
+//! Only applicable to the inventory-based registry.
+#![cfg(feature = "inventory-registry")]
+
+use dicom_encoding::{
+    adapters::{DecodeResult, EncodeOptions, EncodeResult, PixelDataObject, PixelRWAdapter},
+    submit_transfer_syntax, Codec, Endianness, NeverAdapter, TransferSyntax, TransferSyntaxIndex,
+};
+use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
+
+/// this would, in theory, provide a pixel data adapter
+#[derive(Debug)]
+struct DummyPixelAdapter;
+
+impl PixelRWAdapter for DummyPixelAdapter {
+    fn decode(&self, _src: &dyn PixelDataObject, _dst: &mut Vec<u8>) -> DecodeResult<()> {
+        panic!("Implementation is for testing purposes, this was not meant to be called");
+    }
+
+    fn encode(
+        &self,
+        _src: &dyn PixelDataObject,
+        _options: EncodeOptions,
+        _dst: &mut Vec<u8>,
+    ) -> EncodeResult<()> {
+        Err(dicom_encoding::adapters::EncodeError::NotImplemented)
+    }
+}
+
+// install this dummy as a private transfer syntax
+submit_transfer_syntax! {
+    TransferSyntax::<NeverAdapter, _>::new(
+        "1.2.840.10008.9999.9999.2",
+        "Dummy Lossless",
+        Endianness::Little,
+        true,
+        Codec::PixelData(DummyPixelAdapter)
+    )
+}
+
+#[test]
+fn contains_dummy_ts() {
+    // contains our dummy TS, and claims to be fully supported
+    let ts = TransferSyntaxRegistry.get("1.2.840.10008.9999.9999.2");
+    assert!(ts.is_some());
+    let ts = ts.unwrap();
+    assert_eq!(ts.uid(), "1.2.840.10008.9999.9999.2");
+    assert_eq!(ts.name(), "Dummy Lossless");
+    assert!(ts.fully_supported());
+}

--- a/transfer-syntax-registry/tests/submit_replace.rs
+++ b/transfer-syntax-registry/tests/submit_replace.rs
@@ -1,0 +1,59 @@
+//! Independent test for submission of a dummy TS implementation
+//! to replace a built-in stub.
+//!
+//! Only applicable to the inventory-based registry.
+#![cfg(feature = "inventory-registry")]
+
+use dicom_encoding::{
+    submit_transfer_syntax, Codec, DataRWAdapter, Endianness, NeverPixelAdapter, TransferSyntax,
+    TransferSyntaxIndex,
+};
+use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
+use std::io::{Read, Write};
+
+/// this would, in theory, provide a dataset adapter
+#[derive(Debug)]
+struct DummyCodecAdapter;
+
+impl<R: 'static, W: 'static> DataRWAdapter<R, W> for DummyCodecAdapter {
+    type Reader = Box<dyn Read>;
+    type Writer = Box<dyn Write>;
+
+    fn adapt_reader(&self, _reader: R) -> Self::Reader
+    where
+        R: Read,
+    {
+        unimplemented!()
+    }
+
+    fn adapt_writer(&self, _writer: W) -> Self::Writer
+    where
+        W: Write,
+    {
+        unimplemented!()
+    }
+}
+
+// pretend to implement JPIP Referenced Deflate,
+// which is in the registry by default,
+// but not fully supported
+submit_transfer_syntax! {
+    TransferSyntax::new(
+        "1.2.840.10008.1.2.4.95",
+        "JPIP Referenced Deflate (Override)",
+        Endianness::Little,
+        true,
+        Codec::Dataset::<_, NeverPixelAdapter>(DummyCodecAdapter)
+    )
+}
+
+#[test]
+fn contains_dummy_ts() {
+    // contains our dummy TS, and claims to be fully supported
+    let ts = TransferSyntaxRegistry.get("1.2.840.10008.1.2.4.95");
+    assert!(ts.is_some());
+    let ts = ts.unwrap();
+    assert_eq!(ts.uid(), "1.2.840.10008.1.2.4.95");
+    assert_eq!(ts.name(), "JPIP Referenced Deflate (Override)");
+    assert!(ts.fully_supported());
+}

--- a/transfer-syntax-registry/tests/submit_replace_precondition.rs
+++ b/transfer-syntax-registry/tests/submit_replace_precondition.rs
@@ -1,0 +1,24 @@
+//! Independent test for the precondition of `submit_replace`:
+//! the transfer syntax used must be stubbed.
+//!
+//! Only applicable to the inventory-based registry.
+#![cfg(feature = "inventory-registry")]
+
+use dicom_encoding::{Codec, TransferSyntaxIndex};
+use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
+
+
+/// Assert that this transfer syntax is provided built-in as a stub.
+/// 
+/// If this changes, please replace the transfer syntax to test against
+/// and override.
+#[test]
+fn registry_has_stub_ts_by_default() {
+    // this TS is provided by default, but not fully supported
+    let ts = TransferSyntaxRegistry.get("1.2.840.10008.1.2.4.95");
+    assert!(ts.is_some());
+    let ts = ts.unwrap();
+    assert_eq!(ts.uid(), "1.2.840.10008.1.2.4.95");
+    assert_eq!(ts.name(), "JPIP Referenced Deflate");
+    assert!(matches!(ts.codec(), Codec::Unsupported | Codec::EncapsulatedPixelData));
+}


### PR DESCRIPTION
Resolves #212. 

- Update inventory to 0.2.2
- Use a new type `TransferSyntaxFactory` to register transfer syntaxes, so that they can be constructed and type-erased in a non-const expression
- Change `TransferSyntaxRegistry` to no longer provide `'static` references to transfer syntax descriptors
- Improve documentation
- Extend transfer syntax submission tests
