### PR TITLE
[storescu] safeguard max PDU length check

### DIFF
--- a/storescu/src/main.rs
+++ b/storescu/src/main.rs
@@ -285,7 +285,7 @@ fn run() -> Result<(), Error> {
                 );
             }
 
-            if nbytes < scu.acceptor_max_pdu_length() as usize - 100 {
+            if nbytes < scu.acceptor_max_pdu_length().saturating_sub(100) as usize {
                 let pdu = Pdu::PData {
                     data: vec![
                         PDataValue {


### PR DESCRIPTION
When deciding whether to put everything in a single PDU or in separate PDUs, make a calculation which does not panic if the negotiated maximum PDU length is too low.