### PR TITLE
[object] Add a few more iterator-related methods

### DIFF
--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -461,6 +461,10 @@ where
     }
 }
 
+/// This implementation creates an iterator
+/// to the elements of the underlying data set,
+/// consuming the whole object.
+/// The attributes in the file meta group are _not_ included.
 impl<O> IntoIterator for FileDicomObject<O>
 where
     O: IntoIterator,
@@ -473,6 +477,9 @@ where
     }
 }
 
+/// This implementation creates an iterator
+/// to the elements of the underlying data set.
+/// The attributes in the file meta group are _not_ included.
 impl<'a, O> IntoIterator for &'a FileDicomObject<O>
 where
     &'a O: IntoIterator,


### PR DESCRIPTION
This extends some of the types in the `object` crate which provide iterators to the contents of the DICOM objects.

This might help to make the object API a bit more ergonomic.
