### PR TITLE
Feature gate capabilities: image, ndarray, rayon

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,10 +22,12 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           cache: true
-      # test base functionality
-      - run: cargo test
-      # test GDCM support in dicom-pixeldata
-      - run: cargo test --package dicom-pixeldata --features gdcm
+      # test project with default + useful features
+      - run: cargo test --features image,ndarray
+      # test dicom-pixeldata with gdcm-rs
+      - run: cargo test -p dicom-pixeldata --features gdcm
+      # test dicom-pixeldata without default features
+      - run: cargo test -p dicom-pixeldata --no-default-features
 
   check_windows:
     name: Check (Windows)

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -10,10 +10,6 @@ categories = ["encoding"]
 keywords = ["dicom"]
 readme = "README.md"
 
-[features]
-default = []
-inventory-registry = ['inventory']
-
 [dependencies]
 dicom-core = { path = "../core", version = "0.5.3" }
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.5.0" }
@@ -21,3 +17,7 @@ encoding = "0.2.33"
 byteordered = "0.6"
 inventory = { version = "0.3.2", optional = true }
 snafu = "0.7.3"
+
+[features]
+default = []
+inventory-registry = ['inventory']

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -37,7 +37,7 @@ dicom-test-files = "0.2.1"
 [features]
 default = ["rayon"]
 gdcm = ["gdcm-rs"]
-ndarray = ["dep:ndarray", "dep:ndarray-stats"]
+ndarray = ["dep:ndarray"]
 rayon = ["dep:rayon", "image?/jpeg_rayon", "dicom-encoding/rayon"]
 
 [package.metadata.docs.rs]

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -38,7 +38,7 @@ dicom-test-files = "0.2.1"
 default = ["rayon"]
 gdcm = ["gdcm-rs"]
 ndarray = ["dep:ndarray"]
-rayon = ["dep:rayon", "image?/jpeg_rayon", "dicom-encoding/rayon"]
+rayon = ["dep:rayon", "image?/jpeg_rayon", "dicom-transfer-syntax-registry/rayon"]
 
 [package.metadata.docs.rs]
 features = ["image", "ndarray"]

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -19,20 +19,26 @@ dicom-dictionary-std = { path = "../dictionary-std", version = "0.5.0" }
 snafu = "0.7.3"
 byteorder = "1.4.3"
 gdcm-rs = { version = "0.5.0", optional = true }
-rayon = "1.5.0"
-ndarray = "0.15.1"
+rayon = { version = "1.5.0", optional = true }
+ndarray = { version = "0.15.1", optional = true }
 num-traits = "0.2.12"
 tracing = "0.1.34"
 
 [dependencies.image]
 version = "0.24.5"
-default-features=false
-features = ["jpeg", "png", "pnm", "tiff", "webp", "bmp", "jpeg_rayon"]
+default-features = false
+features = ["jpeg", "png", "pnm", "tiff", "webp", "bmp"]
+optional = true
 
 [dev-dependencies]
 rstest = "0.16"
 dicom-test-files = "0.2.1"
 
 [features]
-default = []
+default = ["rayon"]
 gdcm = ["gdcm-rs"]
+ndarray = ["dep:ndarray", "dep:ndarray-stats"]
+rayon = ["dep:rayon", "image?/jpeg_rayon", "dicom-encoding/rayon"]
+
+[package.metadata.docs.rs]
+features = ["image", "ndarray"]

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -35,7 +35,7 @@ rstest = "0.16"
 dicom-test-files = "0.2.1"
 
 [features]
-default = ["rayon"]
+default = ["rayon", "dicom-transfer-syntax-registry/native"]
 gdcm = ["gdcm-rs"]
 ndarray = ["dep:ndarray"]
 rayon = ["dep:rayon", "image?/jpeg_rayon", "dicom-transfer-syntax-registry/rayon"]

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -158,6 +158,7 @@ mod tests {
 
     const MAX_TEST_FRAMES: u32 = 16;
 
+    #[cfg(feature = "image")]
     #[rstest]
     #[case("pydicom/693_J2KI.dcm")]
     #[case("pydicom/693_J2KR.dcm")]
@@ -212,6 +213,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "ndarray")]
     #[test]
     fn test_to_ndarray_signed_word_no_lut() {
         let test_file = dicom_test_files::path("pydicom/JPEG2000.dcm").unwrap();

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -149,13 +149,16 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(any(feature = "ndarray", feature = "image"))]
     use super::*;
+    #[cfg(any(feature = "ndarray", feature = "image"))]
     use dicom_object::open_file;
-    use dicom_test_files;
+    #[cfg(feature = "image")]
     use rstest::rstest;
-    use std::fs;
+    #[cfg(feature = "image")]
     use std::path::Path;
 
+    #[cfg(feature = "image")]
     const MAX_TEST_FRAMES: u32 = 16;
 
     #[cfg(feature = "image")]
@@ -200,7 +203,7 @@ mod tests {
         let pixel_data = obj.decode_pixel_data().unwrap();
         let output_dir =
             Path::new("../target/dicom_test_files/_out/test_gdcm_parse_dicom_pixel_data");
-        fs::create_dir_all(output_dir).unwrap();
+        std::fs::create_dir_all(output_dir).unwrap();
 
         for i in 0..pixel_data.number_of_frames.min(MAX_TEST_FRAMES) {
             let image = pixel_data.to_dynamic_image(i).unwrap();

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -117,6 +117,7 @@ use image::{DynamicImage, ImageBuffer, Luma, Rgb};
 #[cfg(feature = "ndarray")]
 use ndarray::{Array, Ix3, Ix4};
 use num_traits::NumCast;
+use rayon::iter::IntoParallelIterator;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 #[cfg(all(feature = "rayon", feature = "image"))]

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1753,6 +1753,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "ndarray")]
     fn test_to_ndarray_rgb() {
         let test_file = dicom_test_files::path("pydicom/SC_rgb_16bit.dcm").unwrap();
         let obj = open_file(test_file).unwrap();
@@ -1781,6 +1782,7 @@ mod tests {
 
     /// conversion to ndarray in 16-bit
     /// retains the original data of a 16-bit image
+    #[cfg(feature = "ndarray")]
     #[test]
     fn test_to_ndarray_16bit() {
         let test_file = dicom_test_files::path("pydicom/CT_small.dcm").unwrap();

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -28,18 +28,24 @@
 //! eventual Modality and value of interest (VOI) transformations.
 //!
 //! # WebAssembly support
-//! This library works in WebAssembly
-//! by ensuring that the "gdcm" feature is disabled.
-//! This allows the crate to be compiled for WebAssembly
-//! albeit at the cost of supporting a lesser variety of compression algorithms.
+//! This library works in WebAssembly with the following two measures:
+//!  - Ensure that the "gdcm" feature is disabled.
+//!    This allows the crate to be compiled for WebAssembly
+//!    albeit at the cost of supporting a lesser variety of compression algorithms.
+//!  - And either set up [`wasm-bindgen-rayon`][1]
+//!    or disable the `rayon` feature.
+//!
+//! [1]: https://crates.io/crates/wasm-bindgen-rayon
 //!
 //! # Examples
 //!
-//! To convert a DICOM object into a dynamic image:
+//! To convert a DICOM object into a dynamic image
+//! (requires the `image` feature):
 //! ```no_run
 //! # use std::error::Error;
 //! use dicom_object::open_file;
 //! use dicom_pixeldata::PixelDecoder;
+//! # #[cfg(feature = "image")]
 //! # fn main() -> Result<(), Box<dyn Error>> {
 //! let obj = open_file("dicom.dcm")?;
 //! let image = obj.decode_pixel_data()?;
@@ -47,14 +53,19 @@
 //! dynamic_image.save("out.png")?;
 //! # Ok(())
 //! # }
+//! # #[cfg(not(feature = "image"))]
+//! # fn main() {}
 //! ```
 //!
-//! To convert a DICOM object into an ndarray:
+//! To convert a DICOM object into an ndarray
+//! (requires the `ndarray` feature):
 //! ```no_run
 //! # use std::error::Error;
 //! use dicom_object::open_file;
 //! use dicom_pixeldata::PixelDecoder;
+//! # #[cfg(feature = "ndarray")]
 //! use ndarray::s;
+//! # #[cfg(feature = "ndarray")]
 //! # fn main() -> Result<(), Box<dyn Error>> {
 //! let obj = open_file("rgb_dicom.dcm")?;
 //! let pixel_data = obj.decode_pixel_data()?;
@@ -62,15 +73,18 @@
 //! let red_values = ndarray.slice(s![.., .., .., 0]);
 //! # Ok(())
 //! # }
+//! # #[cfg(not(feature = "ndarray"))]
+//! # fn main() {}
 //! ```
 //!
 //! In order to parameterize the conversion,
-//! pass a conversion options valueto the `_with_options` variant methods.
+//! pass a conversion options value to the `_with_options` variant methods.
 //!
 //! ```no_run
 //! # use std::error::Error;
 //! use dicom_object::open_file;
 //! use dicom_pixeldata::{ConvertOptions, PixelDecoder, VoiLutOption};
+//! # #[cfg(feature = "image")]
 //! # fn main() -> Result<(), Box<dyn Error>> {
 //! let obj = open_file("dicom.dcm")?;
 //! let image = obj.decode_pixel_data()?;
@@ -80,6 +94,8 @@
 //! let dynamic_image = image.to_dynamic_image_with_options(0, &options)?;
 //! # Ok(())
 //! # }
+//! # #[cfg(not(feature = "image"))]
+//! # fn main() {}
 //! ```
 //!
 //! See [`ConvertOptions`] for the options available,
@@ -96,15 +112,22 @@ use dicom_encoding::Codec;
 use dicom_object::{FileDicomObject, InMemDicomObject};
 #[cfg(not(feature = "gdcm"))]
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
+#[cfg(feature = "image")]
 use image::{DynamicImage, ImageBuffer, Luma, Rgb};
+#[cfg(feature = "ndarray")]
 use ndarray::{Array, Ix3, Ix4};
 use num_traits::NumCast;
-use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+#[cfg(feature = "rayon")]
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+#[cfg(all(feature = "rayon", feature = "image"))]
+use rayon::slice::ParallelSliceMut;
 use snafu::OptionExt;
 use snafu::{Backtrace, ResultExt, Snafu};
 use std::borrow::Cow;
 
+#[cfg(feature = "image")]
 pub use image;
+#[cfg(feature = "ndarray")]
 pub use ndarray;
 
 mod attribute;
@@ -167,6 +190,7 @@ pub enum InnerError {
     #[snafu(display("Invalid buffer when constructing ImageBuffer"))]
     InvalidImageBuffer { backtrace: Backtrace },
 
+    #[cfg(feature = "ndarray")]
     #[snafu(display("Invalid shape for ndarray"))]
     InvalidShape {
         source: ndarray::ShapeError,
@@ -541,6 +565,7 @@ impl DecodedPixelData<'_> {
     /// followed by the first VOI LUT transformation found in the object.
     /// To change this behavior,
     /// see [`to_dynamic_image_with_options`](Self::to_dynamic_image_with_options).
+    #[cfg(feature = "image")]
     pub fn to_dynamic_image(&self, frame: u32) -> Result<DynamicImage> {
         self.to_dynamic_image_with_options(frame, &ConvertOptions::default())
     }
@@ -570,6 +595,7 @@ impl DecodedPixelData<'_> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "image")]
     pub fn to_dynamic_image_with_options(
         &self,
         frame: u32,
@@ -632,6 +658,7 @@ impl DecodedPixelData<'_> {
         }
     }
 
+    #[cfg(feature = "image")]
     fn mono_image_with_narrow(
         &self,
         pixel_values: impl IntoIterator<Item = u16>,
@@ -653,6 +680,7 @@ impl DecodedPixelData<'_> {
         }
     }
 
+    #[cfg(all(feature = "image", feature = "rayon"))]
     fn mono_image_with_narrow_par(
         &self,
         pixel_values: impl ParallelIterator<Item = u16>,
@@ -674,6 +702,7 @@ impl DecodedPixelData<'_> {
         }
     }
 
+    #[cfg(feature = "image")]
     fn mono_image_with_extend(
         &self,
         pixel_values: impl IntoIterator<Item = u8>,
@@ -699,6 +728,7 @@ impl DecodedPixelData<'_> {
         }
     }
 
+    #[cfg(all(feature = "image", feature = "rayon"))]
     fn mono_image_with_extend_par(
         &self,
         pixel_values: impl ParallelIterator<Item = u8>,
@@ -723,6 +753,7 @@ impl DecodedPixelData<'_> {
         }
     }
 
+    #[cfg(feature = "image")]
     fn rgb_image_with_extend(
         &self,
         pixels: Vec<u8>,
@@ -747,6 +778,7 @@ impl DecodedPixelData<'_> {
         }
     }
 
+    #[cfg(feature = "image")]
     fn rgb_image_with_narrow(
         &self,
         pixels: Vec<u16>,
@@ -767,6 +799,7 @@ impl DecodedPixelData<'_> {
         }
     }
 
+    #[cfg(feature = "image")]
     fn build_monochrome_image(&self, frame: u32, options: &ConvertOptions) -> Result<DynamicImage> {
         let ConvertOptions {
             modality_lut,
@@ -838,8 +871,16 @@ impl DecodedPixelData<'_> {
                             .context(CreateLutSnafu)?,
                         };
 
-                        let pixel_values = lut.map_par_iter(data.par_iter().copied());
-                        self.mono_image_with_extend_par(pixel_values, *bit_depth)?
+                        #[cfg(feature = "rayon")]
+                        {
+                            let pixel_values = lut.map_par_iter(data.par_iter().copied());
+                            self.mono_image_with_extend_par(pixel_values, *bit_depth)?
+                        }
+                        #[cfg(not(feature = "rayon"))]
+                        {
+                            let pixel_values = lut.map_iter(data.iter().copied());
+                            self.mono_image_with_extend(pixel_values, *bit_depth)?
+                        }
                     }
                 }
             }
@@ -942,8 +983,16 @@ impl DecodedPixelData<'_> {
                         }
                         .context(CreateLutSnafu)?;
 
-                        let values = lut.map_par_iter(samples.par_iter().copied());
-                        self.mono_image_with_narrow_par(values, *bit_depth)?
+                        #[cfg(feature = "rayon")]
+                        {
+                            let pixel_values = lut.map_par_iter(samples.par_iter().copied());
+                            self.mono_image_with_narrow_par(pixel_values, *bit_depth)?
+                        }
+                        #[cfg(not(feature = "rayon"))]
+                        {
+                            let pixel_values = lut.map_iter(samples.iter().copied());
+                            self.mono_image_with_narrow(pixel_values, *bit_depth)?
+                        }
                     }
                 }
             }
@@ -958,6 +1007,9 @@ impl DecodedPixelData<'_> {
 
     /// Convert all of the decoded pixel data into a vector of flat pixels
     /// of a given type `T`.
+    ///
+    /// The values are provided in standard order and layout:
+    /// pixels first, then columns, then rows, then frames.
     ///
     /// The underlying pixel data type is extracted based on
     /// the bits allocated and pixel representation,
@@ -992,6 +1044,9 @@ impl DecodedPixelData<'_> {
     /// Convert all of the decoded pixel data into a vector of flat pixels
     /// of a given type `T`.
     ///
+    /// The values are provided in standard order and layout:
+    /// pixel first, then column, then row, with frames traversed last.
+    ///
     /// The underlying pixel data type is extracted based on
     /// the bits allocated and pixel representation,
     /// which is then converted to the requested type.
@@ -1013,6 +1068,9 @@ impl DecodedPixelData<'_> {
     /// Convert the decoded pixel data of a frame
     /// into a vector of flat pixels of a given type `T`.
     ///
+    /// The values are provided in standard order and layout:
+    /// pixels first, then columns, then rows.
+    ///
     /// The underlying pixel data type is extracted based on
     /// the bits allocated and pixel representation,
     /// which is then converted to the requested type.
@@ -1033,6 +1091,9 @@ impl DecodedPixelData<'_> {
 
     /// Convert the decoded pixel data of a frame
     /// into a vector of flat pixels of a given type `T`.
+    ///
+    /// The values are provided in standard order and layout:
+    /// pixels first, then columns, then rows.
     ///
     /// The underlying pixel data type is extracted based on
     /// the bits allocated and pixel representation,
@@ -1153,14 +1214,25 @@ impl DecodedPixelData<'_> {
                         }
                         .context(CreateLutSnafu)?;
 
-                        let data: Vec<T> = lut.map_par_iter(data.par_iter().copied()).collect();
+                        #[cfg(feature = "rayon")]
+                        let out = lut.map_par_iter(data.par_iter().copied()).collect();
 
-                        Ok(data)
+                        #[cfg(not(feature = "rayon"))]
+                        let out = lut.map_iter(data.iter().copied()).collect();
+
+                        Ok(out)
                     }
                     _ => {
+                        #[cfg(feature = "rayon")]
                         // 1-channel Grayscale image
                         let converted: Result<Vec<T>, _> = data
                             .par_iter()
+                            .map(|v| T::from(*v).ok_or(snafu::NoneError))
+                            .collect();
+                        #[cfg(not(feature = "rayon"))]
+                        // 1-channel Grayscale image
+                        let converted: Result<Vec<T>, _> = data
+                            .iter()
                             .map(|v| T::from(*v).ok_or(snafu::NoneError))
                             .collect();
                         converted.context(InvalidDataTypeSnafu).map_err(Error::from)
@@ -1222,7 +1294,15 @@ impl DecodedPixelData<'_> {
                         }
                         .context(CreateLutSnafu)?;
 
-                        Ok(lut.map_par_iter(samples.into_par_iter()).collect())
+                        #[cfg(feature = "rayon")]
+                        {
+                            Ok(lut.map_par_iter(samples.into_par_iter()).collect())
+                        }
+
+                        #[cfg(not(feature = "rayon"))]
+                        {
+                            Ok(lut.map_iter(samples.into_iter()).collect())
+                        }
                     }
                     _ => {
                         // no transformations
@@ -1231,8 +1311,14 @@ impl DecodedPixelData<'_> {
                             PixelRepresentation::Unsigned => {
                                 let dest = bytes_to_vec_u16(data);
 
+                                #[cfg(feature = "rayon")]
                                 let converted: Result<Vec<T>, _> = dest
                                     .par_iter()
+                                    .map(|v| T::from(*v).ok_or(snafu::NoneError))
+                                    .collect();
+                                #[cfg(not(feature = "rayon"))]
+                                let converted: Result<Vec<T>, _> = dest
+                                    .iter()
                                     .map(|v| T::from(*v).ok_or(snafu::NoneError))
                                     .collect();
                                 converted.context(InvalidDataTypeSnafu).map_err(Error::from)
@@ -1242,8 +1328,14 @@ impl DecodedPixelData<'_> {
                                 let mut signed_buffer = vec![0; data.len() / 2];
                                 NativeEndian::read_i16_into(data, &mut signed_buffer);
 
+                                #[cfg(feature = "rayon")]
                                 let converted: Result<Vec<T>, _> = signed_buffer
                                     .par_iter()
+                                    .map(|v| T::from(*v).ok_or(snafu::NoneError))
+                                    .collect();
+                                #[cfg(not(feature = "rayon"))]
+                                let converted: Result<Vec<T>, _> = signed_buffer
+                                    .iter()
                                     .map(|v| T::from(*v).ok_or(snafu::NoneError))
                                     .collect();
                                 converted.context(InvalidDataTypeSnafu).map_err(Error::from)
@@ -1277,6 +1369,7 @@ impl DecodedPixelData<'_> {
     /// applies only the Modality LUT function described in the object,
     /// To change this behavior,
     /// see [`to_ndarray_with_options`](Self::to_ndarray_with_options).
+    #[cfg(feature = "ndarray")]
     pub fn to_ndarray<T: 'static>(&self) -> Result<Array<T, Ix4>>
     where
         T: NumCast,
@@ -1310,6 +1403,7 @@ impl DecodedPixelData<'_> {
     /// only the Modality LUT function described in the object is applied.
     /// Note that certain options may be ignored
     /// if they do not apply.
+    #[cfg(feature = "ndarray")]
     pub fn to_ndarray_with_options<T: 'static>(
         &self,
         options: &ConvertOptions,
@@ -1353,6 +1447,7 @@ impl DecodedPixelData<'_> {
     /// applies only the Modality LUT function described in the object,
     /// To change this behavior,
     /// see [`to_ndarray_frame_with_options`](Self::to_ndarray_frame_with_options).
+    #[cfg(feature = "ndarray")]
     pub fn to_ndarray_frame<T: 'static>(&self, frame: u32) -> Result<Array<T, Ix3>>
     where
         T: NumCast,
@@ -1385,6 +1480,7 @@ impl DecodedPixelData<'_> {
     /// only the Modality LUT function described in the object is applied.
     /// Note that certain options may be ignored
     /// if they do not apply.
+    #[cfg(feature = "ndarray")]
     pub fn to_ndarray_frame_with_options<T: 'static>(
         &self,
         frame: u32,
@@ -1418,10 +1514,16 @@ fn bytes_to_vec_u16(data: &[u8]) -> Vec<u16> {
 
 // Convert u8 pixel array from YBR_FULL or YBR_FULL_422 to RGB
 // Every pixel is replaced with an RGB value
+#[cfg(feature = "image")]
 fn convert_colorspace_u8(i: &mut [u8]) {
+    #[cfg(feature = "rayon")]
+    let iter = i.par_chunks_mut(3);
+    #[cfg(not(feature = "rayon"))]
+    let iter = i.chunks_mut(3);
+
     // Matrix multiplication taken from
     // https://github.com/pydicom/pydicom/blob/f36517e10/pydicom/pixel_data_handlers/util.py#L576
-    i.chunks_mut(3).for_each(|pixel| {
+    iter.for_each(|pixel| {
         let y = pixel[0] as f32;
         let b: f32 = pixel[1] as f32;
         let r: f32 = pixel[2] as f32;
@@ -1444,10 +1546,16 @@ fn convert_colorspace_u8(i: &mut [u8]) {
 
 // Convert u16 pixel array from YBR_FULL or YBR_FULL_422 to RGB
 // Every pixel is replaced with an RGB value
+#[cfg(feature = "image")]
 fn convert_colorspace_u16(i: &mut [u16]) {
+    #[cfg(feature = "rayon")]
+    let iter = i.par_chunks_mut(3);
+    #[cfg(not(feature = "rayon"))]
+    let iter = i.chunks_mut(3);
+
     // Matrix multiplication taken from
     // https://github.com/pydicom/pydicom/blob/f36517e10/pydicom/pixel_data_handlers/util.py#L576
-    i.chunks_mut(3).for_each(|pixel| {
+    iter.for_each(|pixel| {
         let y = pixel[0] as f32;
         let b: f32 = pixel[1] as f32;
         let r: f32 = pixel[2] as f32;
@@ -1470,14 +1578,26 @@ fn convert_colorspace_u16(i: &mut [u16]) {
 
 /// Convert the i16 vector by shifting it up,
 /// thus maintaining the order between sample values.
+#[cfg(feature = "image")]
 fn convert_i16_to_u16(i: &[i16]) -> Vec<u16> {
-    i.par_iter().map(|p| (*p as i32 + 0x8000) as u16).collect()
+    #[cfg(feature = "rayon")]
+    let iter = i.par_iter();
+    #[cfg(not(feature = "rayon"))]
+    let iter = i.iter();
+    iter.map(|p| (*p as i32 + 0x8000) as u16).collect()
 }
 
+/// Trait for objects which can be decoded into pixel data instances.
+///
+/// This is the main trait which extends the capability of [`dicom_object`]
+/// to also make a pathway towards imaging data retrieval.
 pub trait PixelDecoder {
-    /// Decode compressed pixel data.
-    /// A new buffer (Vec<u8>) is created holding the decoded pixel data.
-    fn decode_pixel_data(&self) -> Result<DecodedPixelData>;
+    /// Decode the pixel data in this object,
+    /// yielding a base set of imaging properties
+    /// and pixel data in native form.
+    /// In the event that the pixel data is in an encapsulated form,
+    /// a new byte buffer (`Vec<u8>`) is created.
+    fn decode_pixel_data(&self) -> Result<DecodedPixelData<'_>>;
 }
 
 #[cfg(not(feature = "gdcm"))]
@@ -1615,6 +1735,7 @@ mod tests {
         is_send_and_sync::<Error>();
     }
 
+    #[cfg(feature = "ndarray")]
     #[test]
     fn test_to_vec_rgb() {
         let test_file = dicom_test_files::path("pydicom/SC_rgb_16bit.dcm").unwrap();
@@ -1645,6 +1766,7 @@ mod tests {
     }
 
     /// to_ndarray fails if the target type cannot represent the transformed values
+    #[cfg(feature = "ndarray")]
     #[test]
     fn test_to_ndarray_error() {
         let test_file = dicom_test_files::path("pydicom/CT_small.dcm").unwrap();
@@ -1747,6 +1869,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "image")]
     #[test]
     fn test_force_bit_depth_from_16bit() {
         let test_file = dicom_test_files::path("pydicom/CT_small.dcm").unwrap();
@@ -1783,6 +1906,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "image")]
     #[test]
     fn test_force_bit_depth_from_rgb() {
         let test_file = dicom_test_files::path("pydicom/color-px.dcm").unwrap();
@@ -1819,6 +1943,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "image")]
     #[test]
     fn test_frame_out_of_range() {
         let path =
@@ -1842,12 +1967,47 @@ mod tests {
     #[cfg(not(feature = "gdcm"))]
     mod not_gdcm {
         use super::*;
+        #[cfg(feature = "image")]
         use rstest::rstest;
-        use std::fs;
-        use std::path::Path;
 
         #[test]
-        fn test_native_decoding_pixel_data_rle_8bit_1frame() {
+        fn test_native_decoding_pixel_data_rle_8bit_1frame_vec() {
+            let path = dicom_test_files::path("pydicom/SC_rgb_rle.dcm")
+                .expect("test DICOM file should exist");
+            let object = open_file(&path).unwrap();
+
+            let options = ConvertOptions::new().with_modality_lut(ModalityLutOption::None);
+            let decoded = object.decode_pixel_data().unwrap();
+            let values = decoded.to_vec_with_options::<u8>(&options).unwrap();
+
+            let columns = decoded.columns() as usize;
+            // Validated using Numpy
+            // This doesn't reshape the array based on the PlanarConfiguration
+            // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
+            assert_eq!(values.len(), 30000);
+            // 0,0,r
+            assert_eq!(values[0], 255);
+            // 0,0,g
+            assert_eq!(values[1], 255);
+            // 0,0,b
+            assert_eq!(values[2], 255);
+            // 50,50,r
+            assert_eq!(values[50 * columns * 3 + 50 * 3], 128);
+            // 50,50,g
+            assert_eq!(values[50 * columns * 3 + 50 * 3 + 1], 128);
+            // 50,50,b
+            assert_eq!(values[50 * columns * 3 + 50 * 3 + 2], 128);
+            // 75,75,b
+            assert_eq!(values[75 * columns * 3 + 75 * 3], 0);
+            // 75,75,g
+            assert_eq!(values[75 * columns * 3 + 75 * 3 + 1], 0);
+            // 75,75,b
+            assert_eq!(values[75 * columns * 3 + 75 * 3 + 2], 0);
+        }
+
+        #[cfg(feature = "ndarray")]
+        #[test]
+        fn test_native_decoding_pixel_data_rle_8bit_1frame_ndarray() {
             let path = dicom_test_files::path("pydicom/SC_rgb_rle.dcm")
                 .expect("test DICOM file should exist");
             let object = open_file(&path).unwrap();
@@ -1874,6 +2034,7 @@ mod tests {
             assert_eq!(ndarray[[0, 75, 75, 2]], 0);
         }
 
+        #[cfg(feature = "ndarray")]
         #[test]
         fn test_native_decoding_pixel_data_rle_8bit_2frame() {
             let path = dicom_test_files::path("pydicom/SC_rgb_rle_2frame.dcm")
@@ -1902,6 +2063,7 @@ mod tests {
             assert_eq!(ndarray[[1, 75, 75, 2]], 255);
         }
 
+        #[cfg(feature = "ndarray")]
         #[test]
         fn test_native_decoding_pixel_data_rle_16bit_1frame() {
             let path = dicom_test_files::path("pydicom/SC_rgb_rle_16bit.dcm")
@@ -1929,6 +2091,7 @@ mod tests {
             assert_eq!(ndarray[[0, 75, 75, 2]], 0);
         }
 
+        #[cfg(feature = "ndarray")]
         #[test]
         fn test_native_decoding_pixel_data_rle_16bit_2frame() {
             let path = dicom_test_files::path("pydicom/SC_rgb_rle_16bit_2frame.dcm")
@@ -1956,8 +2119,10 @@ mod tests {
             assert_eq!(ndarray[[1, 75, 75, 2]], 65535);
         }
 
+        #[cfg(feature = "image")]
         const MAX_TEST_FRAMES: u32 = 16;
 
+        #[cfg(feature = "image")]
         #[rstest]
         // jpeg2000 encoding not supported
         #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.91\"")]
@@ -1985,6 +2150,9 @@ mod tests {
         #[case("pydicom/SC_rgb_jpeg_lossy_gdcm.dcm", 1)]
 
         fn test_parse_jpeg_encoded_dicom_pixel_data(#[case] value: &str, #[case] frames: u32) {
+            use std::fs;
+            use std::path::Path;
+
             let test_file = dicom_test_files::path(value).unwrap();
             println!("Parsing pixel data for {}", test_file.display());
             let obj = open_file(test_file).unwrap();

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1968,6 +1968,7 @@ mod tests {
 
     #[cfg(not(feature = "gdcm"))]
     mod not_gdcm {
+        #[cfg(any(feature = "transfer-syntax-registry/rle", feature = "image"))]
         use super::*;
         #[cfg(feature = "image")]
         use rstest::rstest;

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1972,6 +1972,7 @@ mod tests {
         #[cfg(feature = "image")]
         use rstest::rstest;
 
+        #[cfg(feature = "transfer-syntax-registry/rle")]
         #[test]
         fn test_native_decoding_pixel_data_rle_8bit_1frame_vec() {
             let path = dicom_test_files::path("pydicom/SC_rgb_rle.dcm")

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -117,9 +117,8 @@ use image::{DynamicImage, ImageBuffer, Luma, Rgb};
 #[cfg(feature = "ndarray")]
 use ndarray::{Array, Ix3, Ix4};
 use num_traits::NumCast;
-use rayon::iter::IntoParallelIterator;
 #[cfg(feature = "rayon")]
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 #[cfg(all(feature = "rayon", feature = "image"))]
 use rayon::slice::ParallelSliceMut;
 use snafu::OptionExt;

--- a/toimage/Cargo.toml
+++ b/toimage/Cargo.toml
@@ -16,7 +16,7 @@ default = ['dicom-object/inventory-registry', 'dicom-object/backtraces']
 [dependencies]
 clap = { version  = "4.0.18", features = ["derive"] }
 dicom-object = { path = "../object/", version = "0.5.4" }
-dicom-pixeldata = { path = "../pixeldata/", version = "0.1.5" }
+dicom-pixeldata = { path = "../pixeldata/", version = "0.1.5", features = ["image"] }
 snafu = "0.7.3"
 tracing = "0.1.34"
 tracing-subscriber = "0.3.11"

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["dicom"]
 readme = "README.md"
 
 [features]
-default = ["native", "rayon"]
+default = ["rayon"]
 
 # inventory for compile time plugin-based transfer syntax registration
 inventory-registry = ['dicom-encoding/inventory-registry', 'inventory']
@@ -34,3 +34,6 @@ tracing = "0.1.34"
 [dependencies.jpeg-decoder]
 version = "0.3.0"
 optional = true
+
+[package.metadata.docs.rs]
+features = ["native"]

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["dicom"]
 readme = "README.md"
 
 [features]
-default = ["native"]
+default = ["native", "rayon"]
 
 # inventory for compile time plugin-based transfer syntax registration
 inventory-registry = ['dicom-encoding/inventory-registry', 'inventory']
@@ -21,6 +21,7 @@ native = ["jpeg", "rle"]
 jpeg = ["jpeg-decoder"]
 # native RLE lossless support
 rle = []
+rayon = ["jpeg-decoder?/rayon"]
 
 [dependencies]
 dicom-core = { path = "../core", version = "0.5.2" }

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -23,10 +23,10 @@
 
 use crate::create_ts_stub;
 use byteordered::Endianness;
-use dicom_encoding::{
-    transfer_syntax::{AdapterFreeTransferSyntax as Ts, Codec, NeverAdapter},
-    TransferSyntax,
-};
+use dicom_encoding::transfer_syntax::{AdapterFreeTransferSyntax as Ts, Codec};
+
+#[cfg(any(feature = "jpeg", feature = "rle"))]
+use dicom_encoding::transfer_syntax::{NeverAdapter, TransferSyntax};
 
 #[cfg(feature = "jpeg")]
 use crate::adapters::jpeg::JPEGAdapter;

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -214,33 +214,68 @@ pub const JPIP_REFERENCED: Ts = create_ts_stub("1.2.840.10008.1.2.4.94", "JPIP R
 /// **Stub descriptor:** MPEG2 Main Profile / Main Level
 pub const MPEG2_MAIN_PROFILE_MAIN_LEVEL: Ts =
     create_ts_stub("1.2.840.10008.1.2.4.100", "MPEG2 Main Profile / Main Level");
+/// **Stub descriptor:** Fragmentable MPEG2 Main Profile / Main Level
+pub const FRAGMENTABLE_MPEG2_MAIN_PROFILE_MAIN_LEVEL: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.100.1",
+    "Fragmentable MPEG2 Main Profile / Main Level",
+);
 /// **Stub descriptor:** MPEG2 Main Profile / High Level
 pub const MPEG2_MAIN_PROFILE_HIGH_LEVEL: Ts =
     create_ts_stub("1.2.840.10008.1.2.4.101", "MPEG2 Main Profile / High Level");
+/// **Stub descriptor:** Fragmentable MPEG2 Main Profile / High Level
+pub const FRAGMENTABLE_MPEG2_MAIN_PROFILE_HIGH_LEVEL: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.101.1",
+    "Fragmentable MPEG2 Main Profile / High Level",
+);
 /// **Stub descriptor:** MPEG-4 AVC/H.264 High Profile / Level 4.1
 pub const MPEG4_AVC_H264_HIGH_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.102",
     "MPEG-4 AVC/H.264 High Profile / Level 4.1",
+);
+/// **Stub descriptor:** Fragmentable MPEG-4 AVC/H.264 High Profile / Level 4.1
+pub const FRAGMENTABLE_MPEG4_AVC_H264_HIGH_PROFILE: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.102.1",
+    "Fragmentable MPEG-4 AVC/H.264 High Profile / Level 4.1",
 );
 /// **Stub descriptor:** MPEG-4 AVC/H.264 BD-Compatible High Profile / Level 4.1
 pub const MPEG4_AVC_H264_BD_COMPATIBLE_HIGH_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.103",
     "MPEG-4 AVC/H.264 BD-Compatible High Profile / Level 4.1",
 );
+/// **Stub descriptor:** Fragmentable MPEG-4 AVC/H.264 BD-Compatible High Profile / Level 4.1
+pub const FRAGMENTABLE_MPEG4_AVC_H264_BD_COMPATIBLE_HIGH_PROFILE: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.103.1",
+    "Fragmentable MPEG-4 AVC/H.264 BD-Compatible High Profile / Level 4.1",
+);
 /// **Stub descriptor:** MPEG-4 AVC/H.264 High Profile / Level 4.2 For 2D Video
 pub const MPEG4_AVC_H264_HIGH_PROFILE_FOR_2D_VIDEO: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.104",
     "MPEG-4 AVC/H.264 High Profile / Level 4.2 For 2D Video",
+);
+/// **Stub descriptor:** Fragmentable MPEG-4 AVC/H.264 High Profile / Level 4.2 For 2D Video
+pub const FRAGMENTABLE_MPEG4_AVC_H264_HIGH_PROFILE_FOR_2D_VIDEO: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.104.1",
+    "Fragmentable MPEG-4 AVC/H.264 High Profile / Level 4.2 For 2D Video",
 );
 /// **Stub descriptor:** MPEG-4 AVC/H.264 High Profile / Level 4.2 For 3D Video
 pub const MPEG4_AVC_H264_HIGH_PROFILE_FOR_3D_VIDEO: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.105",
     "MPEG-4 AVC/H.264 High Profile / Level 4.2 For 3D Video",
 );
+/// **Stub descriptor:** Fragmentable MPEG-4 AVC/H.264 High Profile / Level 4.2 For 3D Video
+pub const FRAGMENTABLE_MPEG4_AVC_H264_HIGH_PROFILE_FOR_3D_VIDEO: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.105.1",
+    "Fragmentable MPEG-4 AVC/H.264 High Profile / Level 4.2 For 3D Video",
+);
 /// **Stub descriptor:** MPEG-4 AVC/H.264 High Profile / Level 4.2
 pub const MPEG4_AVC_H264_STEREO_HIGH_PROFILE: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.106",
     "MPEG-4 AVC/H.264 Stereo High Profile / Level 4.2",
+);
+/// **Stub descriptor:** Fragmentable MPEG-4 AVC/H.264 Stereo High Profile / Level 4.2
+pub const FRAGMENTABLE_MPEG4_AVC_H264_STEREO_HIGH_PROFILE: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.106.1",
+    "Fragmentable MPEG-4 AVC/H.264 Stereo High Profile / Level 4.2",
 );
 /// **Stub descriptor:** HEVC/H.265 Main Profile / Level 5.1
 pub const HEVC_H265_MAIN_PROFILE: Ts = create_ts_stub(

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -74,6 +74,9 @@ pub const RLE_LOSSLESS: TransferSyntax<NeverAdapter, RleLosslessAdapter> = Trans
     Codec::PixelData(RleLosslessAdapter),
 );
 /// **Stub:** RLE Lossless
+///
+/// A native implementation is available
+/// by enabling the `rle` Cargo feature.
 #[cfg(not(feature = "rle"))]
 pub const RLE_LOSSLESS: Ts = create_ts_stub("1.2.840.10008.1.2.5", "RLE Lossless");
 
@@ -99,6 +102,9 @@ const fn create_ts_jpeg(uid: &'static str, name: &'static str) -> JpegTS {
 pub const JPEG_BASELINE: JpegTS =
     create_ts_jpeg("1.2.840.10008.1.2.4.50", "JPEG Baseline (Process 1)");
 /// **Implemented:** JPEG Baseline (Process 1): Default Transfer Syntax for Lossy JPEG 8 Bit Image Compression
+///
+/// A native implementation is available
+/// by enabling the `jpeg` Cargo feature.
 #[cfg(not(feature = "jpeg"))]
 pub const JPEG_BASELINE: Ts = create_ts_stub("1.2.840.10008.1.2.4.50", "JPEG Baseline (Process 1)");
 
@@ -107,6 +113,9 @@ pub const JPEG_BASELINE: Ts = create_ts_stub("1.2.840.10008.1.2.4.50", "JPEG Bas
 pub const JPEG_EXTENDED: JpegTS =
     create_ts_jpeg("1.2.840.10008.1.2.4.51", "JPEG Extended (Process 2 & 4)");
 /// **Stub descriptor:** JPEG Extended (Process 2 & 4): Default Transfer Syntax for Lossy JPEG 12 Bit Image Compression (Process 4 only)
+///
+/// A native implementation is available
+/// by enabling the `jpeg` Cargo feature.
 #[cfg(not(feature = "jpeg"))]
 pub const JPEG_EXTENDED: Ts =
     create_ts_stub("1.2.840.10008.1.2.4.51", "JPEG Extended (Process 2 & 4)");
@@ -118,6 +127,9 @@ pub const JPEG_LOSSLESS_NON_HIERARCHICAL: JpegTS = create_ts_jpeg(
     "JPEG Lossless, Non-Hierarchical (Process 14)",
 );
 /// **Stub descriptor:** JPEG Lossless, Non-Hierarchical (Process 14)
+///
+/// A native implementation is available
+/// by enabling the `jpeg` Cargo feature.
 #[cfg(not(feature = "jpeg"))]
 pub const JPEG_LOSSLESS_NON_HIERARCHICAL: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.57",
@@ -135,6 +147,9 @@ pub const JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION: JpegTS = create
 /// **Stub descriptor:** JPEG Lossless, Non-Hierarchical, First-Order Prediction
 /// (Process 14 [Selection Value 1]):
 /// Default Transfer Syntax for Lossless JPEG Image Compression
+///
+/// A native implementation is available
+/// by enabling the `jpeg` Cargo feature.
 #[cfg(not(feature = "jpeg"))]
 pub const JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.70",

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -181,7 +181,7 @@ lazy_static! {
         };
 
         use self::entries::*;
-        let built_in_ts: [TransferSyntax; 29] = [
+        let built_in_ts: [TransferSyntax; 36] = [
             IMPLICIT_VR_LITTLE_ENDIAN.erased(),
             EXPLICIT_VR_LITTLE_ENDIAN.erased(),
             EXPLICIT_VR_BIG_ENDIAN.erased(),
@@ -200,12 +200,19 @@ lazy_static! {
             JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION.erased(),
             JPIP_REFERENCED.erased(),
             MPEG2_MAIN_PROFILE_MAIN_LEVEL.erased(),
+            FRAGMENTABLE_MPEG2_MAIN_PROFILE_MAIN_LEVEL.erased(),
             MPEG2_MAIN_PROFILE_HIGH_LEVEL.erased(),
+            FRAGMENTABLE_MPEG2_MAIN_PROFILE_HIGH_LEVEL.erased(),
             MPEG4_AVC_H264_HIGH_PROFILE.erased(),
+            FRAGMENTABLE_MPEG4_AVC_H264_HIGH_PROFILE.erased(),
             MPEG4_AVC_H264_BD_COMPATIBLE_HIGH_PROFILE.erased(),
+            FRAGMENTABLE_MPEG4_AVC_H264_BD_COMPATIBLE_HIGH_PROFILE.erased(),
             MPEG4_AVC_H264_HIGH_PROFILE_FOR_2D_VIDEO.erased(),
+            FRAGMENTABLE_MPEG4_AVC_H264_HIGH_PROFILE_FOR_2D_VIDEO.erased(),
             MPEG4_AVC_H264_HIGH_PROFILE_FOR_3D_VIDEO.erased(),
+            FRAGMENTABLE_MPEG4_AVC_H264_HIGH_PROFILE_FOR_3D_VIDEO.erased(),
             MPEG4_AVC_H264_STEREO_HIGH_PROFILE.erased(),
+            FRAGMENTABLE_MPEG4_AVC_H264_STEREO_HIGH_PROFILE.erased(),
             HEVC_H265_MAIN_PROFILE.erased(),
             HEVC_H265_MAIN_10_PROFILE.erased(),
             RLE_LOSSLESS.erased(),


### PR DESCRIPTION
These changes make it so that `image` and `ndarray` support in the `pixeldata` crate become opt-in, and make it possible for projects to exclude the use of `rayon` entirely.

This is a breaking change because some methods originally always available are put behind Cargo features. Depends on Rust 1.60+, which is below the current minimum version known to work (1.63).


### Summary

- [transfer-syntax-registry] add `rayon` Cargo feature, maps to `jpeg-decoder/rayon`, making it opt-in
- [pixeldata] make `image` and `ndarray` dependencies optional, gated behind features with the same names
   - conversions from decoded pixel data to images or ndarrays are conditioned on these features
   - configured docs.rs to include them
   - tweaked CI pipeline to test both with and without these features
- [pixeldata] add `rayon` feature so that Rayon can be removed entirely
   - use an non-parallel iterator implementation when not enabled
