### PR TITLE
[echoscu|storescu] Change SCP address parameter to enable specifying AE title

### DIFF
--- a/echoscu/README.md
+++ b/echoscu/README.md
@@ -25,10 +25,18 @@ FLAGS:
     -v, --verbose    verbose mode
 
 OPTIONS:
-        --called-ae-title <called-ae-title>      the called AE title [default: ANY-SCP]
+        --called-ae-title <called-ae-title>
+            the called Application Entity title, overrides AE title in address if present [default: ANY-SCP]
+
         --calling-ae-title <calling-ae-title>    the calling AE title [default: ECHOSCU]
     -m, --message-id <message-id>                the C-ECHO message ID [default: 1]
 
 ARGS:
-    <addr>    socket address to SCP (example: "127.0.0.1:104")
+    <addr>    socket address to SCP, optionally with AE title (example: "QUERY-SCP@127.0.0.1:1045")
+```
+
+Example:
+
+```sh
+dicom-echoscu --verbose MAIN-STORAGE@192.168.1.99:104
 ```

--- a/storescu/README.md
+++ b/storescu/README.md
@@ -17,20 +17,29 @@ for `storescu` tools in other DICOM software projects.
 DICOM C-STORE SCU
 
 USAGE:
-    dicom-storescu [FLAGS] [OPTIONS] <addr> <file>
+    dicom-storescu [FLAGS] [OPTIONS] <addr> [files]...
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-    -v, --verbose    verbose mode
+        --fail-first    fail if not all DICOM files can be transferred
+    -h, --help          Prints help information
+    -V, --version       Prints version information
+    -v, --verbose       verbose mode
 
 OPTIONS:
-        --called-ae-title <called-ae-title>      the called AE title [default: ANY-SCP]
-        --calling-ae-title <calling-ae-title>    the calling AE title [default: STORE-SCU]
-        --max-pdu-length <max-pdu-length>        the maximum PDU length [default: 16384]
+        --called-ae-title <called-ae-title>
+            the called Application Entity title, overrides AE title in address if present [default: ANY-SCP]
+
+        --calling-ae-title <calling-ae-title>    the calling Application Entity title [default: STORE-SCU]
+        --max-pdu-length <max-pdu-length>        the maximum PDU length accepted by the SCU [default: 16384]
     -m, --message-id <message-id>                the C-STORE message ID [default: 1]
 
 ARGS:
-    <addr>    socket address to STORE SCP (example: "127.0.0.1:104")
-    <file>    the DICOM file to store
+    <addr>        socket address to Store SCP, optionally with AE title (example: "STORE-SCP@127.0.0.1:104")
+    <files>...    the DICOM file(s) to store
+```
+
+Example:
+
+```sh
+dicom-storescu MAIN-STORAGE@192.168.1.99:104 xray1.dcm xray2.dcm
 ```


### PR DESCRIPTION
This resolves #204, allowing users to specify the called AE title alongside the socket address with the optional syntax `called-ae-title@socketaddress`. The option `called-ae-title` overrides the AE title in the address with a warning.
README files were updated accordingly.

CC @Almeida-a