### PR TITLE
[dump] Tweak output and add "cli" feature flag

### DIFF
--- a/dump/Cargo.toml
+++ b/dump/Cargo.toml
@@ -17,9 +17,11 @@ path = "src/lib.rs"
 [[bin]]
 name = "dicom-dump"
 path = "src/main.rs"
+required-features = ["cli"]
 
 [features]
-default = ['dicom/inventory-registry', 'dicom/backtraces']
+default = ["cli", "dicom/inventory-registry", "dicom/backtraces"]
+cli = ["structopt"]
 
 [dependencies]
 dicom = { path = "../parent/", version = "0.5.0-rc.2", default-features = false }
@@ -27,4 +29,5 @@ term_size = "0.3.2"
 itertools = "0.10"
 snafu = "0.7.0"
 colored = "2.0.0"
-structopt = "0.3.21"
+structopt = { version = "0.3.21", optional = true }
+

--- a/dump/README.md
+++ b/dump/README.md
@@ -15,9 +15,10 @@ This tool is part of the [DICOM-rs](https://github.com/Enet4/dicom-rs) project.
 ## Usage
 
 ```none
-    dicom-dump [FLAGS] [OPTIONS] <file>
+    dicom-dump [FLAGS] [OPTIONS] <files>...
 
 FLAGS:
+        --fail-first       fail if any errors are encountered
     -h, --help             Prints help information
         --no-text-limit    whether text value width limit is disabled (limited to `width` by default)
     -V, --version          Prints version information
@@ -27,5 +28,5 @@ OPTIONS:
     -w, --width <width>    the width of the display (default is to check automatically)
 
 ARGS:
-    <file>    The DICOM file to read
+    <files>...    The DICOM file(s) to read
 ```

--- a/dump/README.md
+++ b/dump/README.md
@@ -7,6 +7,8 @@ A command line utility for inspecting the contents of DICOM files
 by printing them in a human readable format.
 
 A programmatic API for dumping DICOM objects is also available.
+If you intend to use `dicom-dump` exclusively as a library,
+you can disable the `cli` Cargo feature.
 
 This tool is part of the [DICOM-rs](https://github.com/Enet4/dicom-rs) project.
 

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -222,7 +222,7 @@ impl DumpOptions {
             120
         };
 
-        println!("{:-<65}", "");
+        writeln!(&mut to, "{:-<65}", "")?;
 
         dump(&mut to, obj, width, 0, self.no_text_limit)?;
 

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -246,8 +246,6 @@ impl DumpOptions {
             120
         };
 
-        writeln!(&mut to, "{:-<65}", "")?;
-
         dump(&mut to, obj, width, 0, self.no_text_limit, self.no_limit)?;
 
         Ok(())
@@ -917,6 +915,7 @@ mod tests {
             .split('\n')
             .collect();
         let parts: Vec<&str> = lines[0].split(" ").filter(|p| !p.is_empty()).collect();
+
         assert_eq!(&parts[..3], &["(0008,0018)", "SOPInstanceUID", "UI"]);
     }
 }

--- a/dump/src/main.rs
+++ b/dump/src/main.rs
@@ -28,18 +28,22 @@ struct App {
     /// The DICOM file(s) to read
     #[structopt(required = true)]
     files: Vec<PathBuf>,
-    /// whether text value width limit is disabled
+    /// Print text values to the end
     /// (limited to `width` by default)
     #[structopt(long = "no-text-limit")]
     no_text_limit: bool,
-    /// the width of the display
+    /// Print all values to the end
+    /// (implies `no_text_limit`, limited to `width` by default)
+    #[structopt(long = "no-limit")]
+    no_limit: bool,
+    /// The width of the display
     /// (default is to check automatically)
     #[structopt(short = "w", long = "width")]
     width: Option<u32>,
-    /// color mode
+    /// The color mode
     #[structopt(long = "color", default_value = "auto")]
     color: ColorMode,
-    /// fail if any errors are encountered
+    /// Fail if any errors are encountered
     #[structopt(long = "fail-first")]
     fail_first: bool,
 }
@@ -52,6 +56,7 @@ fn main() {
     let App {
         files: filenames,
         no_text_limit,
+        no_limit,
         width,
         color,
         fail_first,
@@ -64,6 +69,7 @@ fn main() {
     let mut options = DumpOptions::new();
     options
         .no_text_limit(no_text_limit)
+        .no_limit(no_limit)
         .width(width)
         .color_mode(color);
     let fail_first = filenames.len() == 1 || fail_first;


### PR DESCRIPTION
- Added `no_limit` flag to API and CLI, which should print the entirety of all data values.
- Removed dash separator when dumping a plain object without file meta group.
- Added `cli` Cargo feature, which slightly reduces some dependencies if disabled.