### PR TITLE
[encoding] Convert doc comment and fix doctest of SpecificCharacterSet::from_code

### DIFF
--- a/encoding/src/text.rs
+++ b/encoding/src/text.rs
@@ -157,18 +157,18 @@ impl Default for SpecificCharacterSet {
 }
 
 impl SpecificCharacterSet {
-    /** Obtain the specific character set identified by the given code string.
-     *
-     * Supported code strings include the possible values
-     * in the respective DICOM element (0008, 0005).
-     *
-     * # Example
-     *
-     * ```
-     * let character_set = SpecificCharacterSet::from_code("ISO_IR 100");
-     * assert_eq!(character_set, Some(SpecificCharacterSet::IsoIr100));
-     * ```
-     */
+    /// Obtain the specific character set identified by the given code string.
+    ///
+    /// Supported code strings include the possible values
+    /// in the respective DICOM element (0008, 0005).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dicom_encoding::text::SpecificCharacterSet;
+    /// let character_set = SpecificCharacterSet::from_code("ISO_IR 100");
+    /// assert_eq!(character_set, Some(SpecificCharacterSet::IsoIr100));
+    /// ```
     pub fn from_code(uid: &str) -> Option<Self> {
         use self::SpecificCharacterSet::*;
         match uid.trim_end() {


### PR DESCRIPTION
This doctest was being ignored due to a regression in the compiler (rust-lang/rust#92872, rust-lang/rust#93038). It was only when the fix hit beta (v1.60) that the test was missing an import.

I also looked for other doctests within block comments, but nothing more to report. One might as well default to line-based comments in the future and prefer not writing doc-tests inside block quotes.