### PR TITLE
Logging via tracing

### DIFF
--- a/dump/Cargo.toml
+++ b/dump/Cargo.toml
@@ -20,14 +20,18 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [features]
-default = ["cli", "dicom/inventory-registry", "dicom/backtraces"]
-cli = ["structopt"]
+default = ["cli"]
+cli = ["structopt", "dicom-transfer-syntax-registry/inventory-registry", "dicom-object/backtraces"]
 
 [dependencies]
-dicom = { path = "../parent/", version = "0.5.0-rc.2", default-features = false }
 term_size = "0.3.2"
 itertools = "0.10"
 snafu = "0.7.0"
 colored = "2.0.0"
 structopt = { version = "0.3.21", optional = true }
+dicom-core = { path = "../core" }
+dicom-encoding = { path = "../encoding" }
+dicom-object = { path = "../object/" }
+dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/" }
+dicom-dictionary-std = { path = "../dictionary-std/" }
 

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -32,14 +32,14 @@
 //! # Result::<(), Box<dyn std::error::Error>>::Ok(())
 //! ```
 use colored::*;
-use dicom::core::dictionary::{DataDictionary, DictionaryEntry};
-use dicom::core::header::Header;
-use dicom::core::value::{PrimitiveValue, Value as DicomValue};
-use dicom::core::VR;
-use dicom::encoding::transfer_syntax::TransferSyntaxIndex;
-use dicom::object::mem::{InMemDicomObject, InMemElement};
-use dicom::object::{FileDicomObject, FileMetaTable, StandardDataDictionary};
-use dicom::transfer_syntax::TransferSyntaxRegistry;
+use dicom_core::dictionary::{DataDictionary, DictionaryEntry};
+use dicom_core::header::Header;
+use dicom_core::value::{PrimitiveValue, Value as DicomValue};
+use dicom_core::VR;
+use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
+use dicom_object::mem::{InMemDicomObject, InMemElement};
+use dicom_object::{FileDicomObject, FileMetaTable, StandardDataDictionary};
+use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
 use std::io::{stdout, Result as IoResult, Write};
@@ -717,7 +717,7 @@ fn value_summary(
             }
         }
         (Strs(values), VR::DT) => {
-            match value.to_multi_datetime(dicom::core::chrono::FixedOffset::east(0)) {
+            match value.to_multi_datetime(dicom_core::chrono::FixedOffset::east(0)) {
                 Ok(values) => {
                     // print as reformatted date
                     DumpValue::DateTime(format_value_list(values, max_characters, false))
@@ -829,13 +829,12 @@ fn determine_width(user_width: Option<u32>) -> u32 {
 #[cfg(test)]
 mod tests {
 
+    use dicom_core::{DataElement, VR, PrimitiveValue};
+    use dicom_dictionary_std::tags;
+    use dicom_object::{InMemDicomObject, FileMetaTableBuilder};
+
     use super::whitespace_or_null;
     use crate::{ColorMode, DumpOptions};
-    use dicom::{
-        core::{DataElement, PrimitiveValue, VR},
-        dictionary_std::tags,
-        object::{FileMetaTableBuilder, InMemDicomObject},
-    };
 
     #[test]
     fn trims_all_whitespace() {

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -11,7 +11,7 @@
 //! (or [`dump_file_to`] to print to an arbitrary writer).
 //!
 //! ```no_run
-//! use dicom::object::open_file;
+//! use dicom_object::open_file;
 //! use dicom_dump::dump_file;
 //!
 //! let obj = open_file("path/to/file.dcm")?;
@@ -22,7 +22,7 @@
 //! See the [`DumpOptions`] builder for additional dumping options.
 //!
 //! ```no_run
-//! use dicom::object::open_file;
+//! use dicom_object::open_file;
 //! use dicom_dump::{DumpOptions, dump_file};
 //!
 //! let obj = open_file("path/to/file2.dcm")?;
@@ -90,7 +90,7 @@ impl Default for DumpFormat {
 /// # Example
 ///
 /// ```no_run
-/// use dicom::object::open_file;
+/// use dicom_object::open_file;
 /// use dicom_dump::{ColorMode, DumpOptions};
 ///
 /// let my_dicom_file = open_file("/path_to_file")?;

--- a/dump/src/main.rs
+++ b/dump/src/main.rs
@@ -1,8 +1,8 @@
 //! A CLI tool for inspecting the contents of a DICOM file
 //! by printing it in a human readable format.
-use dicom::object::open_file;
+use dicom_object::open_file;
 use dicom_dump::{ColorMode, DumpOptions};
-use snafu::ErrorCompat;
+use snafu::{ErrorCompat, Whatever, whatever};
 use std::io::ErrorKind;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -49,9 +49,16 @@ struct App {
 }
 
 fn main() {
-    os_compatibility().unwrap_or_else(|_| {
-        eprintln!("Error setting OS compatibility for colored output");
+    run().unwrap_or_else(|e| {
+        report(e);
+        std::process::exit(-2);
     });
+}
+
+fn run() -> Result<(), Whatever> {
+    if os_compatibility().is_err() {
+        whatever!("Error setting OS compatibility for colored output");
+    }
 
     let App {
         files: filenames,

--- a/echoscu/Cargo.toml
+++ b/echoscu/Cargo.toml
@@ -12,6 +12,12 @@ readme = "README.md"
 
 [dependencies]
 structopt = "0.3.21"
+dicom-core = { path = "../core", version = "0.5.0-rc.2" }
+dicom-dictionary-std = { path = "../dictionary-std/", version = "0.5.0-rc.2" }
+dicom-object = { path = "../object/", version = "0.5.0-rc.2" }
+dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.5.0-rc.2" }
 dicom-ul = { path = "../ul", version = "0.4.0-rc.2" }
-dicom = { path = "../parent", version = "0.5.0-rc.2" }
 smallvec = "1.6.1"
+snafu = "0.7.0"
+tracing = "0.1.34"
+tracing-subscriber = "0.3.11"

--- a/fromimage/Cargo.toml
+++ b/fromimage/Cargo.toml
@@ -19,6 +19,8 @@ dicom-dictionary-std = { path = "../dictionary-std/" }
 dicom-object = { path = "../object/" }
 snafu = "0.7.0"
 structopt = "0.3.23"
+tracing = "0.1.34"
+tracing-subscriber = "0.3.11"
 
 [dependencies.image]
 version = "0.24.1"

--- a/fromimage/src/main.rs
+++ b/fromimage/src/main.rs
@@ -76,6 +76,12 @@ where
 }
 
 fn main() {
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::FmtSubscriber::new(),
+    ).unwrap_or_else(|e| {
+        report(&e);
+    });
+
     let App {
         dcm_file,
         img_file,

--- a/object/Cargo.toml
+++ b/object/Cargo.toml
@@ -24,6 +24,7 @@ itertools = "0.10"
 byteordered = "0.6"
 smallvec = "1.6.1"
 snafu = "0.7.0"
+tracing = "0.1.34"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -318,16 +318,16 @@ impl FileMetaTable {
                     group_length_remaining -= 12 + elem_len;
                     builder.private_information(v)
                 }
-                Tag(0x0002, _) => {
+                tag @ Tag(0x0002, _) => {
                     // unknown tag, do nothing
-                    // could be an unsupported or non-standard attribute,
-                    // consider logging (#49)
+                    // could be an unsupported or non-standard attribute
+                    tracing::info!("Unknown tag {}", tag);
                     builder
                 }
-                _ => {
+                tag => {
                     // unexpected tag from another group! do nothing for now,
                     // but this could pose an issue up ahead (see #50)
-                    // and should be logged (#49)
+                    tracing::warn!("Unexpected off-group tag {}", tag);
                     builder
                 }
             }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -17,3 +17,4 @@ chrono = "0.4.6"
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.5.0-rc.2" }
 smallvec = "1.6.1"
 snafu = "0.7.0"
+tracing = "0.1.34"

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -801,8 +801,7 @@ where
             // in the future. See #40 for discussion.
             if let Some(charset) = parts.first().map(|x| x.as_ref()).and_then(|name| {
                 SpecificCharacterSet::from_code(name).or_else(|| {
-                    // TODO(#49) log this as a warning
-                    eprintln!("Unsupported character set `{}`, ignoring", name);
+                    tracing::warn!("Unsupported character set `{}`, ignoring", name);
                     None
                 })
             }) {

--- a/parser/src/stateful/encode.rs
+++ b/parser/src/stateful/encode.rs
@@ -310,8 +310,7 @@ where
         if let Some(codec) = SpecificCharacterSet::from_code(name) {
             self.text = codec;
         } else {
-            // TODO(#49) log this as a warning
-            eprintln!("Unsupported character set `{}`, ignoring", name);
+            tracing::warn!("Unsupported character set `{}`, ignoring", name);
         }
     }
 

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -23,6 +23,7 @@ rayon = "1.5.0"
 ndarray = "0.15.1"
 ndarray-stats = "0.5"
 num-traits = "0.2.12"
+tracing = "0.1.34"
 
 [dependencies.image]
 version = "0.24.1"

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -807,8 +807,7 @@ impl DecodedPixelData<'_> {
                                 .context(InvalidDataTypeSnafu)?
                             }
                             (VoiLutOption::Default | VoiLutOption::First, None) => {
-                                // log warning (#49)
-                                eprintln!("Could not find window level for object");
+                                tracing::warn!("Could not find window level for object");
                                 Lut::new_rescale_and_normalize(
                                     8,
                                     signed,
@@ -920,8 +919,7 @@ impl DecodedPixelData<'_> {
                                 )
                             }
                             (VoiLutOption::Default | VoiLutOption::First, None) => {
-                                // log warning (#49)
-                                eprintln!("Could not find window level for object");
+                                tracing::warn!("Could not find window level for object");
 
                                 Lut::new_rescale_and_normalize(
                                     self.bits_stored,
@@ -1138,8 +1136,7 @@ impl DecodedPixelData<'_> {
                                 ),
                             ),
                             (VoiLutOption::First, None) => {
-                                // log warning (#49)
-                                eprintln!("Could not find window level for object");
+                                tracing::warn!("Could not find window level for object");
                                 Lut::new_rescale(8, signed, rescale)
                             }
                             (VoiLutOption::Custom(window), _) => Lut::new_rescale_and_window(
@@ -1201,8 +1198,7 @@ impl DecodedPixelData<'_> {
                                 ),
                             ),
                             (VoiLutOption::First, None) => {
-                                // log warning (#49)
-                                eprintln!("Could not find window level for object");
+                                tracing::warn!("Could not find window level for object");
                                 Lut::new_rescale(8, signed, rescale)
                             }
                             (VoiLutOption::Custom(window), _) => Lut::new_rescale_and_window(

--- a/scpproxy/Cargo.toml
+++ b/scpproxy/Cargo.toml
@@ -15,3 +15,5 @@ clap = "2.33.0"
 dicom-ul = { path = "../ul/", version = "0.4.0-rc.2" }
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.5.0-rc.2" }
 snafu = "0.7.0"
+tracing = "0.1.34"
+tracing-subscriber = "0.3.11"

--- a/storescu/Cargo.toml
+++ b/storescu/Cargo.toml
@@ -11,8 +11,15 @@ keywords = ["dicom"]
 readme = "README.md"
 
 [dependencies]
+dicom-core = { path = '../core', version = "0.5.0-rc.2" }
 dicom-ul = { path = '../ul', version = "0.4.0-rc.2" }
-dicom = { path = '../parent', version = "0.5.0-rc.2" }
+dicom-object = { path = '../object', version = "0.5.0-rc.2" }
+dicom-encoding = { path = "../encoding/", version = "0.5.0-rc.2" }
+dicom-dictionary-std = { path = "../dictionary-std/", version = "0.5.0-rc.2" }
+dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.5.0-rc.2" }
 structopt = "0.3.21"
 walkdir = "2.3.2"
 indicatif = "0.16.2"
+tracing = "0.1.34"
+tracing-subscriber = "0.3.11"
+snafu = "0.7.0"

--- a/toimage/Cargo.toml
+++ b/toimage/Cargo.toml
@@ -18,3 +18,5 @@ dicom-object = { path = "../object/" }
 dicom-pixeldata = { path = "../pixeldata/" }
 snafu = "0.7.0"
 structopt = "0.3.23"
+tracing = "0.1.34"
+tracing-subscriber = "0.3.11"

--- a/toimage/src/main.rs
+++ b/toimage/src/main.rs
@@ -75,6 +75,12 @@ where
 }
 
 fn main() {
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::FmtSubscriber::new(),
+    ).unwrap_or_else(|e| {
+        report(&e);
+    });
+
     let App {
         file,
         output,

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -20,3 +20,4 @@ lazy_static = "1.2.0"
 encoding = "0.2.33"
 byteordered = "0.6"
 inventory = { version = "0.2.2", optional = true }
+tracing = "0.1.34"

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -84,7 +84,7 @@ impl TransferSyntaxRegistryImpl {
                     // requirements, better keep it as a separate match arm for
                     // debugging purposes
                     (Codec::Unsupported, Codec::PixelData(_)) => {
-                        eprintln!("Inconsistent requirements for transfer syntax {}: `Unsupported` cannot be replaced with `PixelData`", ts.uid());
+                        tracing::warn!("Inconsistent requirements for transfer syntax {}: `Unsupported` cannot be replaced with `PixelData`", ts.uid());
                         false
                     }
                     // ignoring TS with less or equal implementation

--- a/ul/Cargo.toml
+++ b/ul/Cargo.toml
@@ -15,6 +15,7 @@ byteordered = "0.6"
 dicom-encoding = { path = "../encoding/", version = "0.5.0-rc.2" }
 dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.5.0-rc.2" }
 snafu = "0.7.0"
+tracing = "0.1.34"
 
 [dev-dependencies]
 matches = "0.1.8"

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -128,7 +128,7 @@ where
         .read_u32::<BigEndian>()
         .context(ReadPduFieldSnafu { field: "length" })?;
 
-    // Check max_pdu_length. See also (#49)
+    // Check max_pdu_length
     if strict {
         ensure!(
             pdu_length <= max_pdu_length,
@@ -145,8 +145,8 @@ where
                 max_pdu_length: MAXIMUM_PDU_SIZE
             }
         );
-        eprintln!(
-            "[WARNING] Incoming pdu was too large: length {}, maximum is {}",
+        tracing::warn!(
+            "Incoming pdu was too large: length {}, maximum is {}",
             pdu_length, max_pdu_length
         );
     }


### PR DESCRIPTION
Takes care of #49. Library crates shall use `tracing` to emit events and tools may then use a simple tracing subscriber to print log lines.

This PR also updates some of the crate's error handling constructs.