### PR TITLE
Adjust photometric interpretation of decoded pixel data

### DIFF
--- a/encoding/src/adapters/mod.rs
+++ b/encoding/src/adapters/mod.rs
@@ -151,10 +151,12 @@ pub trait PixelRWAdapter {
     ///
     /// The output is a sequence of native pixel values
     /// which follow the image properties of the given object
-    /// _save for the photometric interpretation_.
+    /// _save for the photometric interpretation and planar configuration_.
     /// The output of an image with 1 sample per pixel
     /// is expected to be interpreted as `MONOCHROME2`,
-    /// and for a 3-channel images, the output must be in RGB.
+    /// and for 3-channel images,
+    /// the output must be in RGB with each pixel contiguous in memory
+    /// (planar configuration of 0).
     fn decode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> DecodeResult<()>;
 
     /// Encode a DICOM object's image into the format supported by this adapter,

--- a/encoding/src/adapters/mod.rs
+++ b/encoding/src/adapters/mod.rs
@@ -141,7 +141,8 @@ impl EncodeOptions {
 pub trait PixelRWAdapter {
     /// Decode the given DICOM object
     /// containing encapsulated pixel data
-    /// into native pixel data as a byte stream.
+    /// into native pixel data as a byte stream in little endian,
+    /// resizing the given vector `dst` to contain exactly these bytes.
     ///
     /// It is a necessary precondition that the object's pixel data
     /// is encoded in accordance to the transfer syntax(es)
@@ -149,8 +150,11 @@ pub trait PixelRWAdapter {
     /// A `NotEncapsulated` error is returned otherwise.
     ///
     /// The output is a sequence of native pixel values
-    /// which follow the image properties of the given object.
-    ///
+    /// which follow the image properties of the given object
+    /// _save for the photometric interpretation_.
+    /// The output of an image with 1 sample per pixel
+    /// is expected to be interpreted as `MONOCHROME2`,
+    /// and for a 3-channel images, the output must be in RGB.
     fn decode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> DecodeResult<()>;
 
     /// Encode a DICOM object's image into the format supported by this adapter,

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -89,13 +89,22 @@ where
             Value::Sequence { items: _, size: _ } => InvalidPixelDataSnafu.fail()?,
         };
 
+        // pixels are already interpreted,
+        // set new photometric interpretation
+        let new_pi = match samples_per_pixel {
+            1 => "MONOCHROME2".to_owned(),
+            3 => "RGB".to_owned(),
+            _ => photometric_interpretation,
+        };
+
         Ok(DecodedPixelData {
             data: Cow::from(decoded_pixel_data),
             cols: cols.into(),
             rows: rows.into(),
             number_of_frames,
-            photometric_interpretation,
+            photometric_interpretation: new_pi,
             samples_per_pixel,
+            planar_configuration: 0,
             bits_allocated,
             bits_stored,
             high_bit,

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -573,7 +573,7 @@ where
                 number_of_frames,
                 photometric_interpretation: new_pi,
                 samples_per_pixel,
-                planar_configuration,
+                planar_configuration: 0,
                 bits_allocated,
                 bits_stored,
                 high_bit,

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -157,6 +157,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// without any LUT transformations applied.
 /// Whether to apply such transformations
 /// can be done through one of the various `to_*` methods.
+#[derive(Debug)]
 pub struct DecodedPixelData<'a> {
     /// the raw bytes of pixel data
     pub data: Cow<'a, [u8]>,

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -927,7 +927,7 @@ mod tests {
         // works fine
         #[case("pydicom/color3d_jpeg_baseline.dcm", 120)]
         //
-        // wWorks fine
+        // works fine
         #[case("pydicom/JPEG-LL.dcm", 1)]
         #[case("pydicom/JPGLosslessP14SV1_1s_1f_8b.dcm", 1)]
         #[case("pydicom/SC_rgb_jpeg_gdcm.dcm", 1)]

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -528,12 +528,20 @@ where
                 .decode(self, &mut data)
                 .context(DecodePixelDataSnafu)?;
 
+            // pixels are already interpreted,
+            // set new photometric interpretation
+            let new_pi = match samples_per_pixel {
+                1 => "MONOCHROME2".to_owned(),
+                3 => "RGB".to_owned(),
+                _ => photometric_interpretation,
+            };
+
             return Ok(DecodedPixelData {
                 data: Cow::from(data),
                 cols: cols.into(),
                 rows: rows.into(),
                 number_of_frames,
-                photometric_interpretation,
+                photometric_interpretation: new_pi,
                 samples_per_pixel,
                 bits_allocated,
                 bits_stored,


### PR DESCRIPTION
When using native pixel data adapters, the result of decoding should always be in MONOCHROME2 or RGB, regardless of the original encoding. This tweaks `pixeldata` so that certain color space conversions are not performed redundantly.