### PR TITLE
Add rust native decoder for jpeg pixeldata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,11 @@ members = [
     "storescu",
     "pixeldata"
 ]
+
+# optimize JPEG decoder to run tests faster
+[profile.dev.package."jpeg-decoder"]
+opt-level = 2
+
+# optimize deflate to run tests faster
+[profile.dev.package."deflate"]
+opt-level = 2

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -21,3 +21,4 @@ encoding = "0.2.33"
 byteordered = "0.6"
 inventory = { version = "0.2.2", optional = true }
 snafu = "0.7.0"
+jpeg-decoder = "0.2.3"

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -21,4 +21,4 @@ encoding = "0.2.33"
 byteordered = "0.6"
 inventory = { version = "0.2.2", optional = true }
 snafu = "0.7.0"
-jpeg-decoder = "0.2.3"
+jpeg-decoder = "0.2.4"

--- a/encoding/src/adapters/jpeg.rs
+++ b/encoding/src/adapters/jpeg.rs
@@ -54,15 +54,20 @@ impl PixelRWAdapter for JPEGAdapter {
             })?;
             let mut decoder = Decoder::new(Cursor::new(fragment));
 
-            if let Ok(decoded) = decoder.decode() {
-                let decoded_len = decoded.len();
-                dst[offset..(offset + decoded_len)].copy_from_slice(&decoded);
-                offset += decoded_len
-            } else {
-                return CustomMessageSnafu {
-                    message: "Could not decode jpeg in frame",
+            match decoder.decode() {
+                Ok(decoded) => {
+                    let decoded_len = decoded.len();
+                    dst[offset..(offset + decoded_len)].copy_from_slice(&decoded);
+                    offset += decoded_len
                 }
-                .fail();
+                Err(_) => {
+                    // TODO: Replace this with a result context error
+                    // println!("{}", e);
+                    return CustomMessageSnafu {
+                        message: "Could not decode jpeg in frame",
+                    }
+                    .fail();
+                }
             }
         }
         Ok(())

--- a/encoding/src/adapters/jpeg.rs
+++ b/encoding/src/adapters/jpeg.rs
@@ -11,7 +11,6 @@ pub struct JPEGAdapter;
 
 impl PixelRWAdapter for JPEGAdapter {
     /// Decode DICOM image data with jpeg encoding.
-
     fn decode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> DecodeResult<()> {
         let cols = src
             .cols()

--- a/encoding/src/adapters/jpeg.rs
+++ b/encoding/src/adapters/jpeg.rs
@@ -1,9 +1,9 @@
 //! Support for JPG image decoding.
-use snafu::{OptionExt, ResultExt};
 
 use super::{CustomMessageSnafu, CustomSnafu, MissingAttributeSnafu};
 use crate::adapters::{DecodeResult, PixelDataObject, PixelRWAdapter};
 use jpeg_decoder::Decoder;
+use snafu::{OptionExt, ResultExt};
 use std::io::Cursor;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/encoding/src/adapters/jpeg.rs
+++ b/encoding/src/adapters/jpeg.rs
@@ -47,6 +47,7 @@ impl PixelRWAdapter for JPEGAdapter {
         let stride: usize = (bytes_per_sample as usize * cols as usize * rows as usize).into();
         dst.resize((samples_per_pixel as usize * stride) * nr_frames, 0);
 
+        let mut offset = 0;
         for i in 0..nr_frames {
             let fragment = &src.fragment(i).context(CustomMessageSnafu {
                 message: "No pixel data found for frame",
@@ -54,7 +55,9 @@ impl PixelRWAdapter for JPEGAdapter {
             let mut decoder = Decoder::new(Cursor::new(fragment));
 
             if let Ok(decoded) = decoder.decode() {
-                dst[0..decoded.len()].copy_from_slice(&decoded);
+                let decoded_len = decoded.len();
+                dst[offset..(offset + decoded_len)].copy_from_slice(&decoded);
+                offset += decoded_len
             } else {
                 return CustomMessageSnafu {
                     message: "Could not decode jpeg in frame",

--- a/encoding/src/adapters/jpeg.rs
+++ b/encoding/src/adapters/jpeg.rs
@@ -1,7 +1,7 @@
 //! Support for JPG image decoding.
 use snafu::{OptionExt, ResultExt};
 
-use super::{CustomMessageSnafu, CustomSnafu, MissingAttributeSnafu};
+use super::{CustomMessageSnafu, CustomSnafu, DecodeError, MissingAttributeSnafu};
 use crate::adapters::{DecodeResult, PixelDataObject, PixelRWAdapter};
 use jpeg_decoder::Decoder;
 use std::io::Cursor;
@@ -9,40 +9,19 @@ use std::io::Cursor;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct JPEGAdapter;
 
-impl PixelRWAdapter for JPEGAdapter {
-    /// Decode DICOM image data with jpeg encoding.
-
-    fn decode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> DecodeResult<()> {
-        let cols = src
-            .cols()
-            .context(MissingAttributeSnafu { name: "Columns" })?;
-        let rows = src.rows().context(MissingAttributeSnafu { name: "Rows" })?;
-        let samples_per_pixel = src.samples_per_pixel().context(MissingAttributeSnafu {
-            name: "SamplesPerPixel",
-        })?;
-        let bits_allocated = src.bits_allocated().context(MissingAttributeSnafu {
-            name: "BitsAllocated",
-        })?;
-
-        if bits_allocated != 8 && bits_allocated != 16 {
-            return CustomMessageSnafu {
-                message: "BitsAllocated other than 8 or 16 is not supported",
-            }
-            .fail();
-        }
-
-        let nr_frames = src.number_of_frames().unwrap_or(1) as usize;
-
-        let fragments = src
-            .raw_pixel_data()
-            .expect("Expect to have pixel data available")
-            .fragments;
-        let bytes_per_sample = bits_allocated / 8;
-
+impl JPEGAdapter {
+    fn encoded_frames(&self, src: &dyn PixelDataObject) -> Result<Vec<Vec<u8>>, DecodeError> {
         // Embedded jpegs can span multiple fragments
         // Create 1:1 mapping between frame and fragment data
         // https://dicom.nema.org/dicom/2013/output/chtml/part05/sect_8.2.html
+        let nr_frames = src.number_of_frames().unwrap_or(1) as usize;
         let mut frame_to_fragments: Vec<Vec<u8>> = vec![Vec::new(); nr_frames];
+        let fragments = src
+            .raw_pixel_data()
+            .context(CustomMessageSnafu {
+                message: "Expected to have raw pixel data available",
+            })?
+            .fragments;
         {
             let mut current_frame = 0;
             for fragment in &fragments {
@@ -69,15 +48,43 @@ impl PixelRWAdapter for JPEGAdapter {
                 .fail();
             }
         }
+        Ok(frame_to_fragments)
+    }
+}
+
+impl PixelRWAdapter for JPEGAdapter {
+    /// Decode DICOM image data with jpeg encoding.
+
+    fn decode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> DecodeResult<()> {
+        let cols = src
+            .cols()
+            .context(MissingAttributeSnafu { name: "Columns" })?;
+        let rows = src.rows().context(MissingAttributeSnafu { name: "Rows" })?;
+        let samples_per_pixel = src.samples_per_pixel().context(MissingAttributeSnafu {
+            name: "SamplesPerPixel",
+        })?;
+        let bits_allocated = src.bits_allocated().context(MissingAttributeSnafu {
+            name: "BitsAllocated",
+        })?;
+
+        if bits_allocated != 8 && bits_allocated != 16 {
+            return CustomMessageSnafu {
+                message: "BitsAllocated other than 8 or 16 is not supported",
+            }
+            .fail();
+        }
+
+        let nr_frames = src.number_of_frames().unwrap_or(1) as usize;
+        let bytes_per_sample = bits_allocated / 8;
+        let encoded_frames = self.encoded_frames(src)?;
 
         // `stride` it the total number of bytes for each sample plane
         let stride: usize = (bytes_per_sample as usize * cols as usize * rows as usize).into();
         dst.resize((samples_per_pixel as usize * stride) * nr_frames, 0);
 
         let mut offset = 0;
-        for i in 0..nr_frames {
-            let fragment = &frame_to_fragments[i];
-            let mut decoder = Decoder::new(Cursor::new(fragment));
+        for frame in encoded_frames {
+            let mut decoder = Decoder::new(Cursor::new(frame));
 
             let decoded = decoder
                 .decode()

--- a/encoding/src/adapters/jpeg.rs
+++ b/encoding/src/adapters/jpeg.rs
@@ -1,0 +1,46 @@
+//! Support for JPG image decoding.
+use byteordered::byteorder::{ByteOrder, LittleEndian};
+use snafu::{OptionExt, ResultExt};
+
+use crate::adapters::{DecodeResult, PixelDataObject, PixelRWAdapter};
+use std::io::{self, Read, Seek};
+
+use super::{CustomMessageSnafu, CustomSnafu, MissingAttributeSnafu};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct JPEGAdapter;
+
+impl PixelRWAdapter for JPEGAdapter {
+    /// Decode DICOM image data with jpeg encoding.
+
+    fn decode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> DecodeResult<()> {
+        let cols = src
+            .cols()
+            .context(MissingAttributeSnafu { name: "Columns" })?;
+        let rows = src.rows().context(MissingAttributeSnafu { name: "Rows" })?;
+        let samples_per_pixel = src.samples_per_pixel().context(MissingAttributeSnafu {
+            name: "SamplesPerPixel",
+        })?;
+        let bits_allocated = src.bits_allocated().context(MissingAttributeSnafu {
+            name: "BitsAllocated",
+        })?;
+
+        if bits_allocated != 8 && bits_allocated != 16 {
+            return CustomMessageSnafu {
+                message: "BitsAllocated other than 8 or 16 is not supported",
+            }
+            .fail();
+        }
+        // For RLE the number of fragments = number of frames
+        // therefore, we can fetch the fragments one-by-one
+        let nr_frames = src.number_of_fragments().context(CustomMessageSnafu {
+            message: "Invalid pixel data, no fragments found",
+        })? as usize;
+        let bytes_per_sample = bits_allocated / 8;
+        // `stride` it the total number of bytes for each sample plane
+        let stride = bytes_per_sample * cols * rows;
+        dst.resize((samples_per_pixel * stride) as usize * nr_frames, 0);
+        todo!();
+        Ok(())
+    }
+}

--- a/encoding/src/adapters/jpeg.rs
+++ b/encoding/src/adapters/jpeg.rs
@@ -79,7 +79,7 @@ impl PixelRWAdapter for JPEGAdapter {
         let encoded_frames = self.encoded_frames(src)?;
 
         // `stride` it the total number of bytes for each sample plane
-        let stride: usize = (bytes_per_sample as usize * cols as usize * rows as usize).into();
+        let stride: usize = bytes_per_sample as usize * cols as usize * rows as usize;
         dst.resize((samples_per_pixel as usize * stride) * nr_frames, 0);
 
         let mut offset = 0;

--- a/encoding/src/adapters/mod.rs
+++ b/encoding/src/adapters/mod.rs
@@ -19,9 +19,7 @@ pub enum DecodeError {
     /// A custom error occurred when decoding,
     /// reported as a static message
     #[snafu(display("Error decoding pixel data: {}", message))]
-    CustomMessage {
-        message: &'static str,
-    },
+    CustomMessage { message: &'static str },
 
     /// Input pixel data is not encapsulated
     NotEncapsulated,
@@ -37,9 +35,7 @@ pub enum DecodeError {
 pub enum EncodeError {
     /// A custom error when encoding fails
     #[snafu(display("Error encoding pixel data {}", message))]
-    CustomEncodeError {
-        message: &'static str,
-    },
+    CustomEncodeError { message: &'static str },
 
     /// Input pixel data is not native
     NotNative,
@@ -64,15 +60,15 @@ pub struct RawPixelData {
 }
 
 /// A DICOM object trait to be interpreted as pixel data.
-/// 
+///
 /// This trait extends the concept of DICOM object
 /// as defined in [`dicom_object`],
 /// in order to retrieve important pieces of the object
 /// for pixel data decoding into images or multi-dimensional arrays.
-/// 
+///
 /// It is defined in this crate so that
 /// transfer syntax implementers only have to depend on `dicom_encoding`.
-/// 
+///
 /// [`dicom_object`]: https://docs.rs/dicom_object
 pub trait PixelDataObject {
     /// Return the Rows attribute or None if it is not found
@@ -137,7 +133,7 @@ impl EncodeOptions {
 
 /// Trait object responsible for decoding and encoding
 /// pixel data based on the Transfersyntax.
-/// 
+///
 /// Every transfer syntax with encapsulated pixel data
 /// should implement these methods.
 ///
@@ -145,32 +141,37 @@ pub trait PixelRWAdapter {
     /// Decode the given DICOM object
     /// containing encapsulated pixel data
     /// into native pixel data as a byte stream.
-    /// 
+    ///
     /// It is a necessary precondition that the object's pixel data
     /// is encoded in accordance to the transfer syntax(es)
     /// supported by this adapter.
     /// A `NotEncapsulated` error is returned otherwise.
-    /// 
+    ///
     /// The output is a sequence of native pixel values
     /// which follow the image properties of the given object.
-    /// 
+    ///
     fn decode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> DecodeResult<()>;
 
     /// Encode a DICOM object's image into the format supported by this adapter,
     /// writing a byte stream of pixel data fragment values
     /// into the given destination.
-    /// 
+    ///
     /// It is a necessary precondition that the object's pixel data
     /// is in a _native encoding_.
     /// A `NotNative` error is returned otherwise.
-    /// 
+    ///
     /// It is possible that
     /// image encoding is not actually supported by this adapter,
     /// in which case a `NotImplemented` error is returned.
     /// Implementers leave the default method implementation
     /// for this behavior.
     #[allow(unused_variables)]
-    fn encode(&self, src: &dyn PixelDataObject, options: EncodeOptions, dst: &mut Vec<u8>) -> EncodeResult<()> {
+    fn encode(
+        &self,
+        src: &dyn PixelDataObject,
+        options: EncodeOptions,
+        dst: &mut Vec<u8>,
+    ) -> EncodeResult<()> {
         Err(EncodeError::NotImplemented)
     }
 }
@@ -187,7 +188,12 @@ impl PixelRWAdapter for NeverPixelAdapter {
         unreachable!();
     }
 
-    fn encode(&self, _src: &dyn PixelDataObject, _options: EncodeOptions, _dst: &mut Vec<u8>) -> EncodeResult<()> {
+    fn encode(
+        &self,
+        _src: &dyn PixelDataObject,
+        _options: EncodeOptions,
+        _dst: &mut Vec<u8>,
+    ) -> EncodeResult<()> {
         unreachable!();
     }
 }

--- a/encoding/src/adapters/mod.rs
+++ b/encoding/src/adapters/mod.rs
@@ -3,6 +3,7 @@
 use dicom_core::value::C;
 use snafu::Snafu;
 
+pub mod jpeg;
 pub mod rle_lossless;
 
 /// Error conditions when decoding pixel data.

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -112,6 +112,7 @@ mod tests {
     use dicom_object::open_file;
     use dicom_test_files;
     use rstest::rstest;
+    use std::fs;
     use std::path::Path;
 
     #[rstest(value => [
@@ -151,17 +152,20 @@ mod tests {
         let test_file = dicom_test_files::path(value).unwrap();
         println!("Parsing pixel data for {}", test_file.display());
         let obj = open_file(test_file).unwrap();
-        let image = obj
-            .decode_pixel_data()
-            .unwrap()
-            .to_dynamic_image(0)
-            .unwrap();
-        image
-            .save(format!(
-                "../target/dicom_test_files/pydicom/{}.png",
-                Path::new(value).file_stem().unwrap().to_str().unwrap()
-            ))
-            .unwrap();
+        let pixel_data = obj.decode_pixel_data().unwrap();
+        let output_dir =
+            Path::new("../target/dicom_test_files/_out/test_gdcm_parse_dicom_pixel_data");
+        fs::create_dir_all(output_dir).unwrap();
+
+        for i in 0..pixel_data.number_of_frames {
+            let image = pixel_data.to_dynamic_image(i).unwrap();
+            let image_path = output_dir.join(format!(
+                "{}-{}.png",
+                Path::new(value).file_stem().unwrap().to_str().unwrap(),
+                i,
+            ));
+            image.save(image_path).unwrap();
+        }
     }
 
     #[test]

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -1,8 +1,8 @@
 //! Decode pixel data using GDCM when the default features are enabled.
 
 use crate::*;
-use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_encoding::adapters::DecodeError;
+use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use gdcm_rs::{decode_single_frame_compressed, GDCMPhotometricInterpretation, GDCMTransferSyntax};
 use std::str::FromStr;
@@ -20,9 +20,12 @@ where
 
         let photometric_interpretation = photometric_interpretation(self)?;
         let pi_type = GDCMPhotometricInterpretation::from_str(&photometric_interpretation)
-            .map_err(|_| UnsupportedPhotometricInterpretationSnafu {
-                pi: photometric_interpretation.clone(),
-            }.build())?;
+            .map_err(|_| {
+                UnsupportedPhotometricInterpretationSnafu {
+                    pi: photometric_interpretation.clone(),
+                }
+                .build()
+            })?;
 
         let transfer_syntax = &self.meta().transfer_syntax;
         let registry =
@@ -34,7 +37,8 @@ where
         let ts_type = GDCMTransferSyntax::from_str(&registry.uid()).map_err(|_| {
             UnsupportedTransferSyntaxSnafu {
                 ts: transfer_syntax.clone(),
-            }.build()
+            }
+            .build()
         })?;
 
         let samples_per_pixel = samples_per_pixel(self)?;
@@ -70,7 +74,7 @@ where
                 .map_err(|source| Error::DecodePixelData {
                     source: DecodeError::Custom {
                         source: Box::new(source) as Box<_>,
-                    }
+                    },
                 })?;
                 decoded_frame.to_vec()
             }
@@ -131,7 +135,7 @@ mod tests {
         "pydicom/SC_rgb.dcm",
         "pydicom/SC_rgb_16bit.dcm",
         "pydicom/SC_rgb_dcmtk_+eb+cr.dcm",
-        "pydicom/SC_rgb_expb.dcm", 
+        "pydicom/SC_rgb_expb.dcm",
         "pydicom/SC_rgb_expb_16bit.dcm",
         "pydicom/SC_rgb_gdcm2k_uncompressed.dcm",
         "pydicom/SC_rgb_gdcm_KY.dcm",

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -857,7 +857,7 @@ mod tests {
         }
 
         #[rstest]
-        #[should_panic(expected = "Could not decode jpeg in frame")]
+        #[should_panic(expected = "Format(\"JPGn(7) marker found where not allowed\")")]
         #[case("pydicom/emri_small_jpeg_ls_lossless.dcm", 10)] // crashes, but not sure if file is ok
         #[case("pydicom/color3d_jpeg_baseline.dcm", 120)]
         // TODO: figure out why slow (40s) in non release mode, maybe out of bounds checks? also very green and only first frame has a picture in it

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -679,9 +679,6 @@ mod tests {
     use super::*;
     use dicom_object::open_file;
     use dicom_test_files;
-    use rstest::rstest;
-    use std::fs;
-    use std::path::Path;
 
     #[test]
     fn test_to_ndarray_rgb() {
@@ -727,116 +724,6 @@ mod tests {
         assert_eq!(pixel_data.rescale_slope, 1.);
     }
 
-    #[cfg(not(feature = "gdcm"))]
-    #[test]
-    fn test_native_decoding_pixel_data_rle_8bit_1frame() {
-        let path =
-            dicom_test_files::path("pydicom/SC_rgb_rle.dcm").expect("test DICOM file should exist");
-        let object = open_file(&path).unwrap();
-        let ndarray = object
-            .decode_pixel_data()
-            .unwrap()
-            .to_ndarray::<u8>()
-            .unwrap();
-        // Validated using Numpy
-        // This doesn't reshape the array based on the PlanarConfiguration
-        // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
-        assert_eq!(ndarray.shape(), &[1, 100, 100, 3]);
-        assert_eq!(ndarray.len(), 30000);
-        assert_eq!(ndarray[[0, 0, 0, 0]], 255);
-        assert_eq!(ndarray[[0, 0, 0, 1]], 255);
-        assert_eq!(ndarray[[0, 0, 0, 2]], 255);
-        assert_eq!(ndarray[[0, 50, 50, 0]], 128);
-        assert_eq!(ndarray[[0, 50, 50, 1]], 128);
-        assert_eq!(ndarray[[0, 50, 50, 2]], 128);
-        assert_eq!(ndarray[[0, 75, 75, 0]], 0);
-        assert_eq!(ndarray[[0, 75, 75, 1]], 0);
-        assert_eq!(ndarray[[0, 75, 75, 2]], 0);
-    }
-
-    #[cfg(not(feature = "gdcm"))]
-    #[test]
-    fn test_native_decoding_pixel_data_rle_8bit_2frame() {
-        let path = dicom_test_files::path("pydicom/SC_rgb_rle_2frame.dcm")
-            .expect("test DICOM file should exist");
-        let object = open_file(&path).unwrap();
-        let ndarray = object
-            .decode_pixel_data()
-            .unwrap()
-            .to_ndarray::<u8>()
-            .unwrap();
-        // Validated using Numpy
-        // This doesn't reshape the array based on the PlanarConfiguration
-        // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
-        assert_eq!(ndarray.shape(), &[2, 100, 100, 3]);
-        assert_eq!(ndarray.len(), 60000);
-        // The second frame is the inverse of the first frame
-        assert_eq!(ndarray[[1, 0, 0, 0]], 0);
-        assert_eq!(ndarray[[1, 0, 0, 1]], 0);
-        assert_eq!(ndarray[[1, 0, 0, 2]], 0);
-        assert_eq!(ndarray[[1, 50, 50, 0]], 127);
-        assert_eq!(ndarray[[1, 50, 50, 1]], 127);
-        assert_eq!(ndarray[[1, 50, 50, 2]], 127);
-        assert_eq!(ndarray[[1, 75, 75, 0]], 255);
-        assert_eq!(ndarray[[1, 75, 75, 1]], 255);
-        assert_eq!(ndarray[[1, 75, 75, 2]], 255);
-    }
-
-    #[cfg(not(feature = "gdcm"))]
-    #[test]
-    fn test_native_decoding_pixel_data_rle_16bit_1frame() {
-        let path = dicom_test_files::path("pydicom/SC_rgb_rle_16bit.dcm")
-            .expect("test DICOM file should exist");
-        let object = open_file(&path).unwrap();
-        let ndarray = object
-            .decode_pixel_data()
-            .unwrap()
-            .to_ndarray::<u16>()
-            .unwrap();
-        // Validated using Numpy
-        // This doesn't reshape the array based on the PlanarConfiguration
-        // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
-        assert_eq!(ndarray.shape(), &[1, 100, 100, 3]);
-        assert_eq!(ndarray.len(), 30000);
-        assert_eq!(ndarray[[0, 0, 0, 0]], 65535);
-        assert_eq!(ndarray[[0, 0, 0, 1]], 65535);
-        assert_eq!(ndarray[[0, 0, 0, 2]], 65535);
-        assert_eq!(ndarray[[0, 50, 50, 0]], 32896);
-        assert_eq!(ndarray[[0, 50, 50, 1]], 32896);
-        assert_eq!(ndarray[[0, 50, 50, 2]], 32896);
-        assert_eq!(ndarray[[0, 75, 75, 0]], 0);
-        assert_eq!(ndarray[[0, 75, 75, 1]], 0);
-        assert_eq!(ndarray[[0, 75, 75, 2]], 0);
-    }
-
-    #[cfg(not(feature = "gdcm"))]
-    #[test]
-    fn test_native_decoding_pixel_data_rle_16bit_2frame() {
-        let path = dicom_test_files::path("pydicom/SC_rgb_rle_16bit_2frame.dcm")
-            .expect("test DICOM file should exist");
-        let object = open_file(&path).unwrap();
-        let ndarray = object
-            .decode_pixel_data()
-            .unwrap()
-            .to_ndarray::<u16>()
-            .unwrap();
-        // Validated using Numpy
-        // This doesn't reshape the array based on the PlanarConfiguration
-        // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
-        assert_eq!(ndarray.shape(), &[2, 100, 100, 3]);
-        assert_eq!(ndarray.len(), 60000);
-        // The second frame is the inverse of the first frame
-        assert_eq!(ndarray[[1, 0, 0, 0]], 0);
-        assert_eq!(ndarray[[1, 0, 0, 1]], 0);
-        assert_eq!(ndarray[[1, 0, 0, 2]], 0);
-        assert_eq!(ndarray[[1, 50, 50, 0]], 32639);
-        assert_eq!(ndarray[[1, 50, 50, 1]], 32639);
-        assert_eq!(ndarray[[1, 50, 50, 2]], 32639);
-        assert_eq!(ndarray[[1, 75, 75, 0]], 65535);
-        assert_eq!(ndarray[[1, 75, 75, 1]], 65535);
-        assert_eq!(ndarray[[1, 75, 75, 2]], 65535);
-    }
-
     #[test]
     fn test_frame_out_of_range() {
         let path =
@@ -856,33 +743,147 @@ mod tests {
             _ => panic!("Unexpected positive outcome for out of range access"),
         }
     }
+    #[cfg(not(feature = "gdcm"))]
+    mod not_gdcm {
+        use super::*;
+        use rstest::rstest;
+        use std::fs;
+        use std::path::Path;
 
-    #[rstest]
-    #[should_panic(expected = "Could not decode jpeg in frame")]
-    #[case("pydicom/emri_small_jpeg_ls_lossless.dcm", 10)] // crashes, but not sure if file is ok
-    #[case("pydicom/color3d_jpeg_baseline.dcm", 120)]
-    // TODO: figure out why slow (40s) in non release mode, maybe out of bounds checks? also very green and only first frame has a picture in it
-    #[case("pydicom/JPGLosslessP14SV1_1s_1f_8b.dcm", 1)] // Works fine
-    #[case("bscans_spec_61.dcm", 61)] // TODO: remove before finished
-    fn test_parse_jpeg_encoded_dicom_pixel_data(#[case] value: &str, #[case] frames: u16) {
-        let test_file = dicom_test_files::path(value).unwrap();
-        println!("Parsing pixel data for {}", test_file.display());
-        let obj = open_file(test_file).unwrap();
-        let pixel_data = obj.decode_pixel_data().unwrap();
-        assert_eq!(pixel_data.number_of_frames, frames);
+        #[test]
+        fn test_native_decoding_pixel_data_rle_8bit_1frame() {
+            let path = dicom_test_files::path("pydicom/SC_rgb_rle.dcm")
+                .expect("test DICOM file should exist");
+            let object = open_file(&path).unwrap();
+            let ndarray = object
+                .decode_pixel_data()
+                .unwrap()
+                .to_ndarray::<u8>()
+                .unwrap();
+            // Validated using Numpy
+            // This doesn't reshape the array based on the PlanarConfiguration
+            // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
+            assert_eq!(ndarray.shape(), &[1, 100, 100, 3]);
+            assert_eq!(ndarray.len(), 30000);
+            assert_eq!(ndarray[[0, 0, 0, 0]], 255);
+            assert_eq!(ndarray[[0, 0, 0, 1]], 255);
+            assert_eq!(ndarray[[0, 0, 0, 2]], 255);
+            assert_eq!(ndarray[[0, 50, 50, 0]], 128);
+            assert_eq!(ndarray[[0, 50, 50, 1]], 128);
+            assert_eq!(ndarray[[0, 50, 50, 2]], 128);
+            assert_eq!(ndarray[[0, 75, 75, 0]], 0);
+            assert_eq!(ndarray[[0, 75, 75, 1]], 0);
+            assert_eq!(ndarray[[0, 75, 75, 2]], 0);
+        }
 
-        let output_dir =
-            Path::new("../target/dicom_test_files/_out/test_parse_jpeg_encoded_dicom_pixel_data");
-        fs::create_dir_all(output_dir).unwrap();
+        #[test]
+        fn test_native_decoding_pixel_data_rle_8bit_2frame() {
+            let path = dicom_test_files::path("pydicom/SC_rgb_rle_2frame.dcm")
+                .expect("test DICOM file should exist");
+            let object = open_file(&path).unwrap();
+            let ndarray = object
+                .decode_pixel_data()
+                .unwrap()
+                .to_ndarray::<u8>()
+                .unwrap();
+            // Validated using Numpy
+            // This doesn't reshape the array based on the PlanarConfiguration
+            // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
+            assert_eq!(ndarray.shape(), &[2, 100, 100, 3]);
+            assert_eq!(ndarray.len(), 60000);
+            // The second frame is the inverse of the first frame
+            assert_eq!(ndarray[[1, 0, 0, 0]], 0);
+            assert_eq!(ndarray[[1, 0, 0, 1]], 0);
+            assert_eq!(ndarray[[1, 0, 0, 2]], 0);
+            assert_eq!(ndarray[[1, 50, 50, 0]], 127);
+            assert_eq!(ndarray[[1, 50, 50, 1]], 127);
+            assert_eq!(ndarray[[1, 50, 50, 2]], 127);
+            assert_eq!(ndarray[[1, 75, 75, 0]], 255);
+            assert_eq!(ndarray[[1, 75, 75, 1]], 255);
+            assert_eq!(ndarray[[1, 75, 75, 2]], 255);
+        }
 
-        for i in 0..pixel_data.number_of_frames {
-            let image = pixel_data.to_dynamic_image(i).unwrap();
-            let image_path = output_dir.join(format!(
-                "{}-{}.png",
-                Path::new(value).file_stem().unwrap().to_str().unwrap(),
-                i,
-            ));
-            image.save(image_path).unwrap();
+        #[test]
+        fn test_native_decoding_pixel_data_rle_16bit_1frame() {
+            let path = dicom_test_files::path("pydicom/SC_rgb_rle_16bit.dcm")
+                .expect("test DICOM file should exist");
+            let object = open_file(&path).unwrap();
+            let ndarray = object
+                .decode_pixel_data()
+                .unwrap()
+                .to_ndarray::<u16>()
+                .unwrap();
+            // Validated using Numpy
+            // This doesn't reshape the array based on the PlanarConfiguration
+            // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
+            assert_eq!(ndarray.shape(), &[1, 100, 100, 3]);
+            assert_eq!(ndarray.len(), 30000);
+            assert_eq!(ndarray[[0, 0, 0, 0]], 65535);
+            assert_eq!(ndarray[[0, 0, 0, 1]], 65535);
+            assert_eq!(ndarray[[0, 0, 0, 2]], 65535);
+            assert_eq!(ndarray[[0, 50, 50, 0]], 32896);
+            assert_eq!(ndarray[[0, 50, 50, 1]], 32896);
+            assert_eq!(ndarray[[0, 50, 50, 2]], 32896);
+            assert_eq!(ndarray[[0, 75, 75, 0]], 0);
+            assert_eq!(ndarray[[0, 75, 75, 1]], 0);
+            assert_eq!(ndarray[[0, 75, 75, 2]], 0);
+        }
+
+        #[test]
+        fn test_native_decoding_pixel_data_rle_16bit_2frame() {
+            let path = dicom_test_files::path("pydicom/SC_rgb_rle_16bit_2frame.dcm")
+                .expect("test DICOM file should exist");
+            let object = open_file(&path).unwrap();
+            let ndarray = object
+                .decode_pixel_data()
+                .unwrap()
+                .to_ndarray::<u16>()
+                .unwrap();
+            // Validated using Numpy
+            // This doesn't reshape the array based on the PlanarConfiguration
+            // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
+            assert_eq!(ndarray.shape(), &[2, 100, 100, 3]);
+            assert_eq!(ndarray.len(), 60000);
+            // The second frame is the inverse of the first frame
+            assert_eq!(ndarray[[1, 0, 0, 0]], 0);
+            assert_eq!(ndarray[[1, 0, 0, 1]], 0);
+            assert_eq!(ndarray[[1, 0, 0, 2]], 0);
+            assert_eq!(ndarray[[1, 50, 50, 0]], 32639);
+            assert_eq!(ndarray[[1, 50, 50, 1]], 32639);
+            assert_eq!(ndarray[[1, 50, 50, 2]], 32639);
+            assert_eq!(ndarray[[1, 75, 75, 0]], 65535);
+            assert_eq!(ndarray[[1, 75, 75, 1]], 65535);
+            assert_eq!(ndarray[[1, 75, 75, 2]], 65535);
+        }
+
+        #[rstest]
+        #[should_panic(expected = "Could not decode jpeg in frame")]
+        #[case("pydicom/emri_small_jpeg_ls_lossless.dcm", 10)] // crashes, but not sure if file is ok
+        #[case("pydicom/color3d_jpeg_baseline.dcm", 120)]
+        // TODO: figure out why slow (40s) in non release mode, maybe out of bounds checks? also very green and only first frame has a picture in it
+        #[case("pydicom/JPGLosslessP14SV1_1s_1f_8b.dcm", 1)] // Works fine
+        #[case("bscans_spec_61.dcm", 61)] // TODO: remove before finished
+        fn test_parse_jpeg_encoded_dicom_pixel_data(#[case] value: &str, #[case] frames: u16) {
+            let test_file = dicom_test_files::path(value).unwrap();
+            println!("Parsing pixel data for {}", test_file.display());
+            let obj = open_file(test_file).unwrap();
+            let pixel_data = obj.decode_pixel_data().unwrap();
+            assert_eq!(pixel_data.number_of_frames, frames);
+
+            let output_dir = Path::new(
+                "../target/dicom_test_files/_out/test_parse_jpeg_encoded_dicom_pixel_data",
+            );
+            fs::create_dir_all(output_dir).unwrap();
+
+            for i in 0..pixel_data.number_of_frames {
+                let image = pixel_data.to_dynamic_image(i).unwrap();
+                let image_path = output_dir.join(format!(
+                    "{}-{}.png",
+                    Path::new(value).file_stem().unwrap().to_str().unwrap(),
+                    i,
+                ));
+                image.save(image_path).unwrap();
+            }
         }
     }
 }

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -863,22 +863,23 @@ mod tests {
         #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.90\"")]
         #[case("pydicom/693_J2KR.dcm", 1)]
         //
-        #[case("pydicom/JPEG-LL.dcm", 1)]
-        //
-        #[should_panic(expected = "Could not create fragment to frame mapping")]
+        #[should_panic(expected = "Format(\"JPGn(7) marker found where not allowed\")")]
         #[case("pydicom/emri_small_jpeg_ls_lossless.dcm", 10)]
+        #[should_panic(expected = "Format(\"JPGn(7) marker found where not allowed\")")]
+        #[case("pydicom/MR_small_jpeg_ls_lossless.dcm", 1)]
+        //
+        #[should_panic(expected = "Unsupported(SamplePrecision(12))")]
+        #[case("pydicom/JPEG-lossy.dcm", 1)]
         //
         // works, but output is grennish
         #[case("pydicom/color3d_jpeg_baseline.dcm", 120)]
         //
         // Works fine
+        #[case("pydicom/JPEG-LL.dcm", 1)]
         #[case("pydicom/JPGLosslessP14SV1_1s_1f_8b.dcm", 1)]
         #[case("pydicom/SC_rgb_jpeg_gdcm.dcm", 1)]
         #[case("pydicom/SC_rgb_jpeg_lossy_gdcm.dcm", 1)]
-        #[case("pydicom/MR_small_jpeg_ls_lossless.dcm", 1)]
-        //
-        #[should_panic(expected = "Could not create fragment to frame mapping")]
-        #[case("pydicom/JPEG-lossy.dcm", 1)]
+
         fn test_parse_jpeg_encoded_dicom_pixel_data(#[case] value: &str, #[case] frames: u16) {
             let test_file = dicom_test_files::path(value).unwrap();
             println!("Parsing pixel data for {}", test_file.display());

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -862,7 +862,10 @@ mod tests {
         #[case("pydicom/693_J2KI.dcm", 1)]
         #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.90\"")]
         #[case("pydicom/693_J2KR.dcm", 1)]
-        #[should_panic(expected = "Format(\"JPGn(7) marker found where not allowed\")")]
+        //
+        #[case("pydicom/JPEG-LL.dcm", 1)]
+        //
+        #[should_panic(expected = "Could not create fragment to frame mapping")]
         #[case("pydicom/emri_small_jpeg_ls_lossless.dcm", 10)]
         //
         // works, but output is grennish
@@ -874,7 +877,7 @@ mod tests {
         #[case("pydicom/SC_rgb_jpeg_lossy_gdcm.dcm", 1)]
         #[case("pydicom/MR_small_jpeg_ls_lossless.dcm", 1)]
         //
-        #[should_panic(expected = "Unsupported(SamplePrecision(12)")]
+        #[should_panic(expected = "Could not create fragment to frame mapping")]
         #[case("pydicom/JPEG-lossy.dcm", 1)]
         fn test_parse_jpeg_encoded_dicom_pixel_data(#[case] value: &str, #[case] frames: u16) {
             let test_file = dicom_test_files::path(value).unwrap();

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -862,7 +862,7 @@ mod tests {
     #[case("pydicom/color3d_jpeg_baseline.dcm", 120)]
     // TODO: figure out why slow (40s) in non release mode, maybe out of bounds checks? also very green and only first frame has a picture in it
     #[case("pydicom/JPGLosslessP14SV1_1s_1f_8b.dcm", 1)] // Works fine
-    #[case("bscans_spec_61.dcm", 61)] // only first picture actually contains data, rest is black
+    #[case("bscans_spec_61.dcm", 61)] // TODO: remove before finished
     fn test_parse_jpeg_encoded_dicom_pixel_data(#[case] value: &str, #[case] frames: u16) {
         let test_file = dicom_test_files::path(value).unwrap();
         println!("Parsing pixel data for {}", test_file.display());

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -856,6 +856,8 @@ mod tests {
             assert_eq!(ndarray[[1, 75, 75, 2]], 65535);
         }
 
+        const MAX_TEST_FRAMES: u16 = 16;
+
         #[rstest]
         // jpeg2000 encoding not supported
         #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.91\"")]
@@ -894,7 +896,7 @@ mod tests {
             );
             fs::create_dir_all(output_dir).unwrap();
 
-            for i in 0..pixel_data.number_of_frames {
+            for i in 0..pixel_data.number_of_frames.min(MAX_TEST_FRAMES) {
                 let image = pixel_data.to_dynamic_image(i).unwrap();
                 let image_path = output_dir.join(format!(
                     "{}-{}.png",

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -863,15 +863,17 @@ mod tests {
         #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.90\"")]
         #[case("pydicom/693_J2KR.dcm", 1)]
         //
-        #[should_panic(expected = "Format(\"JPGn(7) marker found where not allowed\")")]
+        // jpeg-ls encoding not supported
+        #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.80\"")]
         #[case("pydicom/emri_small_jpeg_ls_lossless.dcm", 10)]
-        #[should_panic(expected = "Format(\"JPGn(7) marker found where not allowed\")")]
+        #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.80\"")]
         #[case("pydicom/MR_small_jpeg_ls_lossless.dcm", 1)]
         //
+        // sample precicion of 12 not supported
         #[should_panic(expected = "Unsupported(SamplePrecision(12))")]
         #[case("pydicom/JPEG-lossy.dcm", 1)]
         //
-        // works, but output is grennish
+        // works, but output has coloroffset to what is produced by other tools
         #[case("pydicom/color3d_jpeg_baseline.dcm", 120)]
         //
         // Works fine

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -86,7 +86,7 @@ pub enum Error {
     #[snafu(display("Missing required element"))]
     MissingRequiredField {
         #[snafu(backtrace)]
-        source: dicom_object::Error
+        source: dicom_object::Error,
     },
 
     #[snafu(display("Could not cast pixel data value"))]
@@ -96,31 +96,19 @@ pub enum Error {
     },
 
     #[snafu(display("PixelData attribute is not a primitive value or pixel sequence"))]
-    InvalidPixelData {
-        backtrace: Backtrace,
-    },
+    InvalidPixelData { backtrace: Backtrace },
 
     #[snafu(display("Invalid PixelRepresentation, must be 0 or 1"))]
-    InvalidPixelRepresentation {
-        backtrace: Backtrace,
-    },
+    InvalidPixelRepresentation { backtrace: Backtrace },
 
     #[snafu(display("Invalid BitsAllocated, must be 8 or 16"))]
-    InvalidBitsAllocated {
-        backtrace: Backtrace,
-    },
+    InvalidBitsAllocated { backtrace: Backtrace },
 
     #[snafu(display("Unsupported PhotometricInterpretation {}", pi))]
-    UnsupportedPhotometricInterpretation {
-        pi: String,
-        backtrace: Backtrace,
-    },
+    UnsupportedPhotometricInterpretation { pi: String, backtrace: Backtrace },
 
     #[snafu(display("Unsupported SamplesPerPixel {}", spp))]
-    UnsupportedSamplesPerPixel {
-        spp: u16,
-        backtrace: Backtrace,
-    },
+    UnsupportedSamplesPerPixel { spp: u16, backtrace: Backtrace },
 
     #[snafu(display("Unknown transfer syntax `{}`", ts_uid))]
     UnknownTransferSyntax {
@@ -129,20 +117,13 @@ pub enum Error {
     },
 
     #[snafu(display("Unsupported TransferSyntax {}", ts))]
-    UnsupportedTransferSyntax {
-        ts: String,
-        backtrace: Backtrace,
-    },
+    UnsupportedTransferSyntax { ts: String, backtrace: Backtrace },
 
     #[snafu(display("Multi-frame DICOM images are not supported"))]
-    UnsupportedMultiFrame {
-        backtrace: Backtrace,
-    },
+    UnsupportedMultiFrame { backtrace: Backtrace },
 
     #[snafu(display("Invalid buffer when constructing ImageBuffer"))]
-    InvalidImageBuffer {
-        backtrace: Backtrace,
-    },
+    InvalidImageBuffer { backtrace: Backtrace },
 
     #[snafu(display("Invalid shape for ndarray"))]
     InvalidShape {
@@ -151,19 +132,13 @@ pub enum Error {
     },
 
     #[snafu(display("Invalid data type for ndarray element"))]
-    InvalidDataType {
-        backtrace: Backtrace,
-    },
+    InvalidDataType { backtrace: Backtrace },
 
     #[snafu(display("Unsupported color space"))]
-    UnsupportedColorSpace {
-        backtrace: Backtrace,
-    },
+    UnsupportedColorSpace { backtrace: Backtrace },
 
     #[snafu(display("Could not decode pixel data"))]
-    DecodePixelData {
-        source: DecodeError
-    },
+    DecodePixelData { source: DecodeError },
 
     #[snafu(display("Frame #{} is out of range", frame_number))]
     FrameOutOfRange {
@@ -175,7 +150,7 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// A blob of decoded pixel data.
-/// 
+///
 /// This is the outcome of decoding a DICOM object's imaging-related attributes,
 /// into a native form.
 /// The decoded data will be stored as raw bytes in native form
@@ -228,7 +203,8 @@ impl DecodedPixelData<'_> {
                         if frame_end > (*self.data).len() {
                             FrameOutOfRangeSnafu {
                                 frame_number: frame,
-                            }.fail()?
+                            }
+                            .fail()?
                         }
                         let buffer: Vec<u8> =
                             (&self.data[(frame_start as usize..frame_end as usize)]).to_vec();
@@ -247,7 +223,8 @@ impl DecodedPixelData<'_> {
                         if frame_end > (*self.data).len() {
                             FrameOutOfRangeSnafu {
                                 frame_number: frame,
-                            }.fail()?
+                            }
+                            .fail()?
                         }
                         let mut buffer = vec![0; frame_length / 2];
                         match self.pixel_representation {
@@ -295,7 +272,8 @@ impl DecodedPixelData<'_> {
                         if frame_end > (*self.data).len() {
                             FrameOutOfRangeSnafu {
                                 frame_number: frame,
-                            }.fail()?
+                            }
+                            .fail()?
                         }
                         let mut pixel_array: Vec<u8> =
                             (&self.data[(frame_start as usize..frame_end as usize)]).to_vec();
@@ -325,7 +303,8 @@ impl DecodedPixelData<'_> {
                         if frame_end > (*self.data).len() {
                             FrameOutOfRangeSnafu {
                                 frame_number: frame,
-                            }.fail()?
+                            }
+                            .fail()?
                         }
                         let buffer: Vec<u8> =
                             (&self.data[(frame_start as usize..frame_end as usize)]).to_vec();
@@ -393,7 +372,8 @@ impl DecodedPixelData<'_> {
                         .map(|v| T::from(*v).ok_or(snafu::NoneError))
                         .collect();
                     let converted = converted.context(InvalidDataTypeSnafu)?;
-                    let ndarray = Array::from_shape_vec(shape, converted).context(InvalidShapeSnafu)?;
+                    let ndarray =
+                        Array::from_shape_vec(shape, converted).context(InvalidShapeSnafu)?;
                     Ok(ndarray)
                 }
                 // Signed 16 bit 2s complement representation
@@ -406,7 +386,8 @@ impl DecodedPixelData<'_> {
                         .map(|v| T::from(*v).ok_or(snafu::NoneError))
                         .collect();
                     let converted = converted.context(InvalidDataTypeSnafu)?;
-                    let ndarray = Array::from_shape_vec(shape, converted).context(InvalidShapeSnafu)?;
+                    let ndarray =
+                        Array::from_shape_vec(shape, converted).context(InvalidShapeSnafu)?;
                     Ok(ndarray)
                 }
                 _ => InvalidPixelRepresentationSnafu.fail()?,
@@ -532,11 +513,12 @@ where
             .with_context(|| UnknownTransferSyntaxSnafu {
                 ts_uid: transfer_syntax,
             })?;
-        
+
         if !ts.fully_supported() {
             return UnsupportedTransferSyntaxSnafu {
                 ts: transfer_syntax,
-            }.fail();
+            }
+            .fail();
         }
 
         // Try decoding it using a native Rust decoder
@@ -697,6 +679,8 @@ mod tests {
     use super::*;
     use dicom_object::open_file;
     use dicom_test_files;
+    use rstest::rstest;
+    use std::path::Path;
 
     #[test]
     fn test_to_ndarray_rgb() {
@@ -865,7 +849,9 @@ mod tests {
             .unwrap();
         let result = image.decode_pixel_data().unwrap().to_dynamic_image(1);
         match result {
-            Err(Error::FrameOutOfRange { frame_number: 1, .. }) => {}
+            Err(Error::FrameOutOfRange {
+                frame_number: 1, ..
+            }) => {}
             _ => panic!("Unexpected positive outcome for out of range access"),
         }
     }

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -857,12 +857,25 @@ mod tests {
         }
 
         #[rstest]
+        // jpeg2000 encoding not supported
+        #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.91\"")]
+        #[case("pydicom/693_J2KI.dcm", 1)]
+        #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.90\"")]
+        #[case("pydicom/693_J2KR.dcm", 1)]
         #[should_panic(expected = "Format(\"JPGn(7) marker found where not allowed\")")]
-        #[case("pydicom/emri_small_jpeg_ls_lossless.dcm", 10)] // crashes, but not sure if file is ok
+        #[case("pydicom/emri_small_jpeg_ls_lossless.dcm", 10)]
+        //
+        // works, but output is grennish
         #[case("pydicom/color3d_jpeg_baseline.dcm", 120)]
-        // TODO: figure out why slow (40s) in non release mode, maybe out of bounds checks? also very green and only first frame has a picture in it
-        #[case("pydicom/JPGLosslessP14SV1_1s_1f_8b.dcm", 1)] // Works fine
-        #[case("bscans_spec_61.dcm", 61)] // TODO: remove before finished
+        //
+        // Works fine
+        #[case("pydicom/JPGLosslessP14SV1_1s_1f_8b.dcm", 1)]
+        #[case("pydicom/SC_rgb_jpeg_gdcm.dcm", 1)]
+        #[case("pydicom/SC_rgb_jpeg_lossy_gdcm.dcm", 1)]
+        #[case("pydicom/MR_small_jpeg_ls_lossless.dcm", 1)]
+        //
+        #[should_panic(expected = "Unsupported(SamplePrecision(12)")]
+        #[case("pydicom/JPEG-lossy.dcm", 1)]
         fn test_parse_jpeg_encoded_dicom_pixel_data(#[case] value: &str, #[case] frames: u16) {
             let test_file = dicom_test_files::path(value).unwrap();
             println!("Parsing pixel data for {}", test_file.display());

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -855,4 +855,24 @@ mod tests {
             _ => panic!("Unexpected positive outcome for out of range access"),
         }
     }
+
+    #[rstest(value => [
+        "pydicom/emri_small_jpeg_ls_lossless.dcm"
+])]
+    fn test_parse_dicom_pixel_data(value: &str) {
+        let test_file = dicom_test_files::path(value).unwrap();
+        println!("Parsing pixel data for {}", test_file.display());
+        let obj = open_file(test_file).unwrap();
+        let image = obj
+            .decode_pixel_data()
+            .unwrap()
+            .to_dynamic_image(0)
+            .unwrap();
+        image
+            .save(format!(
+                "../target/dicom_test_files/pydicom/{}.png",
+                Path::new(value).file_stem().unwrap().to_str().unwrap()
+            ))
+            .unwrap();
+    }
 }

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -129,26 +129,27 @@ pub const JPEG_LS_LOSSY_IMAGE_COMPRESSION: JpegTS = create_ts_jpeg(
     "1.2.840.10008.1.2.4.81",
     "JPEG-LS Lossy (Near-Lossless) Image Compression",
 );
+
+// --- partially supported transfer syntaxes, pixel data encapsulation not supported ---
+
 /// **Stub descriptor:** JPEG 2000 Image Compression (Lossless Only)
-pub const JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: JpegTS = create_ts_jpeg(
+pub const JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.90",
     "JPEG 2000 Image Compression (Lossless Only)",
 );
 /// **Stub descriptor:** JPEG 2000 Image Compression
-pub const JPEG_2000_IMAGE_COMPRESSION: JpegTS =
-    create_ts_jpeg("1.2.840.10008.1.2.4.91", "JPEG 2000 Image Compression");
+pub const JPEG_2000_IMAGE_COMPRESSION: Ts =
+    create_ts_stub("1.2.840.10008.1.2.4.91", "JPEG 2000 Image Compression");
 /// **Stub descriptor:** JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)
-pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION_LOSSLESS_ONLY: JpegTS = create_ts_jpeg(
+pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.92",
     "JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)",
 );
 /// **Stub descriptor:** JPEG 2000 Part 2 Multi-component Image Compression
-pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION: JpegTS = create_ts_jpeg(
+pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.93",
     "JPEG 2000 Part 2 Multi-component Image Compression",
 );
-
-// --- partially supported transfer syntaxes, pixel data encapsulation not supported ---
 
 /// **Stub descriptor:** JPIP Referenced
 pub const JPIP_REFERENCED: Ts = create_ts_stub("1.2.840.10008.1.2.4.94", "JPIP Referenced");

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -20,6 +20,7 @@
 use crate::create_ts_stub;
 use byteordered::Endianness;
 use dicom_encoding::{
+    adapters::jpeg::JPEGAdapter,
     adapters::rle_lossless::RLELosslessAdapter,
     transfer_syntax::{AdapterFreeTransferSyntax as Ts, Codec, NeverAdapter},
     TransferSyntax,
@@ -85,53 +86,70 @@ pub const JPIP_REFERENCED_DEFLATE: Ts = Ts::new(
     Codec::Unsupported,
 );
 
-// --- partially supported transfer syntaxes, pixel data encapsulation not supported ---
+// JPEG encoded pixel data
+/// An alias for a transfer syntax specifier with JPEGPixelAdapter
+pub type JpegTS = TransferSyntax<NeverAdapter, JPEGAdapter>;
+
+/// create a TS with jpeg encapsulation
+const fn create_ts_jpeg(uid: &'static str, name: &'static str) -> JpegTS {
+    TransferSyntax::new(
+        uid,
+        name,
+        Endianness::Little,
+        true,
+        Codec::PixelData(JPEGAdapter),
+    )
+}
 
 /// **Stub descriptor:** JPEG Baseline (Process 1): Default Transfer Syntax for Lossy JPEG 8 Bit Image Compression
-pub const JPEG_BASELINE: Ts = create_ts_stub("1.2.840.10008.1.2.4.50", "JPEG Baseline (Process 1)");
+pub const JPEG_BASELINE: JpegTS =
+    create_ts_jpeg("1.2.840.10008.1.2.4.50", "JPEG Baseline (Process 1)");
 /// **Stub descriptor:** JPEG Extended (Process 2 & 4): Default Transfer Syntax for Lossy JPEG 12 Bit Image Compression (Process 4 only)
-pub const JPEG_EXTENDED: Ts =
-    create_ts_stub("1.2.840.10008.1.2.4.51", "JPEG Extended (Process 2 & 4)");
+pub const JPEG_EXTENDED: JpegTS =
+    create_ts_jpeg("1.2.840.10008.1.2.4.51", "JPEG Extended (Process 2 & 4)");
 /// **Stub descriptor:** JPEG Lossless, Non-Hierarchical (Process 14)
-pub const JPEG_LOSSLESS_NON_HIERARCHICAL: Ts = create_ts_stub(
+pub const JPEG_LOSSLESS_NON_HIERARCHICAL: JpegTS = create_ts_jpeg(
     "1.2.840.10008.1.2.4.57",
     "JPEG Lossless, Non-Hierarchical (Process 14)",
 );
 /// **Stub descriptor:** JPEG Lossless, Non-Hierarchical, First-Order Prediction
 /// (Process 14 [Selection Value 1]):
 /// Default Transfer Syntax for Lossless JPEG Image Compression
-pub const JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION: Ts = create_ts_stub(
+pub const JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION: JpegTS = create_ts_jpeg(
     "1.2.840.10008.1.2.4.70",
     "JPEG Lossless, Non-Hierarchical, First-Order Prediction",
 );
 /// **Stub descriptor:** JPEG-LS Lossless Image Compression
-pub const JPEG_LS_LOSSLESS_IMAGE_COMPRESSION: Ts = create_ts_stub(
+pub const JPEG_LS_LOSSLESS_IMAGE_COMPRESSION: JpegTS = create_ts_jpeg(
     "1.2.840.10008.1.2.4.80",
     "JPEG-LS Lossless Image Compression",
 );
 /// **Stub descriptor:** JPEG-LS Lossy (Near-Lossless) Image Compression
-pub const JPEG_LS_LOSSY_IMAGE_COMPRESSION: Ts = create_ts_stub(
+pub const JPEG_LS_LOSSY_IMAGE_COMPRESSION: JpegTS = create_ts_jpeg(
     "1.2.840.10008.1.2.4.81",
     "JPEG-LS Lossy (Near-Lossless) Image Compression",
 );
 /// **Stub descriptor:** JPEG 2000 Image Compression (Lossless Only)
-pub const JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
+pub const JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: JpegTS = create_ts_jpeg(
     "1.2.840.10008.1.2.4.90",
     "JPEG 2000 Image Compression (Lossless Only)",
 );
 /// **Stub descriptor:** JPEG 2000 Image Compression
-pub const JPEG_2000_IMAGE_COMPRESSION: Ts =
-    create_ts_stub("1.2.840.10008.1.2.4.91", "JPEG 2000 Image Compression");
+pub const JPEG_2000_IMAGE_COMPRESSION: JpegTS =
+    create_ts_jpeg("1.2.840.10008.1.2.4.91", "JPEG 2000 Image Compression");
 /// **Stub descriptor:** JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)
-pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
+pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION_LOSSLESS_ONLY: JpegTS = create_ts_jpeg(
     "1.2.840.10008.1.2.4.92",
     "JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)",
 );
 /// **Stub descriptor:** JPEG 2000 Part 2 Multi-component Image Compression
-pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION: Ts = create_ts_stub(
+pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION: JpegTS = create_ts_jpeg(
     "1.2.840.10008.1.2.4.93",
     "JPEG 2000 Part 2 Multi-component Image Compression",
 );
+
+// --- partially supported transfer syntaxes, pixel data encapsulation not supported ---
+
 /// **Stub descriptor:** JPIP Referenced
 pub const JPIP_REFERENCED: Ts = create_ts_stub("1.2.840.10008.1.2.4.94", "JPIP Referenced");
 

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -119,18 +119,18 @@ pub const JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION: JpegTS = create
     "1.2.840.10008.1.2.4.70",
     "JPEG Lossless, Non-Hierarchical, First-Order Prediction",
 );
+
+// --- partially supported transfer syntaxes, pixel data encapsulation not supported ---
 /// **Stub descriptor:** JPEG-LS Lossless Image Compression
-pub const JPEG_LS_LOSSLESS_IMAGE_COMPRESSION: JpegTS = create_ts_jpeg(
+pub const JPEG_LS_LOSSLESS_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.80",
     "JPEG-LS Lossless Image Compression",
 );
 /// **Stub descriptor:** JPEG-LS Lossy (Near-Lossless) Image Compression
-pub const JPEG_LS_LOSSY_IMAGE_COMPRESSION: JpegTS = create_ts_jpeg(
+pub const JPEG_LS_LOSSY_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.81",
     "JPEG-LS Lossy (Near-Lossless) Image Compression",
 );
-
-// --- partially supported transfer syntaxes, pixel data encapsulation not supported ---
 
 /// **Stub descriptor:** JPEG 2000 Image Compression (Lossless Only)
 pub const JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(


### PR DESCRIPTION
Provides jpeg decoding for single and multiframe dicoms. Also supports frames distributed onto multiple fragments.

Still to tackle:
- [x] Multiframe images only show up with 'data' on the first frame, rest is empty
- [x] remove untested jpeg encoder settings in tranfer syntax
- [x] change test so it writes pics to dedicated out dir (so there are no clashes between tests)
- [x] make snafu context error on jpeg parsing work
- [x] implement parsing of frames split into multiple fragments
- [x] ~~color offset (lots of green in one test case~~ Might be related to some other issue. not sure that it can be handled in decoder
- [x] ~~Slow in non release mode (maybe some bounds checks?)~~ Should not be fault of jpeg decoder
