### PR TITLE
Use patched version of dicom-test-files

### DIFF
--- a/object/Cargo.toml
+++ b/object/Cargo.toml
@@ -26,5 +26,10 @@ smallvec = "1.6.1"
 snafu = "0.7.0"
 
 [dev-dependencies]
-dicom-test-files = "0.2.0"
 tempfile = "3.2.0"
+
+# Patch version fixes shakyness in tests which use DICOM test files,
+# can be updated once https://github.com/robyoung/dicom-test-files/pull/2 is merged
+[dev-dependencies.dicom-test-files]
+git = "https://github.com/Enet4/dicom-test-files"
+branch = "patch-1"

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -26,8 +26,13 @@ ndarray-stats = "0.5"
 num-traits = "0.2.12"
 
 [dev-dependencies]
-dicom-test-files = "0.2.0"
 rstest = "0.10.0"
+
+# Patch version fixes shakyness in tests which use DICOM test files,
+# can be updated once https://github.com/robyoung/dicom-test-files/pull/2 is merged
+[dev-dependencies.dicom-test-files]
+git = "https://github.com/Enet4/dicom-test-files"
+branch = "patch-1"
 
 [features]
 default = []


### PR DESCRIPTION
This should fix the shakiness of test in this repository until a new version of the `dicom-test-files` is released with robyoung/dicom-test-files#2.