### PR TITLE
Shrink size of GetAttributeError

### DIFF
--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -51,7 +51,8 @@ pub enum GetAttributeError {
     Retrieve {
         name: AttributeName,
         #[snafu(backtrace)]
-        source: dicom_object::Error,
+        #[snafu(source(from(dicom_object::Error, Box::from)))]
+        source: Box<dicom_object::Error>,
     },
 
     #[snafu(display("Could not get attribute `{}`", name))]
@@ -64,7 +65,8 @@ pub enum GetAttributeError {
     #[snafu(display("Could not convert attribute `{}`", name))]
     ConvertValue {
         name: AttributeName,
-        source: dicom_core::value::ConvertValueError,
+        #[snafu(source(from(dicom_core::value::ConvertValueError, Box::from)))]
+        source: Box<dicom_core::value::ConvertValueError>,
         backtrace: Backtrace,
     },
 

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -457,3 +457,13 @@ pub fn photometric_interpretation<D: DataDictionary + Clone>(
         .trim()
         .into())
 }
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn errors_are_not_too_large() {
+        let size = std::mem::size_of::<super::GetAttributeError>();
+        assert!(size <= 64, "GetAttributeError size is too large ({} > 64)", size);
+    }
+}


### PR DESCRIPTION
The sizes of the error types in `dicom-pixeldata` were very large, which can have an impact on performance. This manages to shrink the stack memory size of `GetAttributeError` from 168 bytes to 64 bytes.

- add test to require smaller size of `GetAttributeError`
- Replace `GetAttributeError::name` type with `AttributeName`
- Simplify `GetAttributeError::MissingRequiredField`
- Box `GetAttributeError` variants `Retrieve` and `ConvertValue`

Since `GetAttributeError` is never made public (dependent is an opaque error type), this is not a breaking change.

