### PR TITLE
ClientAssociation release() and abort() take &mut self instead of mut self

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -522,7 +522,7 @@ impl ClientAssociation {
 
     /// Gracefully terminate the association by exchanging release messages
     /// and then shutting down the TCP connection.
-    pub fn release(mut self) -> Result<()> {
+    pub fn release(&mut self) -> Result<()> {
         let out = self.release_impl();
         let _ = self.socket.shutdown(std::net::Shutdown::Both);
         out
@@ -535,7 +535,7 @@ impl ClientAssociation {
     /// if the exchange fails.
     /// Send an abort message and shut down the TCP connection,
     /// terminating the association.
-    pub fn abort(mut self) -> Result<()> {
+    pub fn abort(&mut self) -> Result<()> {
         let pdu = Pdu::AbortRQ {
             source: AbortRQSource::ServiceUser,
         };

--- a/ul/tests/association_echo.rs
+++ b/ul/tests/association_echo.rs
@@ -64,7 +64,7 @@ fn spawn_scp() -> Result<(JoinHandle<Result<()>>, SocketAddr)> {
 fn scu_scp_association_test() {
     let (scp_handle, scp_addr) = spawn_scp().unwrap();
 
-    let association = ClientAssociationOptions::new()
+    let mut association = ClientAssociationOptions::new()
         .calling_ae_title(SCU_AE_TITLE)
         .called_ae_title(SCP_AE_TITLE)
         .with_presentation_context(VERIFICATION_SOP_CLASS, vec![IMPLICIT_VR_LE, EXPLICIT_VR_LE])

--- a/ul/tests/association_store.rs
+++ b/ul/tests/association_store.rs
@@ -70,7 +70,7 @@ fn spawn_scp() -> Result<(JoinHandle<Result<()>>, SocketAddr)> {
 fn scu_scp_association_test() {
     let (scp_handle, scp_addr) = spawn_scp().unwrap();
 
-    let association = ClientAssociationOptions::new()
+    let mut association = ClientAssociationOptions::new()
         .calling_ae_title(SCU_AE_TITLE)
         .called_ae_title(SCP_AE_TITLE)
         .with_presentation_context(MR_IMAGE_STORAGE_RAW, vec![IMPLICIT_VR_LE])


### PR DESCRIPTION
Hello,
I stumbled upon this while incorporating `ClientAssociation` into some higher-level API.
Can we change this?
Makes working with the ClientAssociation easier.