### PR TITLE
[ul] Fix errors in A-ABORT PDU writing

### DIFF
--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -205,13 +205,20 @@ impl AbortRQSource {
     }
 }
 
+/// An enumeration of supported A-ABORT PDU provider reasons.
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
 pub enum AbortRQServiceProviderReason {
+    /// Either _Reason Not Specified_ or _Unrecognized PDU_
     ReasonNotSpecifiedUnrecognizedPdu,
+    /// Unexpected PDU
     UnexpectedPdu,
+    /// Reserved
     Reserved,
+    /// Unrecognized PDU parameter
     UnrecognizedPduParameter,
+    /// Unexpected PDU parameter
     UnexpectedPduParameter,
+    /// Invalid PDU parameter
     InvalidPduParameter,
 }
 

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -182,7 +182,7 @@ impl AbortRQSource {
         let result = match (source, reason) {
             (0, _) => AbortRQSource::ServiceUser,
             (1, _) => AbortRQSource::Reserved,
-            (2, 0) => AbortRQSource::ServiceProvider(
+            (2, 0) | (2, 1) => AbortRQSource::ServiceProvider(
                 AbortRQServiceProviderReason::ReasonNotSpecifiedUnrecognizedPdu,
             ),
             (2, 2) => AbortRQSource::ServiceProvider(AbortRQServiceProviderReason::UnexpectedPdu),

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -524,15 +524,11 @@ where
             write_chunk_u32(writer, |writer| {
                 // 7 - Reserved - This reserved field shall be sent with a value 00H but not tested
                 // to this value when received.
-                writer
-                    .write_u8(0x00)
-                    .context(WriteReservedSnafu { bytes: 1_u32 })?;
-
                 // 8 - Reserved - This reserved field shall be sent with a value 00H but not tested
                 // to this value when received.
                 writer
-                    .write_u8(0x00)
-                    .context(WriteReservedSnafu { bytes: 1_u32 })?;
+                    .write_all(&[0x00, 0x00])
+                    .context(WriteReservedSnafu { bytes: 2_u32 })?;
 
                 // 9 - Source - This Source field shall contain an integer value encoded as an
                 // unsigned binary number. One of the following values shall be used:

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -416,11 +416,7 @@ where
                         // 5 - Presentation-context-ID - Presentation-context-ID values shall be odd
                         // integers between 1 and 255, encoded as an unsigned binary number. For a
                         // complete description of the use of this field see Section 7.1.1.13.
-                        writer
-                            .write_u8(presentation_data_value.presentation_context_id)
-                            .context(WriteFieldSnafu {
-                                field: "Presentation-context-ID",
-                            })?;
+                        writer.push(presentation_data_value.presentation_context_id);
 
                         // 6-xxx - Presentation-data-value - This Presentation-data-value field
                         // shall contain DICOM message information (command and/or data set) with a
@@ -445,16 +441,10 @@ where
                         if presentation_data_value.is_last {
                             message_header |= 0x02;
                         }
-                        writer.write_u8(message_header).context(WriteFieldSnafu {
-                            field: "Presentation-data-value control header",
-                        })?;
+                        writer.push(message_header);
 
                         // Message fragment
-                        writer.write_all(&presentation_data_value.data).context(
-                            WriteFieldSnafu {
-                                field: "Presentation-data-value",
-                            },
-                        )?;
+                        writer.extend(&presentation_data_value.data);
 
                         Ok(())
                     })
@@ -480,9 +470,8 @@ where
                 .context(WriteReservedSnafu { bytes: 1_u32 })?;
 
             write_chunk_u32(writer, |writer| {
-                writer.write_all(&[0u8; 4]).context(WriteFieldSnafu {
-                    field: "ReleaseRQ data",
-                })
+                writer.extend(&[0u8; 4]);
+                Ok(())
             })
             .context(WriteChunkSnafu { name: "ReleaseRQ" })?;
 
@@ -501,9 +490,8 @@ where
                 .context(WriteReservedSnafu { bytes: 1_u32 })?;
 
             write_chunk_u32(writer, |writer| {
-                writer.write_all(&[0u8; 4]).context(WriteFieldSnafu {
-                    field: "ReleaseRP data",
-                })
+                writer.extend(&[0u8; 4]);
+                Ok(())
             })
             .context(WriteChunkSnafu { name: "ReleaseRP" })?;
 
@@ -524,11 +512,10 @@ where
             write_chunk_u32(writer, |writer| {
                 // 7 - Reserved - This reserved field shall be sent with a value 00H but not tested
                 // to this value when received.
+                writer.push(0);
                 // 8 - Reserved - This reserved field shall be sent with a value 00H but not tested
                 // to this value when received.
-                writer
-                    .write_all(&[0x00, 0x00])
-                    .context(WriteReservedSnafu { bytes: 2_u32 })?;
+                writer.push(0);
 
                 // 9 - Source - This Source field shall contain an integer value encoded as an
                 // unsigned binary number. One of the following values shall be used:
@@ -561,9 +548,7 @@ where
                         AbortRQServiceProviderReason::InvalidPduParameter => [0x02, 0x06],
                     },
                 };
-                writer.write_all(&source_word).context(WriteFieldSnafu {
-                    field: "AbortRQSource",
-                })?;
+                writer.extend(&source_word);
 
                 Ok(())
             })
@@ -584,9 +569,8 @@ where
                 .context(WriteReservedSnafu { bytes: 1_u32 })?;
 
             write_chunk_u32(writer, |writer| {
-                writer.write_all(data).context(WriteFieldSnafu {
-                    field: "Unknown data",
-                })
+                writer.extend(data);
+                Ok(())
             })
             .context(WriteChunkSnafu { name: "Unknown" })?;
 

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -553,7 +553,7 @@ where
                 // this value when received.
                 let source_word = match source {
                     AbortRQSource::ServiceUser => [0x00; 2],
-                    AbortRQSource::Reserved => [0x00, 0x01],
+                    AbortRQSource::Reserved => [0x01, 0x00],
                     AbortRQSource::ServiceProvider(reason) => match reason {
                         AbortRQServiceProviderReason::ReasonNotSpecifiedUnrecognizedPdu => {
                             [0x02, 0x00]
@@ -1092,7 +1092,7 @@ mod tests {
                 0x07, 0x00, //
                 // PDU length: 4 bytes
                 0x00, 0x00, 0x00, 0x04, //
-                // reserved 2 bytes + source: service user (0)
+                // reserved 2 bytes + source: service user (0) + reason (0)
                 0x00, 0x00, 0x00, 0x00,
             ]
         );
@@ -1110,8 +1110,8 @@ mod tests {
                 0x07, 0x00, //
                 // PDU length: 4 bytes
                 0x00, 0x00, 0x00, 0x04, //
-                // reserved 2 bytes + source: reserved (1)
-                0x00, 0x00, 0x00, 0x01,
+                // reserved 2 bytes + source: reserved (1) + reason (0)
+                0x00, 0x00, 0x01, 0x00,
             ]
         );
         out.clear();

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -1089,8 +1089,10 @@ mod tests {
             &out,
             &[
                 // code 7 + reserved byte
-                0x07, 0x00, // PDU length: 4 bytes
-                0x00, 0x00, 0x00, 0x04, // reserved 2 bytes + source: service user (0)
+                0x07, 0x00, //
+                // PDU length: 4 bytes
+                0x00, 0x00, 0x00, 0x04, //
+                // reserved 2 bytes + source: service user (0)
                 0x00, 0x00, 0x00, 0x00,
             ]
         );
@@ -1105,8 +1107,10 @@ mod tests {
             &out,
             &[
                 // code 7 + reserved byte
-                0x07, 0x00, // PDU length: 4 bytes
-                0x00, 0x00, 0x00, 0x04, // reserved 2 bytes + source: reserved (1)
+                0x07, 0x00, //
+                // PDU length: 4 bytes
+                0x00, 0x00, 0x00, 0x04, //
+                // reserved 2 bytes + source: reserved (1)
                 0x00, 0x00, 0x00, 0x01,
             ]
         );
@@ -1123,9 +1127,12 @@ mod tests {
             &out,
             &[
                 // code 7 + reserved byte
-                0x07, 0x00, // PDU length: 4 bytes
-                0x00, 0x00, 0x00, 0x04, // reserved 2 bytes
-                0x00, 0x00, // source: service provider (2), invalid parameter value (6)
+                0x07, 0x00, //
+                // PDU length: 4 bytes
+                0x00, 0x00, 0x00, 0x04, //
+                // reserved 2 bytes
+                0x00, 0x00, //
+                // source: service provider (2), invalid parameter value (6)
                 0x02, 0x06,
             ]
         );


### PR DESCRIPTION
- write `[1, 0]` on _Reserved_ source for consistency
- write code `2` on Source Provider, which was missing

Detected via the fuzz tests in #258. Thanks @evanrichter for reporting inconsistencies here.