### PR TITLE
Clippy maintenance

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,7 @@
     unused_qualifications,
     unused_import_braces
 )]
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 //! This is the core library of DICOM-rs containing various concepts,
 //! data structures and traits specific to DICOM content.

--- a/core/src/value/person_name.rs
+++ b/core/src/value/person_name.rs
@@ -22,7 +22,7 @@ use std::fmt::{Display, Formatter};
 /// assert_eq!(dr_seuss.prefix(), Some("Dr."));
 /// assert_eq!(dr_seuss.given(), Some("Theodor"));
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
 pub struct PersonName<'a> {
     prefix: Option<&'a str>,
     family: Option<&'a str>,

--- a/core/src/value/range.rs
+++ b/core/src/value/range.rs
@@ -273,7 +273,7 @@ impl DicomDateTime {
 /// assert!(dr.start().is_some());
 /// assert!(dr.end().is_none());
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub struct DateRange {
     start: Option<NaiveDate>,
     end: Option<NaiveDate>,
@@ -290,7 +290,7 @@ pub struct DateRange {
 /// assert!(tr.start().is_none());
 /// assert!(tr.end().is_some());
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub struct TimeRange {
     start: Option<NaiveTime>,
     end: Option<NaiveTime>,
@@ -316,7 +316,7 @@ pub struct TimeRange {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub struct DateTimeRange {
     start: Option<DateTime<FixedOffset>>,
     end: Option<DateTime<FixedOffset>>,

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::derive_partial_eq_without_eq)]
 //! DICOM data dumping library
 //!
 //! This is a helper library

--- a/encoding/src/decode/basic.rs
+++ b/encoding/src/decode/basic.rs
@@ -8,7 +8,7 @@ use std::io::Read;
 type Result<T> = std::io::Result<T>;
 
 /// A basic decoder of DICOM primitive elements in little endian.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
 pub struct LittleEndianBasicDecoder;
 
 impl BasicDecode for LittleEndianBasicDecoder {
@@ -146,7 +146,7 @@ impl BasicDecode for LittleEndianBasicDecoder {
 }
 
 /// A basic decoder of DICOM primitive elements in big endian.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
 pub struct BigEndianBasicDecoder;
 
 impl BasicDecode for BigEndianBasicDecoder {

--- a/encoding/src/lib.rs
+++ b/encoding/src/lib.rs
@@ -4,6 +4,7 @@
     unused_qualifications,
     unused_import_braces
 )]
+#![allow(clippy::derive_partial_eq_without_eq)]
 //! DICOM encoding and decoding primitives.
 //!
 //! This crate provides interfaces and data structures for reading and writing

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::derive_partial_eq_without_eq)]
 //! This crate contains a high-level abstraction for reading and manipulating
 //! DICOM objects.
 //! At this level, objects are comparable to a dictionary of elements,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::derive_partial_eq_without_eq)]
 //! This crate works on top of DICOM encoding primitives to provide transfer
 //! syntax resolution and abstraction for parsing DICOM data sets, which
 //! ultimately enables the user to perceive the DICOM object as a sequence of

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::derive_partial_eq_without_eq)]
 //! This crate contains the DICOM pixel data handlers and is
 //! responsible for decoding various forms of native and compressed pixel data,
 //! such as JPEG lossless,

--- a/storescu/src/main.rs
+++ b/storescu/src/main.rs
@@ -563,7 +563,7 @@ fn even_len(l: usize) -> u32 {
 fn check_file(file: &Path) -> Result<DicomFile, Error> {
     // Ignore DICOMDIR files until better support is added
     let _ = (file.file_name() != Some(OsStr::new("DICOMDIR")))
-        .then(|| false)
+        .then_some(false)
         .whatever_context("DICOMDIR file not supported")?;
     let dicom_file = dicom_object::OpenFileOptions::new()
         .read_until(Tag(0x0001, 0x000))


### PR DESCRIPTION
- impl Eq and Hash for some types (not all of them though; see https://github.com/rust-lang/rust-clippy/issues/9063 for more info)
- fix check_file use of `then(|| false)`