### PR TITLE
[object] Make it possible to mutate FileMetaTable in FileDicomObject

### DIFF
--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -298,6 +298,14 @@ impl<O> FileDicomObject<O> {
         &self.meta
     }
 
+    /// Retrieve a mutable reference to the processed meta header table.
+    /// 
+    /// Considerable care should be taken when modifying this table,
+    /// as it may influence object reading and writing operations.
+    pub fn meta_mut(&mut self) -> &mut FileMetaTable {
+        &mut self.meta
+    }
+
     /// Retrieve the inner DICOM object structure, discarding the meta table.
     pub fn into_inner(self) -> O {
         self.obj

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -466,6 +466,7 @@ where
     ///
     /// At the moment, this is sure to return `None`, because the meta
     /// table is kept in a separate wrapper value.
+    #[deprecated(since = "0.5.3", note = "Always returns None, see `FileDicomObject::meta` instead")]
     pub fn meta(&self) -> Option<&FileMetaTable> {
         None
     }


### PR DESCRIPTION
- Add new methods to manipulate `FileMetaTable` and refactor some of the implementation
- Add `FileDicomObject::meta_mut`
- Deprecate `InMemDicomObject::meta`