### PR TITLE
Change chat platform to Zulip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,14 +72,14 @@ cargo fmt
 ## Discussion and roadmapping
 If you have more long-termed ideas about what DICOM-rs should include next,
 please have a look at the [roadmap] and look into existing issues to provide feedback.
-You can also have a chat at the official [Gitter room].
+You can also talk about the project at the official [DICOM-rs Zulip organization].
 
 If you have any further questions or concerns,
 or would like to be deeper involved in the project,
 please reach out to the project maintainers.
 
 [roadmap]: https://github.com/Enet4/dicom-rs/wiki/Roadmap
-[Gitter room]: https://gitter.im/dicom-rs/community
+[Zulip organization]: https://dicom-rs.zulipchat.com
 
 ## Project team and governance
 DICOM-rs is currently led by Eduardo Pinho ([**@Enet4**](https://github.com/Enet4), <enet4mikeenet@gmail.com>).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![continuous integration](https://github.com/Enet4/dicom-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/Enet4/dicom-rs/actions/workflows/rust.yml)
 ![Minimum Rust Version Stable](https://img.shields.io/badge/Minimum%20Rust%20Version-stable-green.svg)
 [![dependency status](https://deps.rs/repo/github/Enet4/dicom-rs/status.svg)](https://deps.rs/repo/github/Enet4/dicom-rs)
-[![Gitter](https://badges.gitter.im/dicom-rs/community.svg)](https://gitter.im/dicom-rs/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![DICOM-rs chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://dicom-rs.zulipchat.com/)
 [![Documentation](https://docs.rs/dicom/badge.svg)](https://docs.rs/dicom)
 
 An ecosystem of library and tools for [DICOM](https://dicomstandard.org) compliant systems.


### PR DESCRIPTION
DICOM-rs is moving away from Gitter and into Zulip for free-form, real-time communication. https://dicom-rs.zulipchat.com

I have already set up this organization with a general stream, a help stream, and a read-only stream with a GitHub activity feed.

If you are unfamiliar with Zulip, see [Getting Started](https://dicom-rs.zulipchat.com/help/getting-started-with-zulip).