### PR TITLE
Implement support for multiframe image decoding via gdcm

### DIFF
--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -18,7 +18,7 @@ dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry", version
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.5.0" }
 snafu = "0.7.0"
 byteorder = "1.4.3"
-gdcm-rs = { version = "0.3.0", optional = true }
+gdcm-rs = { version = "0.4.0", optional = true }
 rayon = "1.5.0"
 ndarray = "0.15.1"
 ndarray-stats = "0.5"

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -103,11 +103,7 @@ where
             }
             Value::Primitive(p) => {
                 // Non-encoded, just return the pixel data of the first frame
-                let total_bytes = rows as usize
-                    * cols as usize
-                    * samples_per_pixel as usize
-                    * (bits_allocated as usize / 8);
-                p.to_bytes()[0..total_bytes].to_vec()
+                p.to_bytes().to_vec()
             }
             Value::Sequence { items: _, size: _ } => InvalidPixelDataSnafu.fail()?,
         };

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -163,9 +163,6 @@ pub enum InnerError {
     #[snafu(display("Unsupported TransferSyntax `{}`", ts))]
     UnsupportedTransferSyntax { ts: String, backtrace: Backtrace },
 
-    #[snafu(display("Multi-frame DICOM images are not supported"))]
-    UnsupportedMultiFrame { backtrace: Backtrace },
-
     #[snafu(display("Invalid buffer when constructing ImageBuffer"))]
     InvalidImageBuffer { backtrace: Backtrace },
 


### PR DESCRIPTION
this is mostly done to test https://github.com/pevers/gdcm-rs/pull/7 for now and maybe get some visibility on how to improve it right away.

Does not crash but for the 2 test files I added it either produces black images or images with 'bad' colors.