### PR TITLE
Add SopClassExtendedNegotiationSubItem for Pdu

### DIFF
--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -325,6 +325,7 @@ pub enum UserVariableItem {
     MaxLength(u32),
     ImplementationClassUID(String),
     ImplementationVersionName(String),
+    SopClassExtendedNegotiationSubItem(String, Vec<u8>)
 }
 
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -900,6 +900,51 @@ where
                             implementation_version_name,
                         ));
                     }
+                    0x56 => {
+                        // SOP Class Extended Negotiation Sub-Item
+
+                        // 5-6 - SOP-class-uid-length - The SOP-class-uid-length shall be the number
+                        // of bytes from the first byte of the following field to the last byte of the
+                        // SOP-class-uid field. It shall be encoded as an unsigned binary number.
+                        let sop_class_uid_length =
+                            cursor.read_u16::<BigEndian>().context(ReadPduFieldSnafu {
+                                field: "SOP-class-uid-length",
+                            })?;
+
+                        // 7 - xxx - SOP-class-uid - The SOP Class or Meta SOP Class identifier
+                        // encoded as a UID as defined in Section 9 “Unique Identifiers (UIDs)” in PS3.5.
+                        let sop_class_uid = codec
+                            .decode(&read_n(&mut cursor, sop_class_uid_length as usize).context(
+                                ReadPduFieldSnafu {
+                                    field: "SOP-class-uid",
+                                },
+                            )?)
+                            .context(DecodeTextSnafu {
+                                field: "SOP-class-uid",
+                            })?
+                            .trim()
+                            .to_string();
+
+                        let data_length =
+                            cursor.read_u16::<BigEndian>().context(ReadPduFieldSnafu {
+                                field: "Service-class-application-information-length",
+                            })?;
+
+                        // xxx-xxx - Service-class-application-information -This field shall contain
+                        // the application information specific to the Service Class specification
+                        // identified by the SOP-class-uid. The semantics and value of this field
+                        // is defined in the identified Service Class specification.
+                        let data = read_n(&mut cursor, data_length as usize).context(
+                            ReadPduFieldSnafu {
+                                field: "Service-class-application-information",
+                            },
+                        )?;
+
+                        user_variables.push(UserVariableItem::SopClassExtendedNegotiationSubItem(
+                            sop_class_uid,
+                            data,
+                        ));
+                    }
                     _ => {
                         user_variables.push(UserVariableItem::Unknown(
                             item_type,

--- a/ul/tests/pdu.rs
+++ b/ul/tests/pdu.rs
@@ -29,6 +29,10 @@ fn can_read_write_associate_rq() -> Result<(), Box<dyn std::error::Error>> {
             UserVariableItem::ImplementationClassUID("class uid".to_string()),
             UserVariableItem::ImplementationVersionName("version name".to_string()),
             UserVariableItem::MaxLength(23),
+            UserVariableItem::SopClassExtendedNegotiationSubItem(
+                "abstract 1".to_string(),
+                vec![1, 1, 0, 1, 1, 0, 1],
+            ),
         ],
     };
 
@@ -62,16 +66,21 @@ fn can_read_write_associate_rq() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(presentation_contexts[1].transfer_syntaxes.len(), 2);
         assert_eq!(presentation_contexts[1].transfer_syntaxes[0], "transfer 3");
         assert_eq!(presentation_contexts[1].transfer_syntaxes[1], "transfer 4");
-        assert_eq!(user_variables.len(), 3);
-        matches!(
-            user_variables[0],
-            UserVariableItem::ImplementationClassUID(_)
-        );
-        matches!(
-            user_variables[1],
-            UserVariableItem::ImplementationVersionName(_)
-        );
-        matches!(user_variables[2], UserVariableItem::MaxLength(_));
+        assert_eq!(user_variables.len(), 4);
+        assert!(matches!(
+            &user_variables[0],
+            UserVariableItem::ImplementationClassUID(u) if u == "class uid"
+        ));
+        assert!(matches!(
+            &user_variables[1],
+            UserVariableItem::ImplementationVersionName(v) if v == "version name"
+        ));
+        assert!(matches!(user_variables[2], UserVariableItem::MaxLength(l) if l == 23));
+        assert!(matches!(&user_variables[3],
+            UserVariableItem::SopClassExtendedNegotiationSubItem(sop_class_uid, data)
+            if sop_class_uid ==  "abstract 1" &&
+            data.as_slice() == [1,1,0,1,1,0,1]
+        ));
     } else {
         panic!("invalid pdu type");
     }


### PR DESCRIPTION
This adds a `SopClassExtendedNegotiationSubItem` to the Pdu's `UserVariableItem `enum.
It will be useful for extended negotiation options between AEs.

Fixes test for PDU UserVariables that never failed. 