### PR TITLE
Fix assorted clippy lints

### DIFF
--- a/core/src/value/deserialize.rs
+++ b/core/src/value/deserialize.rs
@@ -323,7 +323,7 @@ where
 {
     debug_assert!(!buf.is_empty());
     debug_assert!(buf.len() < 10);
-    (&buf[1..]).iter().fold((buf[0] - b'0').into(), |acc, v| {
+    buf[1..].iter().fold((buf[0] - b'0').into(), |acc, v| {
         acc * T::ten() + (*v - b'0').into()
     })
 }

--- a/encoding/src/encode/mod.rs
+++ b/encoding/src/encode/mod.rs
@@ -163,15 +163,15 @@ pub trait BasicEncode {
         match value {
             Empty => Ok(0), // no-op
             Date(date) => {
-                encode_collection_delimited(&mut to, &*date, |to, date| encode_date(to, *date))
+                encode_collection_delimited(&mut to, date, |to, date| encode_date(to, *date))
                     .context(WriteDateSnafu)
             }
             Time(time) => {
-                encode_collection_delimited(&mut to, &*time, |to, time| encode_time(to, *time))
+                encode_collection_delimited(&mut to, time, |to, time| encode_time(to, *time))
                     .context(WriteTimeSnafu)
             }
             DateTime(datetime) => {
-                encode_collection_delimited(&mut to, &*datetime, |to, datetime| {
+                encode_collection_delimited(&mut to, datetime, |to, datetime| {
                     encode_datetime(to, *datetime)
                 })
                 .context(WriteDateTimeSnafu)
@@ -183,7 +183,7 @@ pub trait BasicEncode {
                 write!(to, "{}", s).context(WriteStringSnafu)?;
                 Ok(s.len())
             }
-            Strs(s) => encode_collection_delimited(&mut to, &*s, |to, s| {
+            Strs(s) => encode_collection_delimited(&mut to, s, |to, s| {
                 // Note: this will always print in UTF-8. Consumers should
                 // intercept string primitive values and encode them according
                 // to the expected character set.

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -53,7 +53,7 @@ pub struct InMemDicomObject<D = StandardDataDictionary> {
     len: Length,
 }
 
-impl<'s, D> PartialEq for InMemDicomObject<D> {
+impl<D> PartialEq for InMemDicomObject<D> {
     // This implementation ignores the data dictionary.
     fn eq(&self, other: &Self) -> bool {
         self.entries == other.entries

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -598,10 +598,10 @@ impl FileMetaTableBuilder {
 
     /// Build the table.
     pub fn build(self) -> Result<FileMetaTable> {
-        let information_version = self.information_version.unwrap_or_else(|| {
+        let information_version = self.information_version.unwrap_or(
             // Missing information version, will assume (00H, 01H). See #28
-            [0, 1]
-        });
+            [0, 1],
+        );
         let media_storage_sop_class_uid =
             self.media_storage_sop_class_uid
                 .context(MissingElementSnafu {

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -429,7 +429,7 @@ impl FileMetaTable {
 }
 
 /// A builder for DICOM meta information tables.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct FileMetaTableBuilder {
     /// File Meta Information Group Length (UL)
     information_group_length: Option<u32>,
@@ -456,25 +456,6 @@ pub struct FileMetaTableBuilder {
     private_information_creator_uid: Option<String>,
     /// Private Information (OB)
     private_information: Option<Vec<u8>>,
-}
-
-impl Default for FileMetaTableBuilder {
-    fn default() -> FileMetaTableBuilder {
-        FileMetaTableBuilder {
-            information_group_length: None,
-            information_version: None,
-            media_storage_sop_class_uid: None,
-            media_storage_sop_instance_uid: None,
-            transfer_syntax: None,
-            implementation_class_uid: None,
-            implementation_version_name: None,
-            source_application_entity_title: None,
-            sending_application_entity_title: None,
-            receiving_application_entity_title: None,
-            private_information_creator_uid: None,
-            private_information: None,
-        }
-    }
 }
 
 /// Ensure that the string is even lengthed, by adding a trailing character

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -364,10 +364,7 @@ impl PhotometricInterpretation {
     /// one of the monochrome variants
     /// (`MONOCHROME1` or `MONOCHROME2`).
     pub fn is_monochrome(&self) -> bool {
-        match self {
-            PhotometricInterpretation::Monochrome1 | PhotometricInterpretation::Monochrome2 => true,
-            _ => false,
-        }
+        matches!(self, PhotometricInterpretation::Monochrome1 | PhotometricInterpretation::Monochrome2)
     }
 }
 

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -835,7 +835,7 @@ impl DecodedPixelData<'_> {
                                 8,
                                 signed,
                                 rescale,
-                                data.into_iter().copied(),
+                                data.iter().copied(),
                             )
                             .context(CreateLutSnafu)?,
                         };

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1414,7 +1414,7 @@ impl DecodedPixelData<'_> {
 fn bytes_to_vec_u16(data: &[u8]) -> Vec<u16> {
     debug_assert!(data.len() % 2 == 0);
     let mut pixel_array: Vec<u16> = vec![0; data.len() / 2];
-    NativeEndian::read_u16_into(&data, &mut pixel_array);
+    NativeEndian::read_u16_into(data, &mut pixel_array);
     pixel_array
 }
 

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -444,22 +444,16 @@ where
                 // following fragment shall contain the last fragment of a Message Data Set or of a
                 // Message Command. If bit 1 is set to 0, the following fragment
                 // does not contain the last fragment of a Message Data Set or of a Message Command.
-                let value_type;
-                let is_last;
                 let header = cursor.read_u8().context(ReadPduFieldSnafu {
                     field: "Message Control Header",
                 })?;
-
-                if header & 0x01 > 0 {
-                    value_type = PDataValueType::Command;
+                
+                let value_type = if header & 0x01 > 0 {
+                    PDataValueType::Command
                 } else {
-                    value_type = PDataValueType::Data;
-                }
-                if header & 0x02 > 0 {
-                    is_last = true;
-                } else {
-                    is_last = false;
-                }
+                    PDataValueType::Data
+                };
+                let is_last = (header & 0x02) > 0;
 
                 let data =
                     read_n(&mut cursor, (item_length - 2) as usize).context(ReadPduFieldSnafu {


### PR DESCRIPTION
Affected crates: `core`,  `encoding`, `object`, `ul`, `pixeldata`