### PR TITLE
[core][parser] Require chrono 0.4.22

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["dicom"]
 readme = "README.md"
 
 [dependencies]
-chrono = "0.4.6"
+chrono = "0.4.22"
 itertools = "0.10"
 num-traits = "0.2.12"
 safe-transmute = "0.11.0"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 dicom-core = { path = "../core", version = "0.5.0" }
 dicom-encoding = { path = "../encoding", version = "0.5.0" }
-chrono = "0.4.6"
+chrono = "0.4.22"
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.5.0" }
 smallvec = "1.6.1"
 snafu = "0.7.0"


### PR DESCRIPTION
Evade known vulnerability [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159.html).