### PR TITLE
Fix rustc warning at DecodedPixelData::frame_data

### DIFF
--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -439,7 +439,7 @@ impl DecodedPixelData<'_> {
             .fail()?
         }
 
-        Ok(&self.data[(frame_start as usize..frame_end as usize)])
+        Ok(&self.data[frame_start as usize..frame_end as usize])
     }
 
     /// Retrieve a copy of a frame's raw pixel data samples


### PR DESCRIPTION
unnecessary parentheses