### PR TITLE
[ul] Improve association robustness and expressiveness

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -56,7 +56,7 @@ pub enum Error {
     #[snafu(display("protocol version mismatch: expected {}, got {}", expected, got))]
     ProtocolVersionMismatch { expected: u16, got: u16 },
 
-    /// the association was rejected by the server
+    #[snafu(display("association rejected by the server: {}", association_source))]
     Rejected {
         association_result: AssociationRJResult,
         association_source: AssociationRJSource,

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -22,7 +22,10 @@ use crate::{
 };
 use snafu::{ensure, ResultExt, Snafu};
 
-use super::pdata::{PDataReader, PDataWriter};
+use super::{
+    pdata::{PDataReader, PDataWriter},
+    uid::trim_uid,
+};
 
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
@@ -205,10 +208,12 @@ impl<'a> ClientAssociationOptions<'a> {
     where
         T: Into<Cow<'a, str>>,
     {
-        let transfer_syntaxes: Vec<Cow<'a, str>> =
-            transfer_syntax_uids.into_iter().map(|t| t.into()).collect();
+        let transfer_syntaxes: Vec<Cow<'a, str>> = transfer_syntax_uids
+            .into_iter()
+            .map(|t| trim_uid(t.into()))
+            .collect();
         self.presentation_contexts
-            .push((abstract_syntax_uid.into(), transfer_syntaxes));
+            .push((trim_uid(abstract_syntax_uid.into()), transfer_syntaxes));
         self
     }
 

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -355,7 +355,7 @@ impl<'a> ClientAssociationOptions<'a> {
         socket.write_all(&buffer).context(WireSendSnafu)?;
         buffer.clear();
         // receive response
-        let msg = read_pdu(&mut socket, MAXIMUM_PDU_SIZE, true).context(ReceiveResponseSnafu)?;
+        let msg = read_pdu(&mut socket, MAXIMUM_PDU_SIZE, self.strict).context(ReceiveResponseSnafu)?;
 
         match msg {
             Pdu::AssociationAC {
@@ -516,7 +516,7 @@ impl ClientAssociation {
 
     /// Read a PDU message from the other intervenient.
     pub fn receive(&mut self) -> Result<Pdu> {
-        read_pdu(&mut self.socket, self.requestor_max_pdu_length, true).context(ReceiveSnafu)
+        read_pdu(&mut self.socket, self.requestor_max_pdu_length, self.strict).context(ReceiveSnafu)
     }
 
     /// Gracefully terminate the association by exchanging release messages

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -19,6 +19,7 @@
 //! [3]: crate::association::server::ServerAssociationOptions
 pub mod client;
 pub mod server;
+mod uid;
 
 pub(crate) mod pdata;
 

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -323,7 +323,7 @@ where
 
         let max_pdu_length = self.max_pdu_length;
 
-        let pdu = read_pdu(&mut socket, max_pdu_length, true).context(ReceiveRequestSnafu)?;
+        let pdu = read_pdu(&mut socket, max_pdu_length, self.strict).context(ReceiveRequestSnafu)?;
         let mut buffer: Vec<u8> = Vec::with_capacity(max_pdu_length as usize);
         match pdu {
             Pdu::AssociationRQ {

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -21,7 +21,7 @@ use crate::{
     IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
 };
 
-use super::pdata::{PDataWriter, PDataReader};
+use super::{pdata::{PDataWriter, PDataReader}, uid::trim_uid};
 
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
@@ -282,7 +282,7 @@ where
     where
         T: Into<Cow<'a, str>>,
     {
-        self.abstract_syntax_uids.push(abstract_syntax_uid.into());
+        self.abstract_syntax_uids.push(trim_uid(abstract_syntax_uid.into()));
         self
     }
 
@@ -291,7 +291,7 @@ where
     where
         T: Into<Cow<'a, str>>,
     {
-        self.transfer_syntax_uids.push(transfer_syntax_uid.into());
+        self.transfer_syntax_uids.push(trim_uid(transfer_syntax_uid.into()));
         self
     }
 
@@ -388,7 +388,7 @@ where
                     .map(|pc| {
                         if !self
                             .abstract_syntax_uids
-                            .contains(&Cow::from(pc.abstract_syntax))
+                            .contains(&trim_uid(Cow::from(pc.abstract_syntax)))
                         {
                             return PresentationContextResult {
                                 id: pc.id,

--- a/ul/src/association/uid.rs
+++ b/ul/src/association/uid.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 pub(crate) fn trim_uid(uid: Cow<str>) -> Cow<str> {
     if uid.ends_with('\0') {
-        Cow::Owned(uid.trim_end_matches(|c| c == '\0').to_string())
+        Cow::Owned(uid.trim_end_matches(|c: char| c.is_whitespace() || c == '\0').to_string())
     } else {
         uid
     }

--- a/ul/src/association/uid.rs
+++ b/ul/src/association/uid.rs
@@ -1,0 +1,28 @@
+//! Private utility module for working with UIDs
+
+use std::borrow::Cow;
+
+pub(crate) fn trim_uid<'a>(uid: Cow<'a, str>) -> Cow<'a, str> {
+    if uid.ends_with('\0') {
+        Cow::Owned(uid.trim_end_matches(|c| c == '\0').to_string())
+    } else {
+        uid
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::trim_uid;
+
+    #[test]
+    fn test_trim_uid() {
+        let uid = trim_uid(Cow::from("1.2.3.4"));
+        assert_eq!(uid, "1.2.3.4");
+        let uid = trim_uid(Cow::from("1.2.3.4\0"));
+        assert_eq!(uid, "1.2.3.4");
+        let uid = trim_uid(Cow::from("1.2.3.45\0"));
+        assert_eq!(uid, "1.2.3.45");
+    }
+}

--- a/ul/src/association/uid.rs
+++ b/ul/src/association/uid.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 
-pub(crate) fn trim_uid<'a>(uid: Cow<'a, str>) -> Cow<'a, str> {
+pub(crate) fn trim_uid(uid: Cow<str>) -> Cow<str> {
     if uid.ends_with('\0') {
         Cow::Owned(uid.trim_end_matches(|c| c == '\0').to_string())
     } else {

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -7,6 +7,8 @@
 pub mod reader;
 pub mod writer;
 
+use std::fmt::Display;
+
 pub use reader::read_pdu;
 pub use writer::write_pdu;
 
@@ -52,6 +54,23 @@ impl PresentationContextResultReason {
         };
 
         Some(result)
+    }
+}
+
+impl Display for PresentationContextResultReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            PresentationContextResultReason::Acceptance => "acceptance",
+            PresentationContextResultReason::UserRejection => "user rejection",
+            PresentationContextResultReason::NoReason => "no reason",
+            PresentationContextResultReason::AbstractSyntaxNotSupported => {
+                "abstract syntax not supported"
+            }
+            PresentationContextResultReason::TransferSyntaxesNotSupported => {
+                "transfer syntaxes not supported"
+            }
+        };
+        f.write_str(msg)
     }
 }
 
@@ -134,6 +153,16 @@ impl AssociationRJSource {
     }
 }
 
+impl Display for AssociationRJSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AssociationRJSource::ServiceUser(r) => Display::fmt(r, f),
+            AssociationRJSource::ServiceProviderASCE(r) => Display::fmt(r, f),
+            AssociationRJSource::ServiceProviderPresentation(r) => Display::fmt(r, f),
+        }
+    }
+}
+
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
 pub enum AssociationRJServiceUserReason {
     NoReasonGiven,
@@ -143,10 +172,39 @@ pub enum AssociationRJServiceUserReason {
     Reserved(u8),
 }
 
+impl Display for AssociationRJServiceUserReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AssociationRJServiceUserReason::NoReasonGiven => f.write_str("no reason given"),
+            AssociationRJServiceUserReason::ApplicationContextNameNotSupported => {
+                f.write_str("application context name not supported")
+            }
+            AssociationRJServiceUserReason::CallingAETitleNotRecognized => {
+                f.write_str("calling AE title not recognized")
+            }
+            AssociationRJServiceUserReason::CalledAETitleNotRecognized => {
+                f.write_str("called AE title not recognized")
+            }
+            AssociationRJServiceUserReason::Reserved(code) => write!(f, "reserved code {}", code),
+        }
+    }
+}
+
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
 pub enum AssociationRJServiceProviderASCEReason {
     NoReasonGiven,
     ProtocolVersionNotSupported,
+}
+
+impl Display for AssociationRJServiceProviderASCEReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AssociationRJServiceProviderASCEReason::NoReasonGiven => f.write_str("no reason given"),
+            AssociationRJServiceProviderASCEReason::ProtocolVersionNotSupported => {
+                f.write_str("protocol version not supported")
+            }
+        }
+    }
 }
 
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
@@ -154,6 +212,22 @@ pub enum AssociationRJServiceProviderPresentationReason {
     TemporaryCongestion,
     LocalLimitExceeded,
     Reserved(u8),
+}
+
+impl Display for AssociationRJServiceProviderPresentationReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AssociationRJServiceProviderPresentationReason::TemporaryCongestion => {
+                f.write_str("temporary congestion")
+            }
+            AssociationRJServiceProviderPresentationReason::LocalLimitExceeded => {
+                f.write_str("local limit exceeded")
+            }
+            AssociationRJServiceProviderPresentationReason::Reserved(code) => {
+                write!(f, "reserved code {}", code)
+            }
+        }
+    }
 }
 
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
@@ -220,6 +294,20 @@ pub enum AbortRQServiceProviderReason {
     UnexpectedPduParameter,
     /// Invalid PDU parameter
     InvalidPduParameter,
+}
+
+impl Display for AbortRQServiceProviderReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            AbortRQServiceProviderReason::ReasonNotSpecifiedUnrecognizedPdu => "reason unclear",
+            AbortRQServiceProviderReason::UnexpectedPdu => "unexpected PDU",
+            AbortRQServiceProviderReason::Reserved => "reserved code",
+            AbortRQServiceProviderReason::UnrecognizedPduParameter => "unrecognized PDU parameter",
+            AbortRQServiceProviderReason::UnexpectedPduParameter => "unexpected PDU parameter",
+            AbortRQServiceProviderReason::InvalidPduParameter => "invalid PDU parameter",
+        };
+        f.write_str(msg)
+    }
 }
 
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]

--- a/ul/tests/association_store.rs
+++ b/ul/tests/association_store.rs
@@ -17,7 +17,11 @@ static SCP_AE_TITLE: &str = "STORE-SCP";
 
 static IMPLICIT_VR_LE: &str = "1.2.840.10008.1.2";
 static JPEG_BASELINE: &str = "1.2.840.10008.1.2.4.50";
+// raw UID with even padding
+// as potentially provided by DICOM objects
+static MR_IMAGE_STORAGE_RAW: &str = "1.2.840.10008.5.1.4.1.1.4\0";
 static MR_IMAGE_STORAGE: &str = "1.2.840.10008.5.1.4.1.1.4";
+static DIGITAL_MG_STORAGE_SOP_CLASS_RAW: &str = "1.2.840.10008.5.1.4.1.1.1.2\0";
 static DIGITAL_MG_STORAGE_SOP_CLASS: &str = "1.2.840.10008.5.1.4.1.1.1.2";
 
 fn spawn_scp() -> Result<(JoinHandle<Result<()>>, SocketAddr)> {
@@ -69,9 +73,9 @@ fn scu_scp_association_test() {
     let association = ClientAssociationOptions::new()
         .calling_ae_title(SCU_AE_TITLE)
         .called_ae_title(SCP_AE_TITLE)
-        .with_presentation_context(MR_IMAGE_STORAGE, vec![IMPLICIT_VR_LE])
+        .with_presentation_context(MR_IMAGE_STORAGE_RAW, vec![IMPLICIT_VR_LE])
         // MG storage, JPEG baseline
-        .with_presentation_context(DIGITAL_MG_STORAGE_SOP_CLASS, vec![JPEG_BASELINE])
+        .with_presentation_context(DIGITAL_MG_STORAGE_SOP_CLASS_RAW, vec![JPEG_BASELINE])
         .establish(scp_addr)
         .unwrap();
 


### PR DESCRIPTION
- Sanitize transfer syntax and abstract syntax UIDs
- impl `Display` for various reason/source types in `pdu`
- Include association source in association rejection error message
- Add `strict` option for client and server associations
- Add getter method `client_ae_title()` for server associations