### PR TITLE
[object] Update dicom-test-files to v0.2.1

### DIFF
--- a/object/Cargo.toml
+++ b/object/Cargo.toml
@@ -28,9 +28,4 @@ tracing = "0.1.34"
 
 [dev-dependencies]
 tempfile = "3.2.0"
-
-# Patch version fixes shakyness in tests which use DICOM test files,
-# can be updated once https://github.com/robyoung/dicom-test-files/pull/2 is merged
-[dev-dependencies.dicom-test-files]
-git = "https://github.com/Enet4/dicom-test-files"
-branch = "patch-1"
+dicom-test-files = "0.2.1"


### PR DESCRIPTION
This had already been done at `pixeldata`, but it was probably overlooked at `dicom-object`.
