### PR TITLE
Move pixel data adapters to transfer-syntax-registry

### DIFF
--- a/dump/Cargo.toml
+++ b/dump/Cargo.toml
@@ -32,6 +32,5 @@ structopt = { version = "0.3.21", optional = true }
 dicom-core = { path = "../core", version = "0.5.3" }
 dicom-encoding = { path = "../encoding", version = "0.5.3" }
 dicom-object = { path = "../object/", version = "0.5.4" }
-dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.5.1" }
+dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.5.1", default-features = false }
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.5.0" }
-

--- a/echoscu/Cargo.toml
+++ b/echoscu/Cargo.toml
@@ -15,7 +15,7 @@ structopt = "0.3.21"
 dicom-core = { path = "../core", version = "0.5.2" }
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.5.0" }
 dicom-object = { path = "../object/", version = "0.5.3" }
-dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.5.1" }
+dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.5.1", default-features = false }
 dicom-ul = { path = "../ul", version = "0.4.3" }
 smallvec = "1.6.1"
 snafu = "0.7.3"

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -21,4 +21,3 @@ encoding = "0.2.33"
 byteordered = "0.6"
 inventory = { version = "0.2.2", optional = true }
 snafu = "0.7.3"
-jpeg-decoder = "0.3.0"

--- a/encoding/src/adapters.rs
+++ b/encoding/src/adapters.rs
@@ -40,8 +40,8 @@ pub enum DecodeError {
         /// The error message.
         message: String,
         /// The underlying error cause, if any.
-        #[snafu(source(from(Box<dyn std::error::Error + Send + 'static>, Some)))]
-        source: Option<Box<dyn std::error::Error + Send + 'static>>,
+        #[snafu(source(from(Box<dyn std::error::Error + Send + Sync + 'static>, Some)))]
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
     },
 
     /// Input pixel data is not encapsulated
@@ -75,8 +75,8 @@ pub enum EncodeError {
         /// The error message.
         message: String,
         /// The underlying error cause, if any.
-        #[snafu(source(from(Box<dyn std::error::Error + Send + 'static>, Some)))]
-        source: Option<Box<dyn std::error::Error + Send + 'static>>,
+        #[snafu(source(from(Box<dyn std::error::Error + Send + Sync + 'static>, Some)))]
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
     },
 
     /// Input pixel data is not native, should be decoded first

--- a/encoding/src/lib.rs
+++ b/encoding/src/lib.rs
@@ -31,3 +31,6 @@ pub use transfer_syntax::DataRWAdapter;
 pub use transfer_syntax::NeverAdapter;
 pub use transfer_syntax::TransferSyntax;
 pub use transfer_syntax::TransferSyntaxIndex;
+
+// public dependency re-export
+pub use snafu;

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -10,14 +10,26 @@ keywords = ["dicom"]
 readme = "README.md"
 
 [features]
-default = []
+default = ["native"]
+
+# inventory for compile time plugin-based transfer syntax registration
 inventory-registry = ['dicom-encoding/inventory-registry', 'inventory']
+
+# natively implemented image encodings
+native = ["jpeg", "rle"]
+# native JPEG support
+jpeg = ["jpeg-decoder"]
+# native RLE lossless support
+rle = []
 
 [dependencies]
 dicom-core = { path = "../core", version = "0.5.2" }
 dicom-encoding = { path = "../encoding", version = "0.5.2" }
 lazy_static = "1.2.0"
-encoding = "0.2.33"
 byteordered = "0.6"
 inventory = { version = "0.2.2", optional = true }
 tracing = "0.1.34"
+
+[dependencies.jpeg-decoder]
+version = "0.2.4"
+optional = true

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -31,5 +31,5 @@ inventory = { version = "0.2.2", optional = true }
 tracing = "0.1.34"
 
 [dependencies.jpeg-decoder]
-version = "0.2.4"
+version = "0.3.0"
 optional = true

--- a/transfer-syntax-registry/src/adapters/jpeg.rs
+++ b/transfer-syntax-registry/src/adapters/jpeg.rs
@@ -1,11 +1,11 @@
 //! Support for JPG image decoding.
 
-use super::MissingAttributeSnafu;
-use crate::adapters::{DecodeResult, PixelDataObject, PixelRWAdapter};
+use dicom_encoding::snafu::prelude::*;
+use dicom_encoding::adapters::{DecodeResult, PixelDataObject, PixelRWAdapter, decode_error};
 use jpeg_decoder::Decoder;
-use snafu::{whatever, OptionExt, ResultExt};
 use std::io::Cursor;
 
+/// Pixel data adapter for JPEG-based transfer syntaxes.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct JPEGAdapter;
 
@@ -14,12 +14,12 @@ impl PixelRWAdapter for JPEGAdapter {
     fn decode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> DecodeResult<()> {
         let cols = src
             .cols()
-            .context(MissingAttributeSnafu { name: "Columns" })?;
-        let rows = src.rows().context(MissingAttributeSnafu { name: "Rows" })?;
-        let samples_per_pixel = src.samples_per_pixel().context(MissingAttributeSnafu {
+            .context(decode_error::MissingAttributeSnafu { name: "Columns" })?;
+        let rows = src.rows().context(decode_error::MissingAttributeSnafu { name: "Rows" })?;
+        let samples_per_pixel = src.samples_per_pixel().context(decode_error::MissingAttributeSnafu {
             name: "SamplesPerPixel",
         })?;
-        let bits_allocated = src.bits_allocated().context(MissingAttributeSnafu {
+        let bits_allocated = src.bits_allocated().context(decode_error::MissingAttributeSnafu {
             name: "BitsAllocated",
         })?;
 

--- a/transfer-syntax-registry/src/adapters/mod.rs
+++ b/transfer-syntax-registry/src/adapters/mod.rs
@@ -1,0 +1,27 @@
+//! Root module for extended pixel data adapters.
+//! 
+//! Additional support for certain transfer syntaxes
+//! can be added via Cargo features.
+//! 
+//! - [`jpeg`](jpeg) provides native JPEG decoding
+//!   (baseline and lossless).
+//!   Requires the `jpeg` feature,
+//!   enabled by default.
+//! - [`rle_lossless`](rle_lossless) provides RLE lossless decoding.
+//!   Requires the `rle` feature,
+//!   enabled by default.
+
+#[cfg(feature = "jpeg")]
+pub mod jpeg;
+#[cfg(feature = "rle")]
+pub mod rle_lossless;
+
+/// **Note:** This module is a stub.
+/// Enable the `jpeg` feature to use this module.
+#[cfg(not(feature = "jpeg"))]
+pub mod jpeg {}
+
+/// **Note:** This module is a stub.
+/// Enable the `rle` feature to use this module.
+#[cfg(not(feature = "rle"))]
+pub mod rle {}

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -3,28 +3,35 @@
 //! The constants exported here refer to the library's built-in support
 //! for DICOM transfer syntaxes.
 //!
-//! **Fully implemented** means that the default transfer syntax registry
-//! provides built-in support for reading and writing data sets,
-//! as well as for encoding and decoding encapsulated pixel data,
-//! if applicable.
-//! **Stub descriptors** serve to provide information about
-//! the transfer syntax,
-//! and may provide partial support.
-//! In most cases it will be possible to read and write data sets,
-//! but not encode or decode encapsulated pixel data.
+//! - **Fully implemented** means that the default transfer syntax registry
+//!   provides built-in support for reading and writing data sets,
+//!   as well as for encoding and decoding encapsulated pixel data,
+//!   if applicable.
+//! - When specified as **Implemented**,
+//!   the transfer syntax is supported to some extent
+//!   (usually decoding is supported but not encoding).
+//! - **Stub descriptors** serve to provide information about
+//!   the transfer syntax,
+//!   and may provide partial support.
+//!   In most cases it will be possible to read and write data sets,
+//!   but not encode or decode encapsulated pixel data.
 //!
-//! Other crates may be developed to replace stubs,
+//! With the `inventory-registry` feature,
+//! stubs can be replaced by independently developed crates,
 //! hence expanding support for those transfer syntaxes
 //! to the registry.
 
 use crate::create_ts_stub;
 use byteordered::Endianness;
 use dicom_encoding::{
-    adapters::jpeg::JPEGAdapter,
-    adapters::rle_lossless::RLELosslessAdapter,
     transfer_syntax::{AdapterFreeTransferSyntax as Ts, Codec, NeverAdapter},
     TransferSyntax,
 };
+
+#[cfg(feature = "jpeg")]
+use crate::adapters::jpeg::JPEGAdapter;
+#[cfg(feature = "rle")]
+use crate::adapters::rle_lossless::RleLosslessAdapter;
 
 // -- the three base transfer syntaxes, fully supported --
 
@@ -57,13 +64,81 @@ pub const EXPLICIT_VR_BIG_ENDIAN: Ts = Ts::new(
 
 // -- transfer syntaxes with pixel data adapters, fully supported --
 
-/// **Fully supported:** RLE Lossless
-pub const RLE_LOSSLESS: TransferSyntax<NeverAdapter, RLELosslessAdapter> = TransferSyntax::new(
+/// **Implemented:** RLE Lossless
+#[cfg(feature = "rle")]
+pub const RLE_LOSSLESS: TransferSyntax<NeverAdapter, RleLosslessAdapter> = TransferSyntax::new(
     "1.2.840.10008.1.2.5",
     "RLE Lossless",
     Endianness::Little,
     true,
-    Codec::PixelData(RLELosslessAdapter),
+    Codec::PixelData(RleLosslessAdapter),
+);
+/// **Stub:** RLE Lossless
+#[cfg(not(feature = "rle"))]
+pub const RLE_LOSSLESS: Ts = create_ts_stub("1.2.840.10008.1.2.5", "RLE Lossless");
+
+// JPEG encoded pixel data
+/// An alias for a transfer syntax specifier with JPEGPixelAdapter
+#[cfg(feature = "jpeg")]
+type JpegTS = TransferSyntax<NeverAdapter, JPEGAdapter>;
+
+/// create a TS with jpeg encapsulation
+#[cfg(feature = "jpeg")]
+const fn create_ts_jpeg(uid: &'static str, name: &'static str) -> JpegTS {
+    TransferSyntax::new(
+        uid,
+        name,
+        Endianness::Little,
+        true,
+        Codec::PixelData(JPEGAdapter),
+    )
+}
+
+/// **Implemented:** JPEG Baseline (Process 1): Default Transfer Syntax for Lossy JPEG 8 Bit Image Compression
+#[cfg(feature = "jpeg")]
+pub const JPEG_BASELINE: JpegTS =
+    create_ts_jpeg("1.2.840.10008.1.2.4.50", "JPEG Baseline (Process 1)");
+/// **Implemented:** JPEG Baseline (Process 1): Default Transfer Syntax for Lossy JPEG 8 Bit Image Compression
+#[cfg(not(feature = "jpeg"))]
+pub const JPEG_BASELINE: Ts = create_ts_stub("1.2.840.10008.1.2.4.50", "JPEG Baseline (Process 1)");
+
+/// **Implemented:** JPEG Extended (Process 2 & 4): Default Transfer Syntax for Lossy JPEG 12 Bit Image Compression (Process 4 only)
+#[cfg(feature = "jpeg")]
+pub const JPEG_EXTENDED: JpegTS =
+    create_ts_jpeg("1.2.840.10008.1.2.4.51", "JPEG Extended (Process 2 & 4)");
+/// **Stub descriptor:** JPEG Extended (Process 2 & 4): Default Transfer Syntax for Lossy JPEG 12 Bit Image Compression (Process 4 only)
+#[cfg(not(feature = "jpeg"))]
+pub const JPEG_EXTENDED: Ts =
+    create_ts_stub("1.2.840.10008.1.2.4.51", "JPEG Extended (Process 2 & 4)");
+
+/// **Implemented:** JPEG Lossless, Non-Hierarchical (Process 14)
+#[cfg(feature = "jpeg")]
+pub const JPEG_LOSSLESS_NON_HIERARCHICAL: JpegTS = create_ts_jpeg(
+    "1.2.840.10008.1.2.4.57",
+    "JPEG Lossless, Non-Hierarchical (Process 14)",
+);
+/// **Stub descriptor:** JPEG Lossless, Non-Hierarchical (Process 14)
+#[cfg(not(feature = "jpeg"))]
+pub const JPEG_LOSSLESS_NON_HIERARCHICAL: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.57",
+    "JPEG Lossless, Non-Hierarchical (Process 14)",
+);
+
+/// **Implemented:** JPEG Lossless, Non-Hierarchical, First-Order Prediction
+/// (Process 14 [Selection Value 1]):
+/// Default Transfer Syntax for Lossless JPEG Image Compression
+#[cfg(feature = "jpeg")]
+pub const JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION: JpegTS = create_ts_jpeg(
+    "1.2.840.10008.1.2.4.70",
+    "JPEG Lossless, Non-Hierarchical, First-Order Prediction",
+);
+/// **Stub descriptor:** JPEG Lossless, Non-Hierarchical, First-Order Prediction
+/// (Process 14 [Selection Value 1]):
+/// Default Transfer Syntax for Lossless JPEG Image Compression
+#[cfg(not(feature = "jpeg"))]
+pub const JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.70",
+    "JPEG Lossless, Non-Hierarchical, First-Order Prediction",
 );
 
 // --- stub transfer syntaxes, known but not supported ---
@@ -86,41 +161,8 @@ pub const JPIP_REFERENCED_DEFLATE: Ts = Ts::new(
     Codec::Unsupported,
 );
 
-// JPEG encoded pixel data
-/// An alias for a transfer syntax specifier with JPEGPixelAdapter
-pub type JpegTS = TransferSyntax<NeverAdapter, JPEGAdapter>;
-
-/// create a TS with jpeg encapsulation
-const fn create_ts_jpeg(uid: &'static str, name: &'static str) -> JpegTS {
-    TransferSyntax::new(
-        uid,
-        name,
-        Endianness::Little,
-        true,
-        Codec::PixelData(JPEGAdapter),
-    )
-}
-
-/// **Stub descriptor:** JPEG Baseline (Process 1): Default Transfer Syntax for Lossy JPEG 8 Bit Image Compression
-pub const JPEG_BASELINE: JpegTS =
-    create_ts_jpeg("1.2.840.10008.1.2.4.50", "JPEG Baseline (Process 1)");
-/// **Stub descriptor:** JPEG Extended (Process 2 & 4): Default Transfer Syntax for Lossy JPEG 12 Bit Image Compression (Process 4 only)
-pub const JPEG_EXTENDED: JpegTS =
-    create_ts_jpeg("1.2.840.10008.1.2.4.51", "JPEG Extended (Process 2 & 4)");
-/// **Stub descriptor:** JPEG Lossless, Non-Hierarchical (Process 14)
-pub const JPEG_LOSSLESS_NON_HIERARCHICAL: JpegTS = create_ts_jpeg(
-    "1.2.840.10008.1.2.4.57",
-    "JPEG Lossless, Non-Hierarchical (Process 14)",
-);
-/// **Stub descriptor:** JPEG Lossless, Non-Hierarchical, First-Order Prediction
-/// (Process 14 [Selection Value 1]):
-/// Default Transfer Syntax for Lossless JPEG Image Compression
-pub const JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION: JpegTS = create_ts_jpeg(
-    "1.2.840.10008.1.2.4.70",
-    "JPEG Lossless, Non-Hierarchical, First-Order Prediction",
-);
-
 // --- partially supported transfer syntaxes, pixel data encapsulation not supported ---
+
 /// **Stub descriptor:** JPEG-LS Lossless Image Compression
 pub const JPEG_LS_LOSSLESS_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.80",

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -45,6 +45,8 @@ use std::fmt;
 pub use dicom_encoding::TransferSyntax;
 pub mod entries;
 
+mod adapters;
+
 /// Data type for a registry of DICOM.
 pub struct TransferSyntaxRegistryImpl {
     m: HashMap<&'static str, TransferSyntax>,

--- a/ul/Cargo.toml
+++ b/ul/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 byteordered = "0.6"
 dicom-encoding = { path = "../encoding/", version = "0.5.3" }
-dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.5.1" }
+dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.5.1", default-features = false }
 snafu = "0.7.3"
 tracing = "0.1.34"
 


### PR DESCRIPTION
- lighten encoding crate, tweak definitions a bit
- [transfer-syntax-registry] add features for jpeg and rle adapters
- change encoding adapter APIs of `DecodeError` and `EncodeError` for better usability 
- propagate feature usage to other crates