### PR TITLE
fallible allocations during object parsing

### DIFF
--- a/object/fuzz/Cargo.lock
+++ b/object/fuzz/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "dicom-parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "dicom-core",

--- a/object/fuzz/fuzz.sh
+++ b/object/fuzz/fuzz.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+env ASAN_OPTIONS=allocator_may_return_null=1:max_allocation_size_mb=40 cargo +nightly fuzz run open_file


### PR DESCRIPTION
these checks handle arbitrary length records, failing gracefully if allocation is too high. Also, they enforce that the amount of data read exactly matches the length reported.

the fuzzer in dicom-object is updated with a `fuzz.sh` script that sets the correct ASAN parameters to allow fallible allocations (normally ASAN reports large `malloc`s as an immediate failure)