### PR TITLE
Add items helper

### DIFF
--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -484,10 +484,9 @@ where
         self.value().to_multi_datetime(default_offset)
     }
 
-    /// Retrieve items stored in value
+    /// Retrieve the items stored in a sequence value.
     ///
-    /// If value is not a sequence return None.
-    ///
+    /// Returns `None` if the value is not a sequence.
     pub fn to_items(&self) -> Option<&[I]> {
         self.value().items()
     }

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -297,7 +297,7 @@ where
 
     /// Retrieves the element's value as a clean string
     #[deprecated(
-        note = "`to_clean_str()` is now deprecated in favour of using `to_str()` directly. 
+        note = "`to_clean_str()` is now deprecated in favour of using `to_str()` directly.
         `to_raw_str()` replaces the old functionality of `to_str()` and maintains all trailing whitespace."
     )]
     pub fn to_clean_str(&self) -> Result<Cow<str>, CastValueError> {
@@ -482,6 +482,14 @@ where
         default_offset: FixedOffset,
     ) -> Result<Vec<DicomDateTime>, ConvertValueError> {
         self.value().to_multi_datetime(default_offset)
+    }
+
+    /// Retrieve items stored in value
+    ///
+    /// If value is not a sequence return None.
+    ///
+    pub fn to_items(&self) -> Option<&[I]> {
+        self.value().items()
     }
 }
 

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -487,7 +487,7 @@ where
     /// Retrieve the items stored in a sequence value.
     ///
     /// Returns `None` if the value is not a sequence.
-    pub fn to_items(&self) -> Option<&[I]> {
+    pub fn items(&self) -> Option<&[I]> {
         self.value().items()
     }
 }

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -240,7 +240,7 @@ where
     ///
     /// Returns an error if the value is not primitive.
     #[deprecated(
-        note = "`to_clean_str()` is now deprecated in favour of using `to_str()` directly. 
+        note = "`to_clean_str()` is now deprecated in favour of using `to_str()` directly.
         `to_raw_str()` replaces the old functionality of `to_str()` and maintains all trailing whitespace."
     )]
     pub fn to_clean_str(&self) -> Result<Cow<str>, CastValueError> {


### PR DESCRIPTION
Allows for easy access to sequential data for example when trying
to access data stored in CONTENT_SEQUENCE tags commonly used in
SR files.