### PR TITLE
[ul] correct AbortRQServiceProviderReason

### DIFF
--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -513,7 +513,7 @@ impl ServerAssociation {
     pub fn abort(mut self) -> Result<()> {
         let pdu = Pdu::AbortRQ {
             source: AbortRQSource::ServiceProvider(
-                AbortRQServiceProviderReason::ReasonNotSpecifiedUnrecognizedPdu,
+                AbortRQServiceProviderReason::ReasonNotSpecified,
             ),
         };
         let out = self.send(&pdu);

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -182,9 +182,10 @@ impl AbortRQSource {
         let result = match (source, reason) {
             (0, _) => AbortRQSource::ServiceUser,
             (1, _) => AbortRQSource::Reserved,
-            (2, 0) | (2, 1) => AbortRQSource::ServiceProvider(
-                AbortRQServiceProviderReason::ReasonNotSpecifiedUnrecognizedPdu,
-            ),
+            (2, 0) => {
+                AbortRQSource::ServiceProvider(AbortRQServiceProviderReason::ReasonNotSpecified)
+            }
+            (2, 1) => AbortRQSource::ServiceProvider(AbortRQServiceProviderReason::UnrecognizedPdu),
             (2, 2) => AbortRQSource::ServiceProvider(AbortRQServiceProviderReason::UnexpectedPdu),
             (2, 3) => AbortRQSource::ServiceProvider(AbortRQServiceProviderReason::Reserved),
             (2, 4) => AbortRQSource::ServiceProvider(
@@ -208,8 +209,10 @@ impl AbortRQSource {
 /// An enumeration of supported A-ABORT PDU provider reasons.
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
 pub enum AbortRQServiceProviderReason {
-    /// Either _Reason Not Specified_ or _Unrecognized PDU_
-    ReasonNotSpecifiedUnrecognizedPdu,
+    /// Reason Not Specified
+    ReasonNotSpecified,
+    /// Unrecognized PDU
+    UnrecognizedPdu,
     /// Unexpected PDU
     UnexpectedPdu,
     /// Reserved

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -538,9 +538,8 @@ where
                     AbortRQSource::ServiceUser => [0x00; 2],
                     AbortRQSource::Reserved => [0x01, 0x00],
                     AbortRQSource::ServiceProvider(reason) => match reason {
-                        AbortRQServiceProviderReason::ReasonNotSpecifiedUnrecognizedPdu => {
-                            [0x02, 0x00]
-                        }
+                        AbortRQServiceProviderReason::ReasonNotSpecified => [0x02, 0x00],
+                        AbortRQServiceProviderReason::UnrecognizedPdu => [0x02, 0x01],
                         AbortRQServiceProviderReason::UnexpectedPdu => [0x02, 0x02],
                         AbortRQServiceProviderReason::Reserved => [0x02, 0x03],
                         AbortRQServiceProviderReason::UnrecognizedPduParameter => [0x02, 0x04],


### PR DESCRIPTION
Split `ReasonNotSpecifiedUnrecognizedPdu` into `ReasonNotSpecified` and `UnrecognizedPdu`. Resolves #261.

