### PR TITLE
[pixeldata] pixel data conversion options + LUT transformations

### DIFF
--- a/encoding/src/adapters/mod.rs
+++ b/encoding/src/adapters/mod.rs
@@ -11,16 +11,16 @@ pub mod rle_lossless;
 #[non_exhaustive]
 pub enum DecodeError {
     /// A custom error occurred when decoding,
-    /// reported as a dynamic error value
-    #[snafu(display("Error decoding pixel data"))]
+    /// reported as a dynamic error value with a message.
+    /// 
+    /// The [`whatever!`](snafu::whatever) macro can be used
+    /// to easily create an error of this kind.
+    #[snafu(whatever, display("Error decoding pixel data: {}", message))]
     Custom {
-        source: Box<dyn std::error::Error + Send + 'static>,
+        message: String,
+        #[snafu(source(from(Box<dyn std::error::Error + Send + 'static>, Some)))]
+        source: Option<Box<dyn std::error::Error + Send + 'static>>,
     },
-
-    /// A custom error occurred when decoding,
-    /// reported as a static message
-    #[snafu(display("Error decoding pixel data: {}", message))]
-    CustomMessage { message: &'static str },
 
     /// Input pixel data is not encapsulated
     NotEncapsulated,

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -1,6 +1,7 @@
 //! Utility module for fetching key attributes from a DICOM object.
 
-use dicom_core::DataDictionary;
+use dicom_core::{DataDictionary, Tag};
+use dicom_dictionary_std::tags;
 use dicom_object::{mem::InMemElement, FileDicomObject, InMemDicomObject};
 use snafu::{Backtrace, ResultExt, Snafu};
 
@@ -13,10 +14,17 @@ pub enum GetAttributeError {
         source: dicom_object::Error,
     },
 
-    #[snafu(display("Could not convert attribute `{}`", name))]
+    #[snafu(display("Could not get attribute `{}`", name))]
     CastValue {
         name: &'static str,
         source: dicom_core::value::CastValueError,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Could not convert attribute `{}`", name))]
+    ConvertValue {
+        name: &'static str,
+        source: dicom_core::value::ConvertValueError,
         backtrace: Backtrace,
     },
 }
@@ -25,18 +33,12 @@ pub type Result<T, E = GetAttributeError> = std::result::Result<T, E>;
 
 /// Get the Columns from the DICOM object
 pub fn cols<D: DataDictionary + Clone>(obj: &FileDicomObject<InMemDicomObject<D>>) -> Result<u16> {
-    obj.element(dicom_dictionary_std::tags::COLUMNS)
-        .context(MissingRequiredFieldSnafu { name: "Columns" })?
-        .uint16()
-        .context(CastValueSnafu { name: "Columns" })
+    retrieve_required_u16(obj, tags::COLUMNS, "Columns")
 }
 
 /// Get the Rows from the DICOM object
 pub fn rows<D: DataDictionary + Clone>(obj: &FileDicomObject<InMemDicomObject<D>>) -> Result<u16> {
-    obj.element(dicom_dictionary_std::tags::ROWS)
-        .context(MissingRequiredFieldSnafu { name: "Rows" })?
-        .uint16()
-        .context(CastValueSnafu { name: "Rows" })
+    retrieve_required_u16(obj, tags::ROWS, "Rows")
 }
 
 /// Get the PhotoMetricInterpretation from the DICOM object
@@ -44,7 +46,7 @@ pub fn photometric_interpretation<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> Result<String> {
     Ok(obj
-        .element(dicom_dictionary_std::tags::PHOTOMETRIC_INTERPRETATION)
+        .element(tags::PHOTOMETRIC_INTERPRETATION)
         .context(MissingRequiredFieldSnafu {
             name: "PhotometricInterpretation",
         })?
@@ -60,14 +62,7 @@ pub fn photometric_interpretation<D: DataDictionary + Clone>(
 pub fn samples_per_pixel<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> Result<u16> {
-    obj.element(dicom_dictionary_std::tags::SAMPLES_PER_PIXEL)
-        .context(MissingRequiredFieldSnafu {
-            name: "SamplesPerPixel",
-        })?
-        .uint16()
-        .context(CastValueSnafu {
-            name: "SamplesPerPixel",
-        })
+    retrieve_required_u16(obj, tags::SAMPLES_PER_PIXEL, "SamplesPerPixel")
 }
 
 /// Get the PlanarConfiguration from the DICOM object, returning 0 by default
@@ -75,7 +70,7 @@ pub fn samples_per_pixel<D: DataDictionary + Clone>(
 pub fn planar_configuration<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> u16 {
-    obj.element(dicom_dictionary_std::tags::PLANAR_CONFIGURATION)
+    obj.element(tags::PLANAR_CONFIGURATION)
         .map_or(Ok(0), |e| e.to_int())
         .unwrap_or(0)
 }
@@ -84,55 +79,35 @@ pub fn planar_configuration<D: DataDictionary + Clone>(
 pub fn bits_allocated<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> Result<u16> {
-    obj.element(dicom_dictionary_std::tags::BITS_ALLOCATED)
-        .context(MissingRequiredFieldSnafu {
-            name: "BitsAllocated",
-        })?
-        .uint16()
-        .context(CastValueSnafu {
-            name: "BitsAllocated",
-        })
+    retrieve_required_u16(obj, tags::BITS_ALLOCATED, "BitsAllocated")
 }
 
 /// Get the BitsStored from the DICOM object
 pub fn bits_stored<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> Result<u16> {
-    obj.element(dicom_dictionary_std::tags::BITS_STORED)
-        .context(MissingRequiredFieldSnafu { name: "BitsStored" })?
-        .uint16()
-        .context(CastValueSnafu { name: "BitsStored" })
+    retrieve_required_u16(obj, tags::BITS_STORED, "BitsStored")
 }
 
 /// Get the HighBit from the DICOM object
 pub fn high_bit<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> Result<u16> {
-    obj.element(dicom_dictionary_std::tags::HIGH_BIT)
-        .context(MissingRequiredFieldSnafu { name: "HighBit" })?
-        .uint16()
-        .context(CastValueSnafu { name: "HighBit" })
+    retrieve_required_u16(obj, tags::HIGH_BIT, "HighBit")
 }
 
 /// Get the PixelRepresentation from the DICOM object
 pub fn pixel_representation<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> Result<u16> {
-    obj.element(dicom_dictionary_std::tags::PIXEL_REPRESENTATION)
-        .context(MissingRequiredFieldSnafu {
-            name: "PixelRepresentation",
-        })?
-        .uint16()
-        .context(CastValueSnafu {
-            name: "PixelRepresentation",
-        })
+    retrieve_required_u16(obj, tags::PIXEL_REPRESENTATION, "PixelRepresentation")
 }
 
 /// Get the PixelData element from the DICOM object
 pub fn pixel_data<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> Result<&InMemElement<D>> {
-    obj.element(dicom_dictionary_std::tags::PIXEL_DATA)
+    obj.element(tags::PIXEL_DATA)
         .context(MissingRequiredFieldSnafu { name: "PixelData" })
 }
 
@@ -140,14 +115,14 @@ pub fn pixel_data<D: DataDictionary + Clone>(
 pub fn rescale_intercept<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> i16 {
-    obj.element(dicom_dictionary_std::tags::RESCALE_INTERCEPT)
+    obj.element(tags::RESCALE_INTERCEPT)
         .map_or(Ok(0), |e| e.to_int())
         .unwrap_or(0)
 }
 
 /// Get the RescaleSlope from the DICOM object or returns 1.0
 pub fn rescale_slope<D: DataDictionary + Clone>(obj: &FileDicomObject<InMemDicomObject<D>>) -> f32 {
-    obj.element(dicom_dictionary_std::tags::RESCALE_SLOPE)
+    obj.element(tags::RESCALE_SLOPE)
         .map_or(Ok(1.0), |e| e.to_float32())
         .unwrap_or(1.0)
 }
@@ -156,7 +131,56 @@ pub fn rescale_slope<D: DataDictionary + Clone>(obj: &FileDicomObject<InMemDicom
 pub fn number_of_frames<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> u16 {
-    obj.element(dicom_dictionary_std::tags::NUMBER_OF_FRAMES)
+    obj.element(tags::NUMBER_OF_FRAMES)
         .map_or(Ok(1), |e| e.to_int())
         .unwrap_or(1)
+}
+
+/// Retrieve the WindowCenter from the DICOM object if it exists.
+pub fn window_center<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<Option<f64>> {
+    retrieve_optional_to_f64(obj, tags::WINDOW_CENTER, "WindowCenter")
+}
+
+/// Retrieve the WindowWidth from the DICOM object if it exists.
+pub fn window_width<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<Option<f64>> {
+    retrieve_optional_to_f64(obj, tags::WINDOW_WIDTH, "WindowWidth")
+}
+
+#[inline]
+fn retrieve_required_u16<D>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    tag: Tag,
+    name: &'static str,
+) -> Result<u16>
+where
+    D: DataDictionary + Clone,
+{
+    obj.element(tag)
+        .context(MissingRequiredFieldSnafu { name })?
+        .uint16()
+        .context(CastValueSnafu { name })
+}
+
+#[inline]
+fn retrieve_optional_to_f64<D>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    tag: Tag,
+    name: &'static str,
+) -> Result<Option<f64>>
+where
+    D: DataDictionary + Clone,
+{
+    let elem = match obj.element(tag) {
+        Ok(e) => e,
+        Err(dicom_object::Error::NoSuchDataElementTag { .. }) => return Ok(None),
+        Err(e) => return Err(e).context(MissingRequiredFieldSnafu { name }),
+    };
+
+    elem.to_float64()
+        .context(ConvertValueSnafu { name })
+        .map(Some)
 }

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -127,13 +127,6 @@ pub fn high_bit<D: DataDictionary + Clone>(
     retrieve_required_u16(obj, tags::HIGH_BIT, "HighBit")
 }
 
-/// Get the PixelRepresentation from the DICOM object
-pub fn pixel_representation<D: DataDictionary + Clone>(
-    obj: &FileDicomObject<InMemDicomObject<D>>,
-) -> Result<u16> {
-    retrieve_required_u16(obj, tags::PIXEL_REPRESENTATION, "PixelRepresentation")
-}
-
 /// Get the PixelData element from the DICOM object
 pub fn pixel_data<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
@@ -235,4 +228,30 @@ where
     elem.to_float64()
         .context(ConvertValueSnafu { name })
         .map(Some)
+}
+
+/// An interpreted representation of the DICOM _Pixel Representation_ attribute.
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+pub enum PixelRepresentation {
+    /// unsigned pixel data sample values
+    Unsigned,
+    /// signed pixel data sample values
+    Signed,
+}
+
+/// Get the PixelRepresentation from the DICOM object
+pub fn pixel_representation<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<PixelRepresentation> {
+    let p = retrieve_required_u16(obj, tags::PIXEL_REPRESENTATION, "PixelRepresentation")?;
+
+    match p {
+        0 => Ok(PixelRepresentation::Unsigned),
+        1 => Ok(PixelRepresentation::Signed),
+        _ => InvalidValueSnafu {
+            name: "PixelRepresentation",
+            value: p.to_string(),
+        }
+        .fail(),
+    }
 }

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -340,6 +340,19 @@ pub enum PhotometricInterpretation {
     /// one luminance (Y) and two chrominance planes (CB and CR).
     YbrRct,
     /// The photometric interpretation is not one of the known variants.
+    /// 
+    /// **Note:** this value is assumed to be different from
+    /// any other variant listed above,
+    /// and no checks are made to ensure this assumption.
+    /// The construction of `PhotometricInterpretation::Other`
+    /// when one of the existing variants is applicable
+    /// is considered a bug.
+    /// 
+    /// **Note 2:** subsequent crate versions may introduce new variants,
+    /// and as a consequence break any user depending on the `Other` variant.
+    /// If you need to depend on an unspecified variant,
+    /// you should also double check the photometric interpretations here
+    /// every time the crate is updated.
     Other(String),
 }
 
@@ -347,6 +360,17 @@ impl PhotometricInterpretation {
     /// Obtain a string representation of the photometric interpretation.
     pub fn as_str(&self) -> &str {
         self.as_ref()
+    }
+
+    /// Get whether this photometric interpretation is
+    /// one of the monochrome variants
+    /// (`MONOCHROME1` or `MONOCHROME2`).
+    pub fn is_monochrome(&self) -> bool {
+        match self {
+            PhotometricInterpretation::Monochrome1
+            | PhotometricInterpretation::Monochrome2 => true,
+            _ => false,
+        }
     }
 }
 

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -1,0 +1,162 @@
+//! Utility module for fetching key attributes from a DICOM object.
+
+use dicom_core::DataDictionary;
+use dicom_object::{mem::InMemElement, FileDicomObject, InMemDicomObject};
+use snafu::{Backtrace, ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum GetAttributeError {
+    #[snafu(display("Missing required attribute `{}`", name))]
+    MissingRequiredField {
+        name: &'static str,
+        #[snafu(backtrace)]
+        source: dicom_object::Error,
+    },
+
+    #[snafu(display("Could not convert attribute `{}`", name))]
+    CastValue {
+        name: &'static str,
+        source: dicom_core::value::CastValueError,
+        backtrace: Backtrace,
+    },
+}
+
+pub type Result<T, E = GetAttributeError> = std::result::Result<T, E>;
+
+/// Get the Columns from the DICOM object
+pub fn cols<D: DataDictionary + Clone>(obj: &FileDicomObject<InMemDicomObject<D>>) -> Result<u16> {
+    obj.element(dicom_dictionary_std::tags::COLUMNS)
+        .context(MissingRequiredFieldSnafu { name: "Columns" })?
+        .uint16()
+        .context(CastValueSnafu { name: "Columns" })
+}
+
+/// Get the Rows from the DICOM object
+pub fn rows<D: DataDictionary + Clone>(obj: &FileDicomObject<InMemDicomObject<D>>) -> Result<u16> {
+    obj.element(dicom_dictionary_std::tags::ROWS)
+        .context(MissingRequiredFieldSnafu { name: "Rows" })?
+        .uint16()
+        .context(CastValueSnafu { name: "Rows" })
+}
+
+/// Get the PhotoMetricInterpretation from the DICOM object
+pub fn photometric_interpretation<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<String> {
+    Ok(obj
+        .element(dicom_dictionary_std::tags::PHOTOMETRIC_INTERPRETATION)
+        .context(MissingRequiredFieldSnafu {
+            name: "PhotometricInterpretation",
+        })?
+        .string()
+        .context(CastValueSnafu {
+            name: "PhotometricInterpretation",
+        })?
+        .trim()
+        .to_string())
+}
+
+/// Get the SamplesPerPixel from the DICOM object
+pub fn samples_per_pixel<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<u16> {
+    obj.element(dicom_dictionary_std::tags::SAMPLES_PER_PIXEL)
+        .context(MissingRequiredFieldSnafu {
+            name: "SamplesPerPixel",
+        })?
+        .uint16()
+        .context(CastValueSnafu {
+            name: "SamplesPerPixel",
+        })
+}
+
+/// Get the PlanarConfiguration from the DICOM object, returning 0 by default
+#[cfg(not(feature = "gdcm"))]
+pub fn planar_configuration<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> u16 {
+    obj.element(dicom_dictionary_std::tags::PLANAR_CONFIGURATION)
+        .map_or(Ok(0), |e| e.to_int())
+        .unwrap_or(0)
+}
+
+/// Get the BitsAllocated from the DICOM object
+pub fn bits_allocated<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<u16> {
+    obj.element(dicom_dictionary_std::tags::BITS_ALLOCATED)
+        .context(MissingRequiredFieldSnafu {
+            name: "BitsAllocated",
+        })?
+        .uint16()
+        .context(CastValueSnafu {
+            name: "BitsAllocated",
+        })
+}
+
+/// Get the BitsStored from the DICOM object
+pub fn bits_stored<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<u16> {
+    obj.element(dicom_dictionary_std::tags::BITS_STORED)
+        .context(MissingRequiredFieldSnafu { name: "BitsStored" })?
+        .uint16()
+        .context(CastValueSnafu { name: "BitsStored" })
+}
+
+/// Get the HighBit from the DICOM object
+pub fn high_bit<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<u16> {
+    obj.element(dicom_dictionary_std::tags::HIGH_BIT)
+        .context(MissingRequiredFieldSnafu { name: "HighBit" })?
+        .uint16()
+        .context(CastValueSnafu { name: "HighBit" })
+}
+
+/// Get the PixelRepresentation from the DICOM object
+pub fn pixel_representation<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<u16> {
+    obj.element(dicom_dictionary_std::tags::PIXEL_REPRESENTATION)
+        .context(MissingRequiredFieldSnafu {
+            name: "PixelRepresentation",
+        })?
+        .uint16()
+        .context(CastValueSnafu {
+            name: "PixelRepresentation",
+        })
+}
+
+/// Get the PixelData element from the DICOM object
+pub fn pixel_data<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<&InMemElement<D>> {
+    obj.element(dicom_dictionary_std::tags::PIXEL_DATA)
+        .context(MissingRequiredFieldSnafu { name: "PixelData" })
+}
+
+/// Get the RescaleIntercept from the DICOM object or returns 0
+pub fn rescale_intercept<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> i16 {
+    obj.element(dicom_dictionary_std::tags::RESCALE_INTERCEPT)
+        .map_or(Ok(0), |e| e.to_int())
+        .unwrap_or(0)
+}
+
+/// Get the RescaleSlope from the DICOM object or returns 1.0
+pub fn rescale_slope<D: DataDictionary + Clone>(obj: &FileDicomObject<InMemDicomObject<D>>) -> f32 {
+    obj.element(dicom_dictionary_std::tags::RESCALE_SLOPE)
+        .map_or(Ok(1.0), |e| e.to_float32())
+        .unwrap_or(1.0)
+}
+
+/// Get the NumberOfFrames from the DICOM object or returns 1
+pub fn number_of_frames<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> u16 {
+    obj.element(dicom_dictionary_std::tags::NUMBER_OF_FRAMES)
+        .map_or(Ok(1), |e| e.to_int())
+        .unwrap_or(1)
+}

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -145,16 +145,16 @@ pub fn pixel_data<D: DataDictionary + Clone>(
 /// Get the RescaleIntercept from the DICOM object or returns 0
 pub fn rescale_intercept<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
-) -> i16 {
+) -> f64 {
     obj.element(tags::RESCALE_INTERCEPT)
-        .map_or(Ok(0), |e| e.to_int())
-        .unwrap_or(0)
+        .map_or(Ok(0.), |e| e.to_float64())
+        .unwrap_or(0.)
 }
 
 /// Get the RescaleSlope from the DICOM object or returns 1.0
-pub fn rescale_slope<D: DataDictionary + Clone>(obj: &FileDicomObject<InMemDicomObject<D>>) -> f32 {
+pub fn rescale_slope<D: DataDictionary + Clone>(obj: &FileDicomObject<InMemDicomObject<D>>) -> f64 {
     obj.element(tags::RESCALE_SLOPE)
-        .map_or(Ok(1.0), |e| e.to_float32())
+        .map_or(Ok(1.0), |e| e.to_float64())
         .unwrap_or(1.0)
 }
 

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -58,6 +58,30 @@ pub fn photometric_interpretation<D: DataDictionary + Clone>(
         .to_string())
 }
 
+/// Get the VOILUTFunction from the DICOM object
+pub fn voi_lut_function<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<Option<String>> {
+    let elem = match obj.element(tags::VOILUT_FUNCTION) {
+        Ok(e) => e,
+        Err(dicom_object::Error::NoSuchDataElementTag { .. }) => return Ok(None),
+        Err(e) => {
+            return Err(e).context(MissingRequiredFieldSnafu {
+                name: "VOILUTFunction",
+            })
+        }
+    };
+
+    let value = elem
+        .string()
+        .context(CastValueSnafu {
+            name: "VOILUTFunction",
+        })?
+        .trim()
+        .to_string();
+    Ok(Some(value))
+}
+
 /// Get the SamplesPerPixel from the DICOM object
 pub fn samples_per_pixel<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -12,13 +12,13 @@ where
     D: DataDictionary + Clone,
 {
     fn decode_pixel_data(&self) -> Result<DecodedPixelData> {
-        let pixel_data = self
-            .element(dicom_dictionary_std::tags::PIXEL_DATA)
-            .context(MissingRequiredFieldSnafu)?;
-        let cols = cols(self)?;
-        let rows = rows(self)?;
+        use super::attribute::*;
 
-        let photometric_interpretation = photometric_interpretation(self)?;
+        let pixel_data = pixel_data(self).context(GetAttributeSnafu)?;
+        let cols = cols(self).context(GetAttributeSnafu)?;
+        let rows = rows(self).context(GetAttributeSnafu)?;
+
+        let photometric_interpretation = photometric_interpretation(self).context(GetAttributeSnafu)?;
         let pi_type = GDCMPhotometricInterpretation::from_str(&photometric_interpretation)
             .map_err(|_| {
                 UnsupportedPhotometricInterpretationSnafu {
@@ -41,11 +41,11 @@ where
             .build()
         })?;
 
-        let samples_per_pixel = samples_per_pixel(self)?;
-        let bits_allocated = bits_allocated(self)?;
-        let bits_stored = bits_stored(self)?;
-        let high_bit = high_bit(self)?;
-        let pixel_representation = pixel_representation(self)?;
+        let samples_per_pixel = samples_per_pixel(self).context(GetAttributeSnafu)?;
+        let bits_allocated = bits_allocated(self).context(GetAttributeSnafu)?;
+        let bits_stored = bits_stored(self).context(GetAttributeSnafu)?;
+        let high_bit = high_bit(self).context(GetAttributeSnafu)?;
+        let pixel_representation = pixel_representation(self).context(GetAttributeSnafu)?;
         let rescale_intercept = rescale_intercept(self);
         let rescale_slope = rescale_slope(self);
         let number_of_frames = number_of_frames(self);

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -98,6 +98,17 @@ where
             _ => photometric_interpretation,
         };
 
+        let window = if let Some(window_center) = window_center(self).context(GetAttributeSnafu)? {
+            let window_width = window_width(self).context(GetAttributeSnafu)?;
+
+            window_width.map(|width| WindowLevel {
+                center: window_center,
+                width,
+            })
+        } else {
+            None
+        };
+
         Ok(DecodedPixelData {
             data: Cow::from(decoded_pixel_data),
             cols: cols.into(),
@@ -112,6 +123,7 @@ where
             pixel_representation,
             rescale_intercept,
             rescale_slope,
+            window,
         })
     }
 }

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -19,8 +19,9 @@ where
         let cols = cols(self).context(GetAttributeSnafu)?;
         let rows = rows(self).context(GetAttributeSnafu)?;
 
-        let photometric_interpretation = photometric_interpretation(self).context(GetAttributeSnafu)?;
-        let pi_type = GDCMPhotometricInterpretation::from_str(&photometric_interpretation)
+        let photometric_interpretation =
+            photometric_interpretation(self).context(GetAttributeSnafu)?;
+        let pi_type = GDCMPhotometricInterpretation::from_str(photometric_interpretation.as_str())
             .map_err(|_| {
                 UnsupportedPhotometricInterpretationSnafu {
                     pi: photometric_interpretation.clone(),
@@ -72,7 +73,7 @@ where
                     bits_allocated,
                     bits_stored,
                     high_bit,
-                    pixel_representation,
+                    pixel_representation as u16,
                 )
                 .map_err(|source| Error::DecodePixelData {
                     source: DecodeError::Custom {
@@ -96,8 +97,8 @@ where
         // pixels are already interpreted,
         // set new photometric interpretation
         let new_pi = match samples_per_pixel {
-            1 => "MONOCHROME2".to_owned(),
-            3 => "RGB".to_owned(),
+            1 => PhotometricInterpretation::Monochrome2,
+            3 => PhotometricInterpretation::Rgb,
             _ => photometric_interpretation,
         };
 
@@ -119,7 +120,7 @@ where
             number_of_frames,
             photometric_interpretation: new_pi,
             samples_per_pixel,
-            planar_configuration: 0,
+            planar_configuration: PlanarConfiguration::Standard,
             bits_allocated,
             bits_stored,
             high_bit,

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -196,13 +196,15 @@ mod tests {
     }
 
     #[test]
-    fn test_to_ndarray_signed_word() {
+    fn test_to_ndarray_signed_word_no_lut() {
         let test_file = dicom_test_files::path("pydicom/JPEG2000.dcm").unwrap();
         let obj = open_file(test_file).unwrap();
+        let options = ConvertOptions::new()
+            .with_modality_lut(ModalityLutOption::None);
         let ndarray = obj
             .decode_pixel_data()
             .unwrap()
-            .to_ndarray::<i16>()
+            .to_ndarray_with_options::<i16>(&options)
             .unwrap();
         assert_eq!(ndarray.shape(), &[1, 1024, 256, 1]);
         assert_eq!(ndarray.len(), 262144);

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -75,7 +75,7 @@ where
                     high_bit,
                     pixel_representation as u16,
                 )
-                .map_err(|source| Error::DecodePixelData {
+                .map_err(|source| InnerError::DecodePixelData {
                     source: DecodeError::Custom {
                         message: "Could not decode frame via GDCM".to_string(),
                         source: Some(Box::new(source) as Box<_>),

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -73,7 +73,8 @@ where
                 )
                 .map_err(|source| Error::DecodePixelData {
                     source: DecodeError::Custom {
-                        source: Box::new(source) as Box<_>,
+                        message: "Could not decode frame via GDCM".to_string(),
+                        source: Some(Box::new(source) as Box<_>),
                     },
                 })?;
                 decoded_frame.to_vec()

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -110,7 +110,7 @@ pub use image;
 pub use ndarray;
 
 mod attribute;
-pub mod lut;
+mod lut;
 
 pub(crate) mod transform;
 

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -486,8 +486,8 @@ impl DecodedPixelData<'_> {
 
     /// Retrieves the number of samples per pixel.
     #[inline]
-    pub fn samples_per_pixel(&self) -> u32 {
-        self.cols
+    pub fn samples_per_pixel(&self) -> u16 {
+        self.samples_per_pixel
     }
 
     /// Retrieve the number of bits effectively used for each sample.
@@ -1626,6 +1626,38 @@ mod tests {
         let obj = open_file(test_file).unwrap();
         let pixel_data = obj.decode_pixel_data().unwrap();
         assert_eq!(pixel_data.rescale(), Rescale::new(1., 0.));
+    }
+
+    #[test]
+    fn test_general_properties_from_16bit() {
+        let test_file = dicom_test_files::path("pydicom/CT_small.dcm").unwrap();
+        let obj = open_file(test_file).unwrap();
+        let pixel_data = obj.decode_pixel_data().unwrap();
+
+        assert_eq!(pixel_data.columns(), 128, "Unexpected Columns");
+        assert_eq!(pixel_data.rows(), 128, "Unexpected Rows");
+        assert_eq!(
+            pixel_data.number_of_frames(),
+            1,
+            "Unexpected Number of Frames"
+        );
+        assert_eq!(
+            pixel_data.photometric_interpretation(),
+            &PhotometricInterpretation::Monochrome2,
+            "Unexpected Photometric Interpretation"
+        );
+        assert_eq!(
+            pixel_data.samples_per_pixel(),
+            1,
+            "Unexpected Samples per Pixel"
+        );
+        assert_eq!(pixel_data.bits_allocated(), 16, "Unexpected Bits Allocated");
+        assert_eq!(pixel_data.bits_stored(), 16, "Unexpected Bits Stored");
+        assert_eq!(pixel_data.high_bit(), 15, "Unexpected High Bit");
+        assert_eq!(
+            pixel_data.pixel_representation(),
+            PixelRepresentation::Signed
+        );
     }
 
     #[test]

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -74,7 +74,6 @@ use rayon::iter::{
 use snafu::{ensure, OptionExt};
 use snafu::{Backtrace, ResultExt, Snafu};
 use std::borrow::Cow;
-use std::convert::TryFrom;
 
 pub use image;
 pub use ndarray;
@@ -862,6 +861,7 @@ where
 {
     fn decode_pixel_data(&self) -> Result<DecodedPixelData> {
         use attribute::*;
+        use std::convert::TryFrom;
 
         let pixel_data = pixel_data(self).context(GetAttributeSnafu)?;
         let cols = cols(self).context(GetAttributeSnafu)?;

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -2,7 +2,6 @@
 //! responsible for decoding various forms of native and compressed pixel data,
 //! such as JPEG lossless,
 //! and convert it into more usable data structures.
-//! 
 //!
 //! `dicom-pixeldata` currently supports a small,
 //! but increasing number of DICOM image encodings in pure Rust.
@@ -23,10 +22,10 @@
 //! - a vector of flat pixel data values;
 //! - a [multi-dimensional array](ndarray::Array), using [`ndarray`];
 //! - or a [dynamic image object](image::DynamicImage), using [`image`].
-//! 
+//!
 //! This conversion includes
 //! eventual Modality and value of interest (VOI) transformations.
-//! 
+//!
 //! # WebAssembly support
 //! This library works in WebAssembly
 //! by ensuring that the "gdcm" feature is disabled.
@@ -63,10 +62,10 @@
 //! # Ok(())
 //! # }
 //! ```
-//! 
+//!
 //! In order to parameterize the conversion,
 //! pass a conversion options valueto the `_with_options` variant methods.
-//! 
+//!
 //! ```no_run
 //! # use std::error::Error;
 //! use dicom_object::open_file;
@@ -81,10 +80,10 @@
 //! # Ok(())
 //! # }
 //! ```
-//! 
+//!
 //! See [`ConvertOptions`] for the options available,
 //! including the default behavior for each method.
-//! 
+//!
 
 use byteorder::{ByteOrder, NativeEndian};
 use dicom_core::{value::Value, DataDictionary};
@@ -205,7 +204,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Option set for converting decoded pixel data
 /// into other common data structures,
 /// such as a vector, an image, or a multidimensional array.
-/// 
+///
 /// Each option listed affects the transformation in this order:
 /// 1. The Modality LUT function (`modality_lut`)
 ///    is applied to the raw pixel data sample values.
@@ -254,7 +253,7 @@ impl ConvertOptions {
     }
 
     /// Set the output bit depth option to force 8 bits.
-    /// 
+    ///
     /// This is equivalent to `self.with_bit_depth(BitDepthOption::Force8Bit)`.
     pub fn force_8bit(mut self) -> Self {
         self.bit_depth = BitDepthOption::Force8Bit;
@@ -262,7 +261,7 @@ impl ConvertOptions {
     }
 
     /// Set the output bit depth option to force 16 bits.
-    /// 
+    ///
     /// This is equivalent to `self.with_bit_depth(BitDepthOption::Force16Bit)`.
     pub fn force_16bit(mut self) -> Self {
         self.bit_depth = BitDepthOption::Force16Bit;
@@ -1600,6 +1599,7 @@ mod tests {
         assert_eq!(ndarray[[0, 50, 80, 1]], 32896);
     }
 
+    /// to_ndarray fails if the target type cannot represent the transformed values
     #[test]
     fn test_to_ndarray_error() {
         let test_file = dicom_test_files::path("pydicom/CT_small.dcm").unwrap();
@@ -1668,7 +1668,8 @@ mod tests {
 
         // original image has 16 bits stored
         {
-            let image = pixel_data.to_dynamic_image(0)
+            let image = pixel_data
+                .to_dynamic_image(0)
                 .expect("Failed to convert to image");
 
             assert!(image.as_luma16().is_some());
@@ -1677,7 +1678,8 @@ mod tests {
         // force to 16 bits
         {
             let options = ConvertOptions::new().force_16bit();
-            let image = pixel_data.to_dynamic_image_with_options(0, &options)
+            let image = pixel_data
+                .to_dynamic_image_with_options(0, &options)
                 .expect("Failed to convert to image");
 
             assert!(image.as_luma16().is_some());
@@ -1686,7 +1688,8 @@ mod tests {
         // force to 8 bits
         {
             let options = ConvertOptions::new().force_8bit();
-            let image = pixel_data.to_dynamic_image_with_options(0, &options)
+            let image = pixel_data
+                .to_dynamic_image_with_options(0, &options)
                 .expect("Failed to convert to image");
 
             assert!(image.as_luma8().is_some());
@@ -1701,7 +1704,8 @@ mod tests {
 
         // original image is RGB with 8 bits per sample
         {
-            let image = pixel_data.to_dynamic_image(0)
+            let image = pixel_data
+                .to_dynamic_image(0)
                 .expect("Failed to convert to image");
 
             assert!(image.as_rgb8().is_some());
@@ -1710,7 +1714,8 @@ mod tests {
         // force to 16 bits
         {
             let options = ConvertOptions::new().force_16bit();
-            let image = pixel_data.to_dynamic_image_with_options(0, &options)
+            let image = pixel_data
+                .to_dynamic_image_with_options(0, &options)
                 .expect("Failed to convert to image");
 
             assert!(image.as_rgb16().is_some());
@@ -1719,7 +1724,8 @@ mod tests {
         // force to 8 bits
         {
             let options = ConvertOptions::new().force_8bit();
-            let image = pixel_data.to_dynamic_image_with_options(0, &options)
+            let image = pixel_data
+                .to_dynamic_image_with_options(0, &options)
                 .expect("Failed to convert to image");
 
             assert!(image.as_rgb8().is_some());

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -291,6 +291,7 @@ impl DecodedPixelData<'_> {
 
     /// Retrieve a slice of all raw pixel data samples as bytes,
     /// irrespective of the expected size of each sample.
+    #[inline]
     pub fn data(&self) -> &[u8] {
         &self.data
     }
@@ -402,6 +403,7 @@ impl DecodedPixelData<'_> {
     }
 
     /// Retrieve the VOI LUT function defined by the object, if any.
+    #[inline]
     pub fn voi_lut_function(&self) -> Option<VoiLutFunction> {
         self.voi_lut_function
     }

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -66,7 +66,6 @@ use dicom_object::{FileDicomObject, InMemDicomObject};
 #[cfg(not(feature = "gdcm"))]
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use image::{DynamicImage, ImageBuffer, Luma, Rgb};
-use lut::Lut;
 use ndarray::{Array, IxDyn};
 use num_traits::NumCast;
 use rayon::iter::{
@@ -85,6 +84,8 @@ pub mod lut;
 
 pub(crate) mod transform;
 
+// re-exports
+pub use lut::Lut;
 pub use transform::{Rescale, VoiLutFunction, WindowLevel, WindowLevelTransform};
 
 #[cfg(feature = "gdcm")]

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -259,7 +259,7 @@ pub struct DecodedPixelData<'a> {
     /// the number of columns
     pub cols: u32,
     /// the number of frames
-    pub number_of_frames: u16,
+    pub number_of_frames: u32,
     /// the photometric interpretation
     pub photometric_interpretation: String,
     /// the number of samples per pixel
@@ -295,7 +295,7 @@ impl DecodedPixelData<'_> {
     /// followed by a normalization of grayscale values.
     /// To change this behavior,
     /// see [`to_dynamic_image_with_options`].
-    pub fn to_dynamic_image(&self, frame: u16) -> Result<DynamicImage> {
+    pub fn to_dynamic_image(&self, frame: u32) -> Result<DynamicImage> {
         self.to_dynamic_image_with_options(frame, &Options::default())
     }
 
@@ -328,7 +328,7 @@ impl DecodedPixelData<'_> {
     /// ```
     pub fn to_dynamic_image_with_options(
         &self,
-        frame: u16,
+        frame: u32,
         options: &Options,
     ) -> Result<DynamicImage> {
         match self.samples_per_pixel {
@@ -417,7 +417,7 @@ impl DecodedPixelData<'_> {
         }
     }
 
-    fn build_monochrome_image(&self, frame: u16, options: &Options) -> Result<DynamicImage> {
+    fn build_monochrome_image(&self, frame: u32, options: &Options) -> Result<DynamicImage> {
         let Options {
             modality_lut,
             voi_lut,
@@ -1097,7 +1097,7 @@ mod tests {
             assert_eq!(ndarray[[1, 75, 75, 2]], 65535);
         }
 
-        const MAX_TEST_FRAMES: u16 = 16;
+        const MAX_TEST_FRAMES: u32 = 16;
 
         #[rstest]
         // jpeg2000 encoding not supported
@@ -1125,7 +1125,7 @@ mod tests {
         #[case("pydicom/SC_rgb_jpeg_gdcm.dcm", 1)]
         #[case("pydicom/SC_rgb_jpeg_lossy_gdcm.dcm", 1)]
 
-        fn test_parse_jpeg_encoded_dicom_pixel_data(#[case] value: &str, #[case] frames: u16) {
+        fn test_parse_jpeg_encoded_dicom_pixel_data(#[case] value: &str, #[case] frames: u32) {
             let test_file = dicom_test_files::path(value).unwrap();
             println!("Parsing pixel data for {}", test_file.display());
             let obj = open_file(test_file).unwrap();

--- a/pixeldata/src/lut.rs
+++ b/pixeldata/src/lut.rs
@@ -1,0 +1,279 @@
+//! Look-up table (LUT) implementation and transformation functions.
+//!
+//! This module contains the [`Lut`] data type,
+//! designed to turn pixel data native sample values
+//! (as encoded in the _Pixel Data_ attribute)
+//! into displayable or otherwise more meaningful values.
+//!
+//! The type also provides easy-to-use constructor functions
+//! for common DICOM sample value transformations.
+
+use num_traits::{AsPrimitive, NumCast};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+use crate::{Rescale, WindowLevelTransform};
+
+/// A look up table for pixel data sample value transformations.
+///
+/// # Example
+///
+/// The LUT can be populated with common transformations
+/// via the functions [`new_rescale`](Lut::new_rescale),
+/// [`new_rescale_and_normalize`](Lut::new_rescale_and_normalize),
+/// and [`new_rescale_and_window`](Lut::new_rescale_and_window).
+///
+/// ```
+/// # use dicom_pixeldata::{
+/// #     lut::{Lut, Rescale, VoiLutFunction, WindowLevelTransform},
+/// #     WindowLevel
+/// # };
+/// let bits_stored = 8;
+/// let lut = Lut::new_rescale_and_window(
+///     bits_stored,
+///     false,
+///     Rescale::new(1., -1024.),
+///     WindowLevelTransform::new(
+///         VoiLutFunction::Linear,
+///         WindowLevel {
+///             width: 300.,
+///             center: 50.
+///         }
+///     ),
+/// );
+///
+/// let val: u8 = lut.get(100_u8);
+/// ```
+#[derive(Debug)]
+pub struct Lut<T> {
+    /// the table which maps an index to a transformed value,
+    /// of size 2 to the power of `bits_stored`
+    table: Vec<T>,
+    /// whether the input sample values are signed (Pixel Representation = 1)
+    signed: bool,
+}
+
+impl<T: 'static> Lut<T>
+where
+    T: NumCast,
+    T: Copy,
+    T: Send + Sync,
+    f64: AsPrimitive<T>,
+{
+    /// Create a new LUT with the given characteristics
+    /// and populates it with the outputs of the provided function.
+    /// The function may be called concurrently.
+    ///
+    /// - `bits_stored`:
+    ///   the number of bits effectively used to represent the sample values
+    ///   (the _Bits Stored_ DICOM attribute)
+    /// - `signed`:
+    ///   whether the input sample values are expected to be signed
+    ///   (_Pixel Representation_ = 1)
+    /// - `f`: the mapping function
+    pub fn new_with_fn(bits_stored: u16, signed: bool, f: impl Fn(f64) -> f64 + Sync) -> Self {
+        let size = (1 << bits_stored as u32) as usize;
+        debug_assert!(size.is_power_of_two());
+
+        let table = (0..size)
+            .into_par_iter()
+            .map(|i| {
+                // account for signedness to determine input pixel value
+                let x = if signed && i >= size / 2 {
+                    i as f64 - size as f64
+                } else {
+                    i as f64
+                };
+                let v = f(x);
+                v.as_()
+            })
+            .collect();
+        Self { table, signed }
+    }
+
+    /// Create a new LUT containing only the modality rescale transformation.
+    ///
+    /// - `bits_stored`:
+    ///   the number of bits effectively used to represent the sample values
+    ///   (the _Bits Stored_ DICOM attribute)
+    /// - `signed`:
+    ///   whether the input sample values are expected to be signed
+    ///   (_Pixel Representation_ = 1)
+    /// - `rescale`: the rescale parameters
+    pub fn new_rescale(bits_stored: u16, signed: bool, rescale: Rescale) -> Self {
+        Self::new_with_fn(bits_stored, signed, |v| rescale.apply(v))
+    }
+
+    /// Create a new LUT containing the modality rescale transformation
+    /// and a min-max normalization.
+    ///
+    /// The minimum and maximum values expected from the input data
+    /// need to be calculated in advance.
+    ///
+    /// - `bits_stored`:
+    ///   the number of bits effectively used to represent the sample values
+    ///   (the _Bits Stored_ DICOM attribute)
+    /// - `signed`:
+    ///   whether the input sample values are expected to be signed
+    ///   (_Pixel Representation_ = 1)
+    /// - `rescale`: the rescale parameters
+    pub fn new_rescale_and_normalize(
+        bits_stored: u16,
+        signed: bool,
+        rescale: Rescale,
+        min_v: f64,
+        max_v: f64,
+    ) -> Self {
+        let size = (1 << bits_stored as u32) as usize;
+        debug_assert!(size.is_power_of_two());
+        Self::new_with_fn(bits_stored, signed, |v| {
+            let x = rescale.apply(v as f64);
+            let range = max_v - min_v;
+            (x - min_v) * (size - 1) as f64 / range
+        })
+    }
+
+    /// Create a new LUT containing the modality rescale transformation
+    /// and the VOI transformation defined by a window level.
+    ///
+    /// - `bits_stored`:
+    ///   the number of bits effectively used to represent the sample values
+    ///   (the _Bits Stored_ DICOM attribute)
+    /// - `signed`:
+    ///   whether the input sample values are expected to be signed
+    ///   (_Pixel Representation_ = 1)
+    /// - `rescale`: the rescale parameters
+    /// - `voi`: the value of interest (VOI) function and parameters
+    pub fn new_rescale_and_window(
+        bits_stored: u16,
+        signed: bool,
+        rescale: Rescale,
+        voi: WindowLevelTransform,
+    ) -> Self {
+        let y_max = ((1 << (bits_stored as usize)) - 1) as f64;
+        Self::new_with_fn(bits_stored, signed, |v| {
+            let x = v as f64;
+            let v = rescale.apply(x);
+            voi.apply(v, y_max)
+        })
+    }
+
+    /// Apply the transformation to a single pixel sample value.
+    ///
+    /// Although the input is expected to be one of `u8`, `u16`, or `u32`,
+    /// this method works for signed sample values as well,
+    /// with the bits reinterpreted as their unsigned counterpart.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `sample_value` is larger or equal to `2^bits_stored`.
+    pub fn get<I: 'static>(&self, sample_value: I) -> T
+    where
+        I: Copy,
+        I: Into<u32>,
+    {
+        let val = sample_value.into();
+        let index = if self.signed {
+            // adjust for signedness by masking out the extra sign bits
+            let mask = self.table.len() - 1;
+            val as usize & mask
+        } else {
+            val as usize
+        };
+        assert!((index as usize) < self.table.len());
+
+        self.table[index as usize]
+    }
+
+    /// Adapts an iterator of pixel data sample values
+    /// to an iterator of transformed values.
+    pub fn map_iter<'a, I: 'static>(
+        &'a self,
+        iter: impl IntoIterator<Item = I> + 'a,
+    ) -> impl Iterator<Item = T> + 'a
+    where
+        I: Copy,
+        I: Into<u32>,
+    {
+        iter.into_iter().map(move |i| self.get(i))
+    }
+
+    /// Adapts a parallel iterator of pixel data sample values
+    /// to a parallel iterator of transformed values.
+    pub fn map_par_iter<'a, I: 'static>(
+        &'a self,
+        iter: impl ParallelIterator<Item = I> + 'a,
+    ) -> impl ParallelIterator<Item = T> + 'a
+    where
+        I: Copy,
+        I: Into<u32>,
+    {
+        iter.map(move |i| self.get(i))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{VoiLutFunction, WindowLevel};
+
+    use super::*;
+
+    /// Applying a common rescale function to a value
+    /// gives the expected output.
+    #[test]
+    fn modality_lut_baseline_2() {
+        let rescale = Rescale::new(2., -1024.);
+
+        assert_eq!(rescale.apply(0.), -1024.);
+        assert_eq!(rescale.apply(1.), -1022.);
+        assert_eq!(rescale.apply(2.), -1020.);
+        assert_eq!(rescale.apply(1024.), 1024.);
+    }
+
+    #[test]
+    fn lut_signed_numbers() {
+        // 10-bit precision input, signed output
+        let lut: Lut<i16> = Lut::new_rescale(10, true, Rescale::new(2., -1024.));
+
+        assert_eq!(lut.get(0 as u16), -1024);
+        assert_eq!(lut.get(1 as u16), -1022);
+        assert_eq!(lut.get(-1_i16 as u16), -1026);
+        assert_eq!(lut.get(-2_i16 as u16), -1028);
+        assert_eq!(lut.get(500 as u16), -24);
+    }
+
+    #[test]
+    fn lut_rescale_and_window_16bit() {
+        let bits_stored = 16;
+        let lut = Lut::new_rescale_and_window(
+            bits_stored,
+            false,
+            Rescale::new(1., -1024.),
+            WindowLevelTransform::new(
+                VoiLutFunction::Linear,
+                WindowLevel {
+                    width: 300.,
+                    center: 50.,
+                },
+            ),
+        );
+
+        // < 0
+        let val: u16 = lut.get(824_u16);
+        assert_eq!(val, 0);
+
+        // > 200
+        let val: u16 = lut.get(1224_u16);
+        assert_eq!(val, 65535);
+
+        // around the middle
+
+        let val: u16 = lut.get(1024_u16 + 50);
+        let expected_range = 32_500 ..= 33_000;
+        assert!(
+            expected_range.contains(&val),
+            "outcome was {}, expected to be in {:?}",
+            val,
+            expected_range,
+        );
+    }
+}

--- a/pixeldata/src/lut.rs
+++ b/pixeldata/src/lut.rs
@@ -40,8 +40,10 @@ impl CreateLutError {
 ///
 /// The LUT can be populated with common transformations
 /// via the functions [`new_rescale`](Lut::new_rescale),
-/// [`new_rescale_and_normalize`](Lut::new_rescale_and_normalize),
+/// [`new_window`](Lut::new_window),
 /// and [`new_rescale_and_window`](Lut::new_rescale_and_window).
+/// The function [`new_with_fn`](Lut::new_with_fn)
+/// can be used to create a LUT with a custom function.
 ///
 /// ```
 /// # use dicom_pixeldata::{

--- a/pixeldata/src/lut.rs
+++ b/pixeldata/src/lut.rs
@@ -8,7 +8,7 @@
 //! The type also provides easy-to-use constructor functions
 //! for common DICOM sample value transformations.
 
-use num_traits::{AsPrimitive, NumCast};
+use num_traits::NumCast;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::{Rescale, WindowLevelTransform};
@@ -56,7 +56,6 @@ where
     T: NumCast,
     T: Copy,
     T: Send + Sync,
-    f64: AsPrimitive<T>,
 {
     /// Create a new LUT with the given characteristics
     /// and populates it with the outputs of the provided function.
@@ -83,7 +82,7 @@ where
                     i as f64
                 };
                 let v = f(x);
-                v.as_()
+                T::from(v).unwrap_or_else(|| T::from(0_f64).unwrap())
             })
             .collect();
         Self { table, signed }

--- a/pixeldata/src/lut.rs
+++ b/pixeldata/src/lut.rs
@@ -24,8 +24,7 @@ use crate::{Rescale, WindowLevelTransform};
 ///
 /// ```
 /// # use dicom_pixeldata::{
-/// #     lut::{Lut, Rescale, VoiLutFunction, WindowLevelTransform},
-/// #     WindowLevel
+/// #     Lut, Rescale, VoiLutFunction, WindowLevel, WindowLevelTransform,
 /// # };
 /// let bits_stored = 8;
 /// let lut = Lut::new_rescale_and_window(
@@ -268,7 +267,7 @@ mod tests {
         // around the middle
 
         let val: u16 = lut.get(1024_u16 + 50);
-        let expected_range = 32_500 ..= 33_000;
+        let expected_range = 32_500..=33_000;
         assert!(
             expected_range.contains(&val),
             "outcome was {}, expected to be in {:?}",

--- a/pixeldata/src/lut.rs
+++ b/pixeldata/src/lut.rs
@@ -8,10 +8,31 @@
 //! The type also provides easy-to-use constructor functions
 //! for common DICOM sample value transformations.
 
-use num_traits::NumCast;
+use num_traits::{NumCast, ToPrimitive};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use snafu::{OptionExt, Snafu};
 
 use crate::{Rescale, WindowLevelTransform};
+
+/// The LUT could not be created:
+/// entry #{index} was mapped to {y_value},
+/// which could not be cast to the target type.
+#[derive(Debug, PartialEq, Snafu)]
+pub struct CreateLutError {
+    index: usize,
+    y_value: f64,
+}
+
+impl CreateLutError {
+    /// Get the original index in the LUT.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+    /// Get the value which could not be converted to the target type.
+    pub fn y_value(&self) -> f64 {
+        self.y_value
+    }
+}
 
 /// A look up table for pixel data sample value transformations.
 ///
@@ -24,7 +45,8 @@ use crate::{Rescale, WindowLevelTransform};
 ///
 /// ```
 /// # use dicom_pixeldata::{
-/// #     Lut, Rescale, VoiLutFunction, WindowLevel, WindowLevelTransform,
+/// #     CreateLutError, Lut, Rescale, VoiLutFunction,
+/// #     WindowLevel, WindowLevelTransform,
 /// # };
 /// let bits_stored = 8;
 /// let lut = Lut::new_rescale_and_window(
@@ -38,9 +60,10 @@ use crate::{Rescale, WindowLevelTransform};
 ///             center: 50.
 ///         }
 ///     ),
-/// );
+/// )?;
 ///
 /// let val: u8 = lut.get(100_u8);
+/// # Result::<(), CreateLutError>::Ok(())
 /// ```
 #[derive(Debug)]
 pub struct Lut<T> {
@@ -68,11 +91,15 @@ where
     ///   whether the input sample values are expected to be signed
     ///   (_Pixel Representation_ = 1)
     /// - `f`: the mapping function
-    pub fn new_with_fn(bits_stored: u16, signed: bool, f: impl Fn(f64) -> f64 + Sync) -> Self {
+    pub fn new_with_fn(
+        bits_stored: u16,
+        signed: bool,
+        f: impl Fn(f64) -> f64 + Sync,
+    ) -> Result<Self, CreateLutError> {
         let size = (1 << bits_stored as u32) as usize;
         debug_assert!(size.is_power_of_two());
 
-        let table = (0..size)
+        let table: Result<Vec<_>, _> = (0..size)
             .into_par_iter()
             .map(|i| {
                 // account for signedness to determine input pixel value
@@ -81,11 +108,17 @@ where
                 } else {
                     i as f64
                 };
-                let v = f(x);
-                T::from(v).unwrap_or_else(|| T::from(0_f64).unwrap())
+                let value = f(x);
+                T::from(value).context(CreateLutSnafu {
+                    index: i,
+                    y_value: value,
+                })
             })
             .collect();
-        Self { table, signed }
+        Ok(Self {
+            table: table?,
+            signed,
+        })
     }
 
     /// Create a new LUT containing only the modality rescale transformation.
@@ -97,15 +130,19 @@ where
     ///   whether the input sample values are expected to be signed
     ///   (_Pixel Representation_ = 1)
     /// - `rescale`: the rescale parameters
-    pub fn new_rescale(bits_stored: u16, signed: bool, rescale: Rescale) -> Self {
+    pub fn new_rescale(
+        bits_stored: u16,
+        signed: bool,
+        rescale: Rescale,
+    ) -> Result<Self, CreateLutError> {
         Self::new_with_fn(bits_stored, signed, |v| rescale.apply(v))
     }
 
-    /// Create a new LUT containing the modality rescale transformation
-    /// and a min-max normalization.
-    ///
-    /// The minimum and maximum values expected from the input data
-    /// need to be calculated in advance.
+    /// Create a new LUT containing the given modality rescale transformation
+    /// and a min-max normalization
+    /// which satisfies the raw samples given.
+    /// The sample type `I` is expected to be either `u8` or `u16`,
+    /// even if the sample is meant to be interpreted as signed.
     ///
     /// - `bits_stored`:
     ///   the number of bits effectively used to represent the sample values
@@ -114,20 +151,39 @@ where
     ///   whether the input sample values are expected to be signed
     ///   (_Pixel Representation_ = 1)
     /// - `rescale`: the rescale parameters
-    pub fn new_rescale_and_normalize(
+    /// - `samples`: the raw pixel data samples expected to be fed to the LUT
+    pub(crate) fn new_rescale_and_normalize<I>(
         bits_stored: u16,
         signed: bool,
         rescale: Rescale,
-        min_v: f64,
-        max_v: f64,
-    ) -> Self {
-        let size = (1 << bits_stored as u32) as usize;
-        debug_assert!(size.is_power_of_two());
-        Self::new_with_fn(bits_stored, signed, |v| {
-            let x = rescale.apply(v as f64);
-            let range = max_v - min_v;
-            (x - min_v) * (size - 1) as f64 / range
-        })
+        samples: I,
+    ) -> Result<Self, CreateLutError>
+    where
+        I: IntoIterator,
+        I: Clone,
+        I::IntoIter: Clone,
+        I::Item: Clone,
+        I::Item: NumCast,
+        I::Item: ToPrimitive,
+    {
+        let samples_f64 = samples.into_iter().filter_map(|v| v.to_f64());
+        let min: f64 = samples_f64.clone().fold(f64::MAX, |a, b| a.min(b));
+        let max: f64 = samples_f64.fold(f64::MIN, |a, b| a.max(b));
+
+        // convert to f64 and swap if negative slope
+        let (min, max) = if rescale.slope < 0. {
+            (max, min)
+        } else {
+            (min, max)
+        };
+
+        // create a linear window level transform
+        let voi = WindowLevelTransform::linear(crate::WindowLevel {
+            width: max - min,
+            center: min + max / 2.,
+        });
+
+        Self::new_rescale_and_window(bits_stored, signed, rescale, voi)
     }
 
     /// Create a new LUT containing the modality rescale transformation
@@ -146,13 +202,32 @@ where
         signed: bool,
         rescale: Rescale,
         voi: WindowLevelTransform,
-    ) -> Self {
+    ) -> Result<Self, CreateLutError> {
         let y_max = ((1 << (bits_stored as usize)) - 1) as f64;
         Self::new_with_fn(bits_stored, signed, |v| {
             let x = v as f64;
             let v = rescale.apply(x);
             voi.apply(v, y_max)
         })
+    }
+
+    /// Create a new LUT containing
+    /// a VOI transformation defined by a window level.
+    ///
+    /// - `bits_stored`:
+    ///   the number of bits effectively used to represent the sample values
+    ///   (the _Bits Stored_ DICOM attribute)
+    /// - `signed`:
+    ///   whether the input sample values are expected to be signed
+    ///   (_Pixel Representation_ = 1)
+    /// - `voi`: the value of interest (VOI) function and parameters
+    pub fn new_window(
+        bits_stored: u16,
+        signed: bool,
+        voi: WindowLevelTransform,
+    ) -> Result<Self, CreateLutError> {
+        let y_max = ((1 << (bits_stored as usize)) - 1) as f64;
+        Self::new_with_fn(bits_stored, signed, |v| voi.apply(v as f64, y_max))
     }
 
     /// Apply the transformation to a single pixel sample value.
@@ -230,7 +305,7 @@ mod tests {
     #[test]
     fn lut_signed_numbers() {
         // 10-bit precision input, signed output
-        let lut: Lut<i16> = Lut::new_rescale(10, true, Rescale::new(2., -1024.));
+        let lut: Lut<i16> = Lut::new_rescale(10, true, Rescale::new(2., -1024.)).unwrap();
 
         assert_eq!(lut.get(0 as u16), -1024);
         assert_eq!(lut.get(1 as u16), -1022);
@@ -253,7 +328,8 @@ mod tests {
                     center: 50.,
                 },
             ),
-        );
+        )
+        .unwrap();
 
         // < 0
         let val: u16 = lut.get(824_u16);

--- a/pixeldata/src/transform.rs
+++ b/pixeldata/src/transform.rs
@@ -1,0 +1,273 @@
+//! Private module for pixel sample value transformation functions.
+
+use snafu::Snafu;
+
+/// Description of a modality rescale function,
+/// defined by a _rescale slope_ and _rescale intercept_.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Rescale {
+    /// the rescale slope
+    pub slope: f64,
+    /// the rescale intercept
+    pub intercept: f64,
+}
+
+impl Rescale {
+    /// Create a new rescale function.
+    #[inline]
+    pub fn new(slope: f64, intercept: f64) -> Self {
+        Rescale { slope, intercept }
+    }
+
+    /// Apply the rescale function to a value.
+    #[inline]
+    pub fn apply(&self, value: f64) -> f64 {
+        self.slope * value + self.intercept
+    }
+}
+
+/// A known DICOM Value of Interest (VOI) LUT function descriptor.
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+pub enum VoiLutFunction {
+    /// LINEAR
+    Linear,
+    /// LINEAR_EXACT
+    LinearExact,
+    /// SIGMOID
+    Sigmoid,
+}
+
+/// Unrecognized VOI LUT function name
+#[derive(Debug, Copy, Clone, PartialEq, Snafu)]
+pub struct FromVoiLutFunctionError {
+    _private: (),
+}
+
+impl std::convert::TryFrom<&str> for VoiLutFunction {
+    type Error = FromVoiLutFunctionError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "LINEAR" => Ok(Self::Linear),
+            "LINEAR_EXACT" => Ok(Self::LinearExact),
+            "SIGMOID" => Ok(Self::Sigmoid),
+            _ => Err(FromVoiLutFunctionError { _private: () }),
+        }
+    }
+}
+
+impl Default for VoiLutFunction {
+    fn default() -> Self {
+        VoiLutFunction::Linear
+    }
+}
+
+/// The parameters of a single window level
+/// for a VOI LUT transformation,
+/// comprising the window center and the window width.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct WindowLevel {
+    /// The _Window Width_.
+    ///
+    /// Should be greater than 0
+    pub width: f64,
+    /// The _Window Center_.
+    pub center: f64,
+}
+
+/// A full description of a VOI LUT function transformation
+/// based on a window level.
+#[derive(Debug, PartialEq)]
+pub struct WindowLevelTransform {
+    voi_lut_function: VoiLutFunction,
+    window_level: WindowLevel,
+}
+
+impl WindowLevelTransform {
+    /// Create a new window level transformation.
+    ///
+    /// The width of the given `window_level` is automatically clamped
+    /// if it is incompatible with the given LUT function:
+    /// it muse be `>= 0` if the function is [`LinearExact`](VoiLutFunction::LinearExact),
+    /// and `>= 1` in other functions.
+    #[inline]
+    pub fn new(voi_lut_function: VoiLutFunction, window_level: WindowLevel) -> Self {
+        WindowLevelTransform {
+            voi_lut_function,
+            window_level: WindowLevel {
+                center: window_level.center,
+                width: match voi_lut_function {
+                    VoiLutFunction::LinearExact => window_level.width.max(0.),
+                    VoiLutFunction::Linear | VoiLutFunction::Sigmoid => window_level.width.max(1.),
+                },
+            },
+        }
+    }
+    
+    /// Create a new window level transformation
+    /// with the `LINEAR` function.
+    ///
+    /// The width of the given `window_level` is automatically clamped
+    /// to 1 if it is lower than 1.
+    #[inline]
+    pub fn linear(window_level: WindowLevel) -> Self {
+        Self::new(VoiLutFunction::Linear, window_level)
+    }
+
+    /// Apply the window level transformation on a rescaled value,
+    /// into a number between `0` and `y_max`.
+    pub fn apply(&self, value: f64, y_max: f64) -> f64 {
+        match self.voi_lut_function {
+            VoiLutFunction::Linear => window_level_linear(
+                value,
+                self.window_level.width,
+                self.window_level.center,
+                y_max,
+            ),
+            VoiLutFunction::LinearExact => window_level_linear_exact(
+                value,
+                self.window_level.width,
+                self.window_level.center,
+                y_max,
+            ),
+            VoiLutFunction::Sigmoid => window_level_sigmoid(
+                value,
+                self.window_level.width,
+                self.window_level.center,
+                y_max,
+            ),
+        }
+    }
+}
+
+fn window_level_linear(value: f64, window_width: f64, window_center: f64, y_max: f64) -> f64 {
+    let width = window_width as f64;
+    let center = window_center as f64;
+    debug_assert!(width >= 1.);
+
+    // C.11.2.1.2.1
+
+    let min = center - (width - 1.) / 2.;
+    let max = center - 0.5 + (width - 1.) / 2.;
+
+    if value <= min {
+        // if (x <= c - (w-1) / 2), then y = ymin
+        0.
+    } else if value > max {
+        // else if (x > c - 0.5 + (w-1) /2), then y = ymax
+        y_max
+    } else {
+        // else y = ((x - (c - 0.5)) / (w-1) + 0.5) * (ymax- ymin) + ymin
+        ((value - (center - 0.5)) / (width - 1.) + 0.5) * y_max
+    }
+}
+
+fn window_level_linear_exact(value: f64, window_width: f64, window_center: f64, y_max: f64) -> f64 {
+    let width = window_width as f64;
+    let center = window_center as f64;
+    debug_assert!(width >= 0.);
+
+    // C.11.2.1.3.2
+
+    let min = center - width / 2.;
+    let max = center + width / 2.;
+
+    if value <= min {
+        // if (x <= c - w/2), then y = ymin
+        0.
+    } else if value > max {
+        // else if (x > c + w/2), then y = ymax
+        y_max
+    } else {
+        // else y = ((x - c) / w + 0.5) * (ymax - ymin) + ymin
+        ((value - center) / width + 0.5) * y_max
+    }
+}
+
+fn window_level_sigmoid(value: f64, window_width: f64, window_center: f64, y_max: f64) -> f64 {
+    let width = window_width as f64;
+    let center = window_center as f64;
+    assert!(width >= 1.);
+
+    // C.11.2.1.3.1
+
+    y_max / (1. + f64::exp(-4. * (value - center) / width))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Applying a common rescale function to a value
+    /// gives the expected output.
+    #[test]
+    fn modality_lut_baseline() {
+        let rescale = Rescale::new(1., -1024.);
+
+        assert_eq!(rescale.apply(0.), -1024.);
+        assert_eq!(rescale.apply(1.), -1023.);
+        assert_eq!(rescale.apply(2.), -1022.);
+        assert_eq!(rescale.apply(1024.), 0.);
+    }
+
+    /// Applying a linear window level
+    /// as per the example described in the standard
+    /// (C.11.2.1.2.1)
+    /// gives us the expected outcome.
+    #[test]
+    fn window_level_linear_example() {
+        let window_level = WindowLevel {
+            width: 4096.,
+            center: 2048.,
+        };
+        let window_level_transform = WindowLevelTransform::linear(window_level);
+        let y_max = 255.;
+
+        // x <= 0
+        assert_eq!(window_level_transform.apply(-2., y_max), 0.);
+        assert_eq!(window_level_transform.apply(-1., y_max), 0.);
+        assert_eq!(window_level_transform.apply(0., y_max), 0.);
+
+        // x > 4095
+        assert_eq!(window_level_transform.apply(4095.5, y_max), y_max);
+        assert_eq!(window_level_transform.apply(4096., y_max), y_max);
+        assert_eq!(window_level_transform.apply(4097., y_max), y_max);
+
+        // inbetween:  y = ((x - 2047.5) / 4095 + 0.5) * 255
+
+        let x = 1024.;
+        let y = window_level_transform.apply(x, y_max);
+        let expected_y = ((x - 2047.5) / 4095. + 0.5) * 255.;
+
+        assert!((y - expected_y).abs() < 1e-3);
+    }
+
+    /// Applying a linear window level gives us the expected outcome.
+    #[test]
+    fn window_level_linear_1() {
+        let window_level = WindowLevel {
+            width: 300.,
+            center: 50.,
+        };
+        let window_level_transform = WindowLevelTransform::linear(window_level);
+        let y_max = 255.;
+
+        // x <= (50 - 150)
+        let y = window_level_transform.apply(-120., y_max);
+        assert_eq!(y, 0.);
+        let y = window_level_transform.apply(-100.5, y_max);
+        assert_eq!(y, 0.);
+        let y = window_level_transform.apply(-100., y_max);
+        assert_eq!(y, 0.);
+
+        // x >= (50 + 150)
+        let y = window_level_transform.apply(201., y_max);
+        assert_eq!(y, 255.);
+        let y = window_level_transform.apply(200., y_max);
+        assert_eq!(y, 255.);
+
+        // x inbetween
+        let y = window_level_transform.apply(50., y_max);
+        assert!(y > 127. && y < 129.);
+    }
+}


### PR DESCRIPTION
This is a major revamp of the `pixeldata` crate so as to support conversions of decoded pixel data with LUT transformations. Resolves #122.

Summary:

- Refactor `adapters::DecodeError` so that now we have a single `Custom` error variant with support for `snafu::whatever!`.
- Move attribute fetching logic to a separate module
- Add new data types for enumerated attributes (`PhotometricInterpretation`, `PlanarConfiguration`, `PixelRepresentation`, `VOILUTFunction`)
- Implement rescale and window level (linear, linear_exact, sigmoid) transformations
- Implement pixel data conversion using a LUT instead of calculating the target value for each pixel value.
- Extend number of frames and frame number as a 32-bit integer.
- Use `f64` for rescale slope and rescale intercept
- Add options for decoded pixel data conversion methods
- Hide fields of `DecodedPixelData`, exposing content via getter methods instead.
- Make this crate's error type opaque
- Add options for `to_vec*` and `to_ndarray*` methods, including LUT construction and application on pixel data values
