### PR TITLE
bump up gdcm-rs version to 0.3.0

### DIFF
--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -19,7 +19,7 @@ dicom-dictionary-std = { path = "../dictionary-std", version = "0.5.0-rc.2" }
 snafu = "0.7.0"
 byteorder = "1.4.3"
 image = "0.23.14"
-gdcm-rs = { version = "0.2.0", optional = true }
+gdcm-rs = { version = "0.3.0", optional = true }
 rayon = "1.5.0"
 ndarray = "0.15.1"
 ndarray-stats = "0.5"


### PR DESCRIPTION
Updates gdcm-rs version for dicom-pixeldata crate to support building dicom-rs with optional gdcm feature on gcc11