### PR TITLE
Update gdcm-rs to v0.5

### DIFF
--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -18,7 +18,7 @@ dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry", version
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.5.0" }
 snafu = "0.7.3"
 byteorder = "1.4.3"
-gdcm-rs = { version = "0.4.0", optional = true }
+gdcm-rs = { version = "0.5.0", optional = true }
 rayon = "1.5.0"
 ndarray = "0.15.1"
 num-traits = "0.2.12"

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -156,6 +156,8 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
+    const MAX_TEST_FRAMES: u32 = 16;
+
     #[rstest(value => [
         "pydicom/693_J2KI.dcm",
         "pydicom/693_J2KR.dcm",
@@ -200,7 +202,7 @@ mod tests {
             Path::new("../target/dicom_test_files/_out/test_gdcm_parse_dicom_pixel_data");
         fs::create_dir_all(output_dir).unwrap();
 
-        for i in 0..pixel_data.number_of_frames {
+        for i in 0..pixel_data.number_of_frames.min(MAX_TEST_FRAMES) {
             let image = pixel_data.to_dynamic_image(i).unwrap();
             let image_path = output_dir.join(format!(
                 "{}-{}.png",


### PR DESCRIPTION
-  Restrain multi-frame pixel data decoding tests to a maximum of 16 frames per test file (in `gdcm`)
- Update `gdcm-rs` to v0.5.0