### PR TITLE
Constrain dependency usage in project

### DIFF
--- a/dictionary-builder/Cargo.toml
+++ b/dictionary-builder/Cargo.toml
@@ -16,8 +16,12 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2.18.0"
-regex = "1.0.0"
 serde = { version = "1.0.55", features = ["derive"] }
 serde_json = "1.0.17"
 heck = "0.3.1"
-reqwest = { version = "0.11", features = ["blocking"] }
+ureq = "2.4.0"
+
+[dependencies.regex]
+version = "1.1.0"
+default-features = false
+features = ["perf", "unicode-case", "unicode-perl"]

--- a/dictionary-builder/src/main.rs
+++ b/dictionary-builder/src/main.rs
@@ -83,9 +83,9 @@ fn main() {
     if src.starts_with("http:") || src.starts_with("https:") {
         // read from URL
         println!("Downloading DICOM dictionary ...");
-        let mut resp = reqwest::blocking::get(src).unwrap();
+        let resp = ureq::get(src).call().unwrap();
         let mut data = vec![];
-        resp.copy_to(&mut data).unwrap();
+        std::io::copy(&mut resp.into_reader(), &mut data).unwrap();
 
         let preamble = data
             .split(|&b| b == b'\n')

--- a/fromimage/Cargo.toml
+++ b/fromimage/Cargo.toml
@@ -17,6 +17,10 @@ default = ['dicom-object/inventory-registry', 'dicom-object/backtraces']
 dicom-core = { path = "../core" }
 dicom-dictionary-std = { path = "../dictionary-std/" }
 dicom-object = { path = "../object/" }
-image = "0.24.2"
 snafu = "0.7.0"
 structopt = "0.3.23"
+
+[dependencies.image]
+version = "0.24.1"
+default-features=false
+features = ["jpeg", "png", "pnm", "tiff", "webp", "bmp", "jpeg_rayon"]

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -18,12 +18,16 @@ dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry", version
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.5.0-rc.2" }
 snafu = "0.7.0"
 byteorder = "1.4.3"
-image = "0.24.1"
 gdcm-rs = { version = "0.3.0", optional = true }
 rayon = "1.5.0"
 ndarray = "0.15.1"
 ndarray-stats = "0.5"
 num-traits = "0.2.12"
+
+[dependencies.image]
+version = "0.24.1"
+default-features=false
+features = ["jpeg", "png", "pnm", "tiff", "webp", "bmp", "jpeg_rayon"]
 
 [dev-dependencies]
 rstest = "0.10.0"


### PR DESCRIPTION
- [dictionary-builder] use ureq instead of reqwest
- narrow Cargo features in image crate (since some image formats are typically not employed here)