### PR TITLE
[ul] address module

### DIFF
--- a/echoscu/Cargo.toml
+++ b/echoscu/Cargo.toml
@@ -16,7 +16,7 @@ dicom-core = { path = "../core", version = "0.5.0" }
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.5.0" }
 dicom-object = { path = "../object/", version = "0.5.0" }
 dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.5.0" }
-dicom-ul = { path = "../ul", version = "0.4.0" }
+dicom-ul = { path = "../ul", version = "0.4.2" }
 smallvec = "1.6.1"
 snafu = "0.7.0"
 tracing = "0.1.34"

--- a/storescu/Cargo.toml
+++ b/storescu/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 dicom-core = { path = '../core', version = "0.5.0" }
-dicom-ul = { path = '../ul', version = "0.4.0" }
+dicom-ul = { path = '../ul', version = "0.4.2" }
 dicom-object = { path = '../object', version = "0.5.2" }
 dicom-encoding = { path = "../encoding/", version = "0.5.0" }
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.5.0" }

--- a/ul/src/address.rs
+++ b/ul/src/address.rs
@@ -1,0 +1,222 @@
+//! Data types for addresses to nodes in DICOM networks.
+
+use std::{
+    net::{AddrParseError, SocketAddr, ToSocketAddrs},
+    str::FromStr,
+};
+
+use snafu::{ResultExt, Snafu};
+
+/// A specification for a full address to the target SCP:
+/// an application entity title, plus a network socket address.
+///
+/// These addresses can be serialized and parsed
+/// with the syntax `{ae_title}@{socket_address}`.
+///
+/// For the version of the struct without a mandatory AE title,
+/// see [`AeAddr`].
+///
+/// # Example
+///
+/// ```
+/// # use dicom_ul::FullAeAddr;
+/// # use std::net::SocketAddr;
+/// #
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let addr: FullAeAddr = "SCP-STORAGE@127.0.0.1:104".parse()?;
+/// assert_eq!(addr.ae_title(), "SCP-STORAGE");
+/// assert_eq!(addr.socket_addr(), SocketAddr::from(([127, 0, 0, 1], 104)));
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct FullAeAddr {
+    ae_title: String,
+    socket_addr: std::net::SocketAddr,
+}
+
+impl FullAeAddr {
+    /// Create an AE address from its bare constituent parts.
+    pub fn new(ae_title: impl Into<String>, socket_addr: SocketAddr) -> Self {
+        FullAeAddr {
+            ae_title: ae_title.into(),
+            socket_addr,
+        }
+    }
+
+    /// Retrieve the application entity title portion.
+    pub fn ae_title(&self) -> &str {
+        &self.ae_title
+    }
+
+    /// Retrieve the socket address portion.
+    pub fn socket_addr(&self) -> std::net::SocketAddr {
+        self.socket_addr
+    }
+}
+
+impl From<(String, SocketAddr)> for FullAeAddr {
+    fn from((ae_title, socket_addr): (String, SocketAddr)) -> Self {
+        Self::new(ae_title, socket_addr)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Snafu)]
+pub enum ParseAeAddressError {
+    /// Missing `@` in full AE address
+    MissingPart,
+
+    /// Could not parse socket address
+    ParseSocketAddress { source: AddrParseError },
+}
+
+impl FromStr for FullAeAddr {
+    type Err = ParseAeAddressError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some((ae_title, addr)) = s.split_once('@') {
+            Ok(FullAeAddr {
+                ae_title: ae_title.to_string(),
+                socket_addr: addr.parse().context(ParseSocketAddressSnafu)?,
+            })
+        } else {
+            Err(ParseAeAddressError::MissingPart)
+        }
+    }
+}
+
+impl ToSocketAddrs for FullAeAddr {
+    type Iter = std::option::IntoIter<SocketAddr>;
+
+    fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
+        self.socket_addr.to_socket_addrs()
+    }
+}
+
+/// A specification for an address to the target SCP:
+/// a network socket address
+/// which may also include an application entity title.
+///
+/// These addresses can be serialized and parsed
+/// with the syntax `{ae_title}@{socket_address}`,
+/// where the
+///
+/// For the version of the struct in which the AE title part is mandatory,
+/// see [`FullAeAddr`].
+///
+/// # Example
+///
+/// ```
+/// # use dicom_ul::{AeAddr, FullAeAddr};
+/// # use std::net::SocketAddr;
+/// #
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let addr: AeAddr = "SCP-STORAGE@127.0.0.1:104".parse()?;
+/// assert_eq!(addr.ae_title(), Some("SCP-STORAGE"));
+/// assert_eq!(addr.socket_addr(), SocketAddr::from(([127, 0, 0, 1], 104)));
+///
+/// // AE title can be missing
+/// let addr: AeAddr = "192.168.1.99:1045".parse()?;
+/// assert_eq!(addr.ae_title(), None);
+/// // but can be provided later
+/// let full_addr: FullAeAddr = addr.with_ae_title("SCP-QUERY");
+/// assert_eq!(full_addr.ae_title(), "SCP-QUERY");
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct AeAddr {
+    ae_title: Option<String>,
+    socket_addr: std::net::SocketAddr,
+}
+
+impl AeAddr {
+    /// Create an AE address from its bare constituent parts.
+    pub fn new(ae_title: impl Into<String>, socket_addr: SocketAddr) -> Self {
+        AeAddr {
+            ae_title: Some(ae_title.into()),
+            socket_addr,
+        }
+    }
+
+    /// Create an AE address containing only a socket address.
+    pub fn new_socket_addr(socket_addr: SocketAddr) -> Self {
+        AeAddr {
+            ae_title: None,
+            socket_addr,
+        }
+    }
+
+    /// Retrieve the application entity title portion, if present.
+    pub fn ae_title(&self) -> Option<&str> {
+        self.ae_title.as_ref().map(String::as_str)
+    }
+
+    /// Retrieve the socket address portion.
+    pub fn socket_addr(&self) -> std::net::SocketAddr {
+        self.socket_addr
+    }
+
+    /// Create a new address with the full application entity target,
+    /// discarding any potentially existing AE title.
+    pub fn with_ae_title(self, ae_title: impl Into<String>) -> FullAeAddr {
+        FullAeAddr {
+            ae_title: ae_title.into(),
+            socket_addr: self.socket_addr,
+        }
+    }
+
+    /// Create a new address with the full application entity target,
+    /// using the given AE title if it is missing.
+    pub fn with_default_ae_title(self, ae_title: impl Into<String>) -> FullAeAddr {
+        FullAeAddr {
+            ae_title: self.ae_title.unwrap_or_else(|| ae_title.into()),
+            socket_addr: self.socket_addr,
+        }
+    }
+}
+
+/// This conversion provides an address without an AE title.
+impl From<SocketAddr> for AeAddr {
+    fn from(socket_addr: SocketAddr) -> Self {
+        AeAddr {
+            ae_title: None,
+            socket_addr,
+        }
+    }
+}
+
+impl From<FullAeAddr> for AeAddr {
+    fn from(full: FullAeAddr) -> Self {
+        AeAddr {
+            ae_title: Some(full.ae_title),
+            socket_addr: full.socket_addr,
+        }
+    }
+}
+
+impl FromStr for AeAddr {
+    type Err = std::net::AddrParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some((ae_title, address)) = s.split_once('@') {
+            Ok(AeAddr {
+                ae_title: Some(ae_title.to_string()),
+                socket_addr: address.parse()?,
+            })
+        } else {
+            Ok(AeAddr {
+                ae_title: None,
+                socket_addr: s.parse()?,
+            })
+        }
+    }
+}
+
+impl ToSocketAddrs for AeAddr {
+    type Iter = std::option::IntoIter<SocketAddr>;
+
+    fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
+        self.socket_addr.to_socket_addrs()
+    }
+}

--- a/ul/src/address.rs
+++ b/ul/src/address.rs
@@ -177,6 +177,14 @@ impl<T> AeAddr<T> {
         }
     }
 
+    /// Create an address with a missing AE title.
+    pub fn new_socket_addr(socket_addr: T) -> Self {
+        AeAddr {
+            ae_title: None,
+            socket_addr,
+        }
+    }
+
     /// Retrieve the application entity title portion, if present.
     pub fn ae_title(&self) -> Option<&str> {
         self.ae_title.as_deref()

--- a/ul/src/address.rs
+++ b/ul/src/address.rs
@@ -1,17 +1,18 @@
 //! Data types for addresses to nodes in DICOM networks.
 
 use std::{
-    net::{AddrParseError, SocketAddr, ToSocketAddrs},
+    net::{SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs},
     str::FromStr,
 };
 
-use snafu::{ResultExt, Snafu};
+use snafu::{ensure, AsErrorSource, ResultExt, Snafu};
 
 /// A specification for a full address to the target SCP:
-/// an application entity title, plus a network socket address.
+/// an application entity title, plus a generic  address,
+/// typically a socket address.
 ///
 /// These addresses can be serialized and parsed
-/// with the syntax `{ae_title}@{socket_address}`.
+/// with the syntax `{ae_title}@{address}`.
 ///
 /// For the version of the struct without a mandatory AE title,
 /// see [`AeAddr`].
@@ -23,22 +24,27 @@ use snafu::{ResultExt, Snafu};
 /// # use std::net::SocketAddr;
 /// #
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let addr: FullAeAddr = "SCP-STORAGE@127.0.0.1:104".parse()?;
+/// # // socket address can be a string
+/// let addr: FullAeAddr<String> = "SCP-STORAGE@127.0.0.1:104".parse()?;
 /// assert_eq!(addr.ae_title(), "SCP-STORAGE");
-/// assert_eq!(addr.socket_addr(), SocketAddr::from(([127, 0, 0, 1], 104)));
+/// assert_eq!(addr.socket_addr(), "127.0.0.1:104");
+/// # // or anything else which can be parsed into a socket address
+/// let addr: FullAeAddr<SocketAddr> = "SCP-STORAGE@127.0.0.1:104".parse()?;
+/// assert_eq!(addr.ae_title(), "SCP-STORAGE");
+/// assert_eq!(addr.socket_addr(), &SocketAddr::from(([127, 0, 0, 1], 104)));
 /// assert_eq!(&addr.to_string(), "SCP-STORAGE@127.0.0.1:104");
 /// # Ok(())
 /// # }
 /// ```
 #[derive(Debug, Clone, PartialEq)]
-pub struct FullAeAddr {
+pub struct FullAeAddr<T> {
     ae_title: String,
-    socket_addr: std::net::SocketAddr,
+    socket_addr: T,
 }
 
-impl FullAeAddr {
+impl<T> FullAeAddr<T> {
     /// Create an AE address from its bare constituent parts.
-    pub fn new(ae_title: impl Into<String>, socket_addr: SocketAddr) -> Self {
+    pub fn new(ae_title: impl Into<String>, socket_addr: T) -> Self {
         FullAeAddr {
             ae_title: ae_title.into(),
             socket_addr,
@@ -50,32 +56,47 @@ impl FullAeAddr {
         &self.ae_title
     }
 
-    /// Retrieve the socket address portion.
-    pub fn socket_addr(&self) -> std::net::SocketAddr {
-        self.socket_addr
+    /// Retrieve the network address portion.
+    pub fn socket_addr(&self) -> &T {
+        &self.socket_addr
+    }
+
+    /// Convert the full address into its constituent parts.
+    pub fn into_parts(self) -> (String, T) {
+        (self.ae_title, self.socket_addr)
     }
 }
 
-impl From<(String, SocketAddr)> for FullAeAddr {
-    fn from((ae_title, socket_addr): (String, SocketAddr)) -> Self {
+impl<T> From<(String, T)> for FullAeAddr<T> {
+    fn from((ae_title, socket_addr): (String, T)) -> Self {
         Self::new(ae_title, socket_addr)
     }
 }
 
+/// A error which occurred when parsing an AE address.
 #[derive(Debug, Clone, Eq, PartialEq, Snafu)]
-pub enum ParseAeAddressError {
+pub enum ParseAeAddressError<E>
+where
+    E: std::fmt::Debug + AsErrorSource,
+{
     /// Missing `@` in full AE address
     MissingPart,
 
-    /// Could not parse socket address
-    ParseSocketAddress { source: AddrParseError },
+    /// Could not parse network socket address
+    ParseSocketAddress { source: E },
 }
 
-impl FromStr for FullAeAddr {
-    type Err = ParseAeAddressError;
+impl<T> FromStr for FullAeAddr<T>
+where
+    T: FromStr,
+    T::Err: std::fmt::Debug + AsErrorSource,
+{
+    type Err = ParseAeAddressError<<T as FromStr>::Err>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // !!! there should be a way to escape the `@`
         if let Some((ae_title, addr)) = s.split_once('@') {
+            ensure!(!ae_title.is_empty(), MissingPartSnafu);
             Ok(FullAeAddr {
                 ae_title: ae_title.to_string(),
                 socket_addr: addr.parse().context(ParseSocketAddressSnafu)?,
@@ -86,24 +107,30 @@ impl FromStr for FullAeAddr {
     }
 }
 
-impl ToSocketAddrs for FullAeAddr {
-    type Iter = std::option::IntoIter<SocketAddr>;
+impl<T> ToSocketAddrs for FullAeAddr<T>
+where
+    T: ToSocketAddrs,
+{
+    type Iter = T::Iter;
 
     fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
         self.socket_addr.to_socket_addrs()
     }
 }
 
-impl std::fmt::Display for FullAeAddr {
+impl<T> std::fmt::Display for FullAeAddr<T>
+where
+    T: std::fmt::Display,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.ae_title)?;
+        f.write_str(&self.ae_title.replace("@", "\\@"))?;
         f.write_str("@")?;
         std::fmt::Display::fmt(&self.socket_addr, f)
     }
 }
 
 /// A specification for an address to the target SCP:
-/// a network socket address
+/// a generic network socket address
 /// which may also include an application entity title.
 ///
 /// These addresses can be serialized and parsed
@@ -117,42 +144,35 @@ impl std::fmt::Display for FullAeAddr {
 ///
 /// ```
 /// # use dicom_ul::{AeAddr, FullAeAddr};
-/// # use std::net::SocketAddr;
+/// # use std::net::{SocketAddr, SocketAddrV4};
 /// #
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let addr: AeAddr = "SCP-STORAGE@127.0.0.1:104".parse()?;
+/// let addr: AeAddr<SocketAddrV4> = "SCP-STORAGE@127.0.0.1:104".parse()?;
 /// assert_eq!(addr.ae_title(), Some("SCP-STORAGE"));
-/// assert_eq!(addr.socket_addr(), SocketAddr::from(([127, 0, 0, 1], 104)));
-/// assert_eq!(&addr.to_string(), "127.0.0.1:104");
+/// assert_eq!(addr.socket_addr(), &SocketAddrV4::new([127, 0, 0, 1].into(), 104));
+/// assert_eq!(&addr.to_string(), "SCP-STORAGE@127.0.0.1:104");
 ///
 /// // AE title can be missing
-/// let addr: AeAddr = "192.168.1.99:1045".parse()?;
+/// let addr: AeAddr<String> = "192.168.1.99:1045".parse()?;
 /// assert_eq!(addr.ae_title(), None);
 /// // but can be provided later
-/// let full_addr: FullAeAddr = addr.with_ae_title("SCP-QUERY");
+/// let full_addr: FullAeAddr<_> = addr.with_ae_title("SCP-QUERY");
 /// assert_eq!(full_addr.ae_title(), "SCP-QUERY");
+/// assert_eq!(&full_addr.to_string(), "SCP-QUERY@192.168.1.99:1045");
 /// # Ok(())
 /// # }
 /// ```
 #[derive(Debug, Clone, PartialEq)]
-pub struct AeAddr {
+pub struct AeAddr<T> {
     ae_title: Option<String>,
-    socket_addr: std::net::SocketAddr,
+    socket_addr: T,
 }
 
-impl AeAddr {
+impl<T> AeAddr<T> {
     /// Create an AE address from its bare constituent parts.
-    pub fn new(ae_title: impl Into<String>, socket_addr: SocketAddr) -> Self {
+    pub fn new(ae_title: impl Into<String>, socket_addr: T) -> Self {
         AeAddr {
             ae_title: Some(ae_title.into()),
-            socket_addr,
-        }
-    }
-
-    /// Create an AE address containing only a socket address.
-    pub fn new_socket_addr(socket_addr: SocketAddr) -> Self {
-        AeAddr {
-            ae_title: None,
             socket_addr,
         }
     }
@@ -163,13 +183,13 @@ impl AeAddr {
     }
 
     /// Retrieve the socket address portion.
-    pub fn socket_addr(&self) -> std::net::SocketAddr {
-        self.socket_addr
+    pub fn socket_addr(&self) -> &T {
+        &self.socket_addr
     }
 
     /// Create a new address with the full application entity target,
     /// discarding any potentially existing AE title.
-    pub fn with_ae_title(self, ae_title: impl Into<String>) -> FullAeAddr {
+    pub fn with_ae_title(self, ae_title: impl Into<String>) -> FullAeAddr<T> {
         FullAeAddr {
             ae_title: ae_title.into(),
             socket_addr: self.socket_addr,
@@ -178,16 +198,21 @@ impl AeAddr {
 
     /// Create a new address with the full application entity target,
     /// using the given AE title if it is missing.
-    pub fn with_default_ae_title(self, ae_title: impl Into<String>) -> FullAeAddr {
+    pub fn with_default_ae_title(self, ae_title: impl Into<String>) -> FullAeAddr<T> {
         FullAeAddr {
             ae_title: self.ae_title.unwrap_or_else(|| ae_title.into()),
             socket_addr: self.socket_addr,
         }
     }
+
+    /// Convert the address into its constituent parts.
+    pub fn into_parts(self) -> (Option<String>, T) {
+        (self.ae_title, self.socket_addr)
+    }
 }
 
-/// This conversion provides an address without an AE title.
-impl From<SocketAddr> for AeAddr {
+/// This conversion provides a socket address without an AE title.
+impl From<SocketAddr> for AeAddr<SocketAddr> {
     fn from(socket_addr: SocketAddr) -> Self {
         AeAddr {
             ae_title: None,
@@ -196,8 +221,28 @@ impl From<SocketAddr> for AeAddr {
     }
 }
 
-impl From<FullAeAddr> for AeAddr {
-    fn from(full: FullAeAddr) -> Self {
+/// This conversion provides an IPv4 socket address without an AE title.
+impl From<SocketAddrV4> for AeAddr<SocketAddrV4> {
+    fn from(socket_addr: SocketAddrV4) -> Self {
+        AeAddr {
+            ae_title: None,
+            socket_addr,
+        }
+    }
+}
+
+/// This conversion provides an IPv6 socket address without an AE title.
+impl From<SocketAddrV6> for AeAddr<SocketAddrV6> {
+    fn from(socket_addr: SocketAddrV6) -> Self {
+        AeAddr {
+            ae_title: None,
+            socket_addr,
+        }
+    }
+}
+
+impl<T> From<FullAeAddr<T>> for AeAddr<T> {
+    fn from(full: FullAeAddr<T>) -> Self {
         AeAddr {
             ae_title: Some(full.ae_title),
             socket_addr: full.socket_addr,
@@ -205,13 +250,19 @@ impl From<FullAeAddr> for AeAddr {
     }
 }
 
-impl FromStr for AeAddr {
-    type Err = std::net::AddrParseError;
+impl<T> FromStr for AeAddr<T>
+where
+    T: FromStr,
+{
+    type Err = <T as FromStr>::Err;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // !!! there should be a way to escape the `@`
         if let Some((ae_title, address)) = s.split_once('@') {
             Ok(AeAddr {
-                ae_title: Some(ae_title.to_string()),
+                ae_title: Some(ae_title)
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string()),
                 socket_addr: address.parse()?,
             })
         } else {
@@ -223,21 +274,91 @@ impl FromStr for AeAddr {
     }
 }
 
-impl ToSocketAddrs for AeAddr {
-    type Iter = std::option::IntoIter<SocketAddr>;
+impl<T> ToSocketAddrs for AeAddr<T>
+where
+    T: ToSocketAddrs,
+{
+    type Iter = T::Iter;
 
     fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
         self.socket_addr.to_socket_addrs()
     }
 }
 
-impl std::fmt::Display for AeAddr {
+impl<T> std::fmt::Display for AeAddr<T>
+where
+    T: std::fmt::Display,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let socket_addr = self.socket_addr.to_string();
         if let Some(ae_title) = &self.ae_title {
-            f.write_str(ae_title)?;
+            f.write_str(&ae_title.replace("@", "\\@"))?;
+            f.write_str("@")?;
+        } else if socket_addr.contains("@") {
+            // if formatted socket address contains a `@`,
+            // we need to start the output with `@`
+            // so that the start of the socket address
+            // is not interpreted as an AE title
             f.write_str("@")?;
         }
 
-        std::fmt::Display::fmt(&self.socket_addr, f)
+        std::fmt::Display::fmt(&socket_addr, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ae_addr_parse() {
+        // socket address can be a string
+        let addr: FullAeAddr<String> = "SCP-STORAGE@127.0.0.1:104".parse().unwrap();
+        assert_eq!(addr.ae_title(), "SCP-STORAGE");
+        assert_eq!(addr.socket_addr(), "127.0.0.1:104");
+
+        // or anything else which can be parsed into a socket address
+        let addr: FullAeAddr<SocketAddr> = "SCP_STORAGE@127.0.0.1:104".parse().unwrap();
+        assert_eq!(addr.ae_title(), "SCP_STORAGE");
+        assert_eq!(addr.socket_addr(), &SocketAddr::from(([127, 0, 0, 1], 104)));
+        assert_eq!(&addr.to_string(), "SCP_STORAGE@127.0.0.1:104");
+
+        // IPv4 socket address
+        let addr: FullAeAddr<SocketAddrV4> = "MAMMOSTORE@10.0.0.11:104".parse().unwrap();
+        assert_eq!(addr.ae_title(), "MAMMOSTORE");
+        assert_eq!(
+            addr.socket_addr(),
+            &SocketAddrV4::new([10, 0, 0, 11].into(), 104)
+        );
+        assert_eq!(&addr.to_string(), "MAMMOSTORE@10.0.0.11:104");
+    }
+
+    /// test addresses without an AE title
+    #[test]
+    fn ae_addr_parse_no_ae() {
+        // should fail
+        let res = FullAeAddr::<String>::from_str("pacs.hospital.example.com:104");
+        assert!(matches!(res, Err(ParseAeAddressError::MissingPart)));
+        // should also fail (AE title can't be empty)
+        let res = FullAeAddr::<String>::from_str("@pacs.hospital.example.com:104");
+        assert!(matches!(res, Err(ParseAeAddressError::MissingPart)));
+
+        // should return an ae addr with no AE title
+        let addr: AeAddr<String> = "pacs.hospital.example.com:104".parse().unwrap();
+        assert_eq!(addr.ae_title(), None);
+        assert_eq!(addr.socket_addr(), "pacs.hospital.example.com:104");
+        // should also return an ae addr with no AE title
+        let addr: AeAddr<String> = "@pacs.hospital.example.com:104".parse().unwrap();
+        assert_eq!(addr.ae_title(), None);
+        assert_eq!(addr.socket_addr(), "pacs.hospital.example.com:104");
+    }
+
+    #[test]
+    fn ae_addr_parse_weird_scenarios() {
+        // can parse addresses with multiple @'s
+        let addr: FullAeAddr<String> = "ABC@DICOM@pacs.archive.example.com:104".parse().unwrap();
+        assert_eq!(addr.ae_title(), "ABC");
+        assert_eq!(addr.socket_addr(), "DICOM@pacs.archive.example.com:104");
+        assert_eq!(&addr.to_string(), "ABC@DICOM@pacs.archive.example.com:104");
     }
 }

--- a/ul/src/address.rs
+++ b/ul/src/address.rs
@@ -1,5 +1,12 @@
 //! Data types for addresses to nodes in DICOM networks.
-
+//!
+//! This module provides the definitions for [`FullAeAddr`] and [`AeAddr`],
+//! which enable consumers to couple a socket address with an expected
+//! application entity (AE) title.
+//! 
+//! The syntax is `«ae_title»@«network_address»:«port»`,
+//! which works not only with IPv4 and IPv6 addresses,
+//! but also with domain names.
 use std::{
     net::{SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs},
     str::FromStr,
@@ -12,7 +19,9 @@ use snafu::{ensure, AsErrorSource, ResultExt, Snafu};
 /// typically a socket address.
 ///
 /// These addresses can be serialized and parsed
-/// with the syntax `{ae_title}@{address}`.
+/// with the syntax `{ae_title}@{address}`,
+/// where the socket address is parsed according to
+/// the expectations of the parameter type `T`.
 ///
 /// For the version of the struct without a mandatory AE title,
 /// see [`AeAddr`].
@@ -134,8 +143,9 @@ where
 /// which may also include an application entity title.
 ///
 /// These addresses can be serialized and parsed
-/// with the syntax `{ae_title}@{socket_address}`,
-/// where the
+/// with the syntax `{ae_title}@{address}`,
+/// where the socket address is parsed according to
+/// the expectations of the parameter type `T`.
 ///
 /// For the version of the struct in which the AE title part is mandatory,
 /// see [`FullAeAddr`].

--- a/ul/src/address.rs
+++ b/ul/src/address.rs
@@ -3,11 +3,12 @@
 //! This module provides the definitions for [`FullAeAddr`] and [`AeAddr`],
 //! which enable consumers to couple a socket address with an expected
 //! application entity (AE) title.
-//! 
+//!
 //! The syntax is `«ae_title»@«network_address»:«port»`,
 //! which works not only with IPv4 and IPv6 addresses,
 //! but also with domain names.
 use std::{
+    convert::TryFrom,
     net::{SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs},
     str::FromStr,
 };
@@ -289,6 +290,14 @@ where
                 socket_addr: s.parse()?,
             })
         }
+    }
+}
+
+impl<'a> TryFrom<&'a str> for AeAddr<String> {
+    type Error = <AeAddr<String> as FromStr>::Err;
+
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        s.parse()
     }
 }
 

--- a/ul/src/address.rs
+++ b/ul/src/address.rs
@@ -26,6 +26,7 @@ use snafu::{ResultExt, Snafu};
 /// let addr: FullAeAddr = "SCP-STORAGE@127.0.0.1:104".parse()?;
 /// assert_eq!(addr.ae_title(), "SCP-STORAGE");
 /// assert_eq!(addr.socket_addr(), SocketAddr::from(([127, 0, 0, 1], 104)));
+/// assert_eq!(&addr.to_string(), "SCP-STORAGE@127.0.0.1:104");
 /// # Ok(())
 /// # }
 /// ```
@@ -93,6 +94,14 @@ impl ToSocketAddrs for FullAeAddr {
     }
 }
 
+impl std::fmt::Display for FullAeAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.ae_title)?;
+        f.write_str("@")?;
+        std::fmt::Display::fmt(&self.socket_addr, f)
+    }
+}
+
 /// A specification for an address to the target SCP:
 /// a network socket address
 /// which may also include an application entity title.
@@ -114,6 +123,7 @@ impl ToSocketAddrs for FullAeAddr {
 /// let addr: AeAddr = "SCP-STORAGE@127.0.0.1:104".parse()?;
 /// assert_eq!(addr.ae_title(), Some("SCP-STORAGE"));
 /// assert_eq!(addr.socket_addr(), SocketAddr::from(([127, 0, 0, 1], 104)));
+/// assert_eq!(&addr.to_string(), "127.0.0.1:104");
 ///
 /// // AE title can be missing
 /// let addr: AeAddr = "192.168.1.99:1045".parse()?;
@@ -149,7 +159,7 @@ impl AeAddr {
 
     /// Retrieve the application entity title portion, if present.
     pub fn ae_title(&self) -> Option<&str> {
-        self.ae_title.as_ref().map(String::as_str)
+        self.ae_title.as_deref()
     }
 
     /// Retrieve the socket address portion.
@@ -218,5 +228,16 @@ impl ToSocketAddrs for AeAddr {
 
     fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
         self.socket_addr.to_socket_addrs()
+    }
+}
+
+impl std::fmt::Display for AeAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(ae_title) = &self.ae_title {
+            f.write_str(ae_title)?;
+            f.write_str("@")?;
+        }
+
+        std::fmt::Display::fmt(&self.socket_addr, f)
     }
 }

--- a/ul/src/lib.rs
+++ b/ul/src/lib.rs
@@ -16,7 +16,7 @@
 
 pub mod association;
 pub mod pdu;
-mod address;
+pub mod address;
 
 /// The current implementation class UID generically referring to DICOM-rs.
 ///

--- a/ul/src/lib.rs
+++ b/ul/src/lib.rs
@@ -6,6 +6,9 @@
 //! enabling the creation of concrete service class users (SCUs)
 //! and service class providers (SCPs).
 //!
+//! - The [`address`](crate::address) module
+//! provides an abstraction for working with compound addresses
+//! referring to application entities in a network.
 //! - The [`pdu`](crate::pdu) module
 //! provides data structures representing _protocol data units_,
 //! which are passed around as part of the DICOM network communication support.

--- a/ul/src/lib.rs
+++ b/ul/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod association;
 pub mod pdu;
+mod address;
 
 /// The current implementation class UID generically referring to DICOM-rs.
 ///
@@ -36,3 +37,4 @@ pub use association::server::{ServerAssociation, ServerAssociationOptions};
 pub use pdu::reader::read_pdu;
 pub use pdu::writer::write_pdu;
 pub use pdu::Pdu;
+pub use address::{AeAddr, FullAeAddr};


### PR DESCRIPTION
This is a generalization of #274.

- Add AE address module and data types
- Improve address module
- Rethink AE address
- Add `AeAddr::new_socket_addr`
- Add `TryFrom` impl for `AeAddr<String>`
- Add `ClientAssociationOptions::establish_with`
- [echoscu|storescu] update tools to use `ul::AeAddr`
