### PR TITLE
[core][parser] Fix flaws in textual value encoding with in-memory time representations

### DIFF
--- a/core/src/value/serialize.rs
+++ b/core/src/value/serialize.rs
@@ -35,8 +35,9 @@ pub fn encode_datetime<W>(mut to: W, dt: DicomDateTime) -> IoResult<usize>
 where
     W: Write,
 {
-    let len = dt.to_string().len();
-    write!(to, "{}", dt.to_encoded())?;
+    let value = dt.to_encoded();
+    let len = value.len();
+    write!(to, "{}", value)?;
     Ok(len)
 }
 
@@ -76,7 +77,7 @@ mod test {
     fn test_encode_datetime() {
         let mut data = vec![];
         let offset = FixedOffset::east(0);
-        encode_datetime(
+        let bytes = encode_datetime(
             &mut data,
             DicomDateTime::from_date_and_time(
                 DicomDate::from_ymd(1985, 12, 31).unwrap(),
@@ -88,10 +89,11 @@ mod test {
         .unwrap();
         // even zero offset gets encoded into string value
         assert_eq!(from_utf8(&data).unwrap(), "19851231235948.123456+0000");
+        assert_eq!(bytes, 26);
 
         let mut data = vec![];
         let offset = FixedOffset::east(3600);
-        encode_datetime(
+        let bytes = encode_datetime(
             &mut data,
             DicomDateTime::from_date_and_time(
                 DicomDate::from_ymd(2018, 12, 24).unwrap(),
@@ -102,5 +104,6 @@ mod test {
         )
         .unwrap();
         assert_eq!(from_utf8(&data).unwrap(), "2018122404+0100");
+        assert_eq!(bytes, 15);
     }
 }

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -924,7 +924,8 @@ mod tests {
     use super::*;
     use crate::{meta::FileMetaTableBuilder, open_file, Error};
     use byteordered::Endianness;
-    use dicom_core::value::PrimitiveValue;
+    use dicom_core::chrono::FixedOffset;
+    use dicom_core::value::{DicomDate, DicomDateTime, DicomTime, PrimitiveValue};
     use dicom_core::{
         dicom_value,
         header::{DataElementHeader, Length, VR},
@@ -1120,6 +1121,43 @@ mod tests {
                 0x10, 0x00, 0x10, 0x00, // Tag(0x0010, 0x0010)
                 0x08, 0x00, 0x00, 0x00, // Length: 8
                 b'D', b'o', b'e', b'^', b'J', b'o', b'h', b'n',
+            ][..],
+        );
+    }
+
+    /// writing a DICOM date time into an object
+    /// should include value padding
+    #[test]
+    fn inmem_object_write_datetime_odd() {
+        let mut obj = InMemDicomObject::new_empty();
+
+        let dt = DicomDateTime::from_date_and_time(
+            DicomDate::from_ymd(2022, 11, 22).unwrap(),
+            DicomTime::from_hms(18, 09, 35).unwrap(),
+            FixedOffset::east_opt(3600).unwrap(),
+        )
+        .unwrap();
+        let patient_name =
+            DataElement::new(Tag(0x0008, 0x0015), VR::DT, dicom_value!(DateTime, dt));
+        obj.put(patient_name);
+
+        // explicit VR Little Endian
+        let ts = TransferSyntaxRegistry.get("1.2.840.10008.1.2.1").unwrap();
+
+        let mut out = Vec::new();
+        obj.write_dataset_with_ts(&mut out, &ts)
+            .expect("should write DICOM data without errors");
+
+        assert_eq!(
+            out,
+            &[
+                0x08, 0x00, 0x15, 0x00, // Tag(0x0008, 0x0015)
+                b'D', b'T', // VR: DT
+                0x14, 0x00, // Length: 20 bytes
+                b'2', b'0', b'2', b'2', b'1', b'1', b'2', b'2', // date
+                b'1', b'8', b'0', b'9', b'3', b'5', // time
+                b'+', b'0', b'1', b'0', b'0', // offset
+                b' ', // padding to even length
             ][..],
         );
     }


### PR DESCRIPTION
This fixes two bugs which affect the writing of DICOM data when a time or date-time primitive value is constructed in-memory as a binary value (for example, using `DicomDateTime`).

- [core] Fix reported length of encoded datetime values
- [parser] Use the right padding byte when encoding a DICOM value as text when it is not already in its textual form in-memory

Also added more test coverage in the `object` crate.

Resolves #311.