### PR TITLE
[ul] Add safeguard to PDU item length

### DIFF
--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -53,6 +53,11 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Invalid item length {} (must be >=2)", length))]
+    InvalidItemLength {
+        length: u32,
+    },
+
     #[snafu(display("Could not read {} reserved bytes", bytes))]
     ReadReserved {
         bytes: u32,
@@ -416,6 +421,8 @@ where
                 let item_length = cursor.read_u32::<BigEndian>().context(ReadPduFieldSnafu {
                     field: "Item-Length",
                 })?;
+
+                ensure!(item_length >= 2, InvalidItemLengthSnafu { length: item_length });
 
                 // 5 - Presentation-context-ID - Presentation-context-ID values shall be odd
                 // integers between 1 and 255, encoded as an unsigned binary number. For a complete

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -483,7 +483,7 @@ where
             // tested to this value when received.
             cursor
                 .seek(SeekFrom::Current(4))
-                .context(ReadPduFieldSnafu { field: "Reserved" })?;
+                .context(ReadReservedSnafu { bytes: 4_u32 })?;
 
             Ok(Pdu::ReleaseRQ)
         }
@@ -494,7 +494,7 @@ where
             // tested to this value when received.
             cursor
                 .seek(SeekFrom::Current(4))
-                .context(ReadPduFieldSnafu { field: "Reserved" })?;
+                .context(ReadReservedSnafu { bytes: 4_u32 })?;
 
             Ok(Pdu::ReleaseRP)
         }
@@ -503,15 +503,12 @@ where
 
             // 7 - Reserved - This reserved field shall be sent with a value 00H but not tested to
             // this value when received.
-            cursor
-                .read_u8()
-                .context(ReadPduFieldSnafu { field: "Reserved" })?;
-
             // 8 - Reserved - This reserved field shall be sent with a value 00H but not tested to
             // this value when received.
+            let mut buf = [0u8; 2];
             cursor
-                .read_u8()
-                .context(ReadPduFieldSnafu { field: "Reserved" })?;
+                .read_exact(&mut buf)
+                .context(ReadReservedSnafu { bytes: 2_u32 })?;
 
             // 9 - Source - This Source field shall contain an integer value encoded as an unsigned
             // binary number. One of the following values shall be used:


### PR DESCRIPTION
A P-DATA-TF PDU item length must always be 2 or larger, otherwise the data is malformed. An explicit check on this prevents subtraction overflow which could be caused by malformed external data.

This was detected by the fuzz test harness proposed in #258.