### PR TITLE
Leading whitespaces in VR DS and IS  

### DIFF
--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -964,8 +964,7 @@ impl PrimitiveValue {
     {
         match self {
             PrimitiveValue::Str(s) => {
-                s.trim_end()
-                    .trim_start()
+                s.trim()
                     .parse()
                     .context(ParseIntegerSnafu)
                     .map_err(|err| ConvertValueError {
@@ -975,8 +974,7 @@ impl PrimitiveValue {
                     })
             }
             PrimitiveValue::Strs(s) if !s.is_empty() => s[0]
-                .trim_end()
-                .trim_start()
+                .trim()
                 .parse()
                 .context(ParseIntegerSnafu)
                 .map_err(|err| ConvertValueError {
@@ -1305,8 +1303,7 @@ impl PrimitiveValue {
     pub fn to_float32(&self) -> Result<f32, ConvertValueError> {
         match self {
             PrimitiveValue::Str(s) => {
-                s.trim_end()
-                    .trim_start()
+                s.trim()
                     .parse()
                     .context(ParseFloatSnafu)
                     .map_err(|err| ConvertValueError {
@@ -1316,8 +1313,7 @@ impl PrimitiveValue {
                     })
             }
             PrimitiveValue::Strs(s) if !s.is_empty() => s[0]
-                .trim_end()
-                .trim_start()
+                .trim()
                 .parse()
                 .context(ParseFloatSnafu)
                 .map_err(|err| ConvertValueError {
@@ -1657,8 +1653,7 @@ impl PrimitiveValue {
     pub fn to_float64(&self) -> Result<f64, ConvertValueError> {
         match self {
             PrimitiveValue::Str(s) => {
-                s.trim_end()
-                    .trim_start()
+                s.trim()
                     .parse()
                     .context(ParseFloatSnafu)
                     .map_err(|err| ConvertValueError {
@@ -1668,8 +1663,7 @@ impl PrimitiveValue {
                     })
             }
             PrimitiveValue::Strs(s) if !s.is_empty() => s[0]
-                .trim_end()
-                .trim_start()
+                .trim()
                 .parse()
                 .context(ParseFloatSnafu)
                 .map_err(|err| ConvertValueError {

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -965,6 +965,7 @@ impl PrimitiveValue {
         match self {
             PrimitiveValue::Str(s) => {
                 s.trim_end()
+                    .trim_start()
                     .parse()
                     .context(ParseIntegerSnafu)
                     .map_err(|err| ConvertValueError {
@@ -975,6 +976,7 @@ impl PrimitiveValue {
             }
             PrimitiveValue::Strs(s) if !s.is_empty() => s[0]
                 .trim_end()
+                .trim_start()
                 .parse()
                 .context(ParseIntegerSnafu)
                 .map_err(|err| ConvertValueError {
@@ -1129,6 +1131,7 @@ impl PrimitiveValue {
             PrimitiveValue::Str(s) => {
                 let out = s
                     .trim_end()
+                    .trim_start()
                     .parse()
                     .context(ParseIntegerSnafu)
                     .map_err(|err| ConvertValueError {
@@ -1142,6 +1145,7 @@ impl PrimitiveValue {
                 .iter()
                 .map(|v| {
                     v.trim_end()
+                        .trim_start()
                         .parse()
                         .context(ParseIntegerSnafu)
                         .map_err(|err| ConvertValueError {
@@ -1302,6 +1306,7 @@ impl PrimitiveValue {
         match self {
             PrimitiveValue::Str(s) => {
                 s.trim_end()
+                    .trim_start()
                     .parse()
                     .context(ParseFloatSnafu)
                     .map_err(|err| ConvertValueError {
@@ -1312,6 +1317,7 @@ impl PrimitiveValue {
             }
             PrimitiveValue::Strs(s) if !s.is_empty() => s[0]
                 .trim_end()
+                .trim_start()
                 .parse()
                 .context(ParseFloatSnafu)
                 .map_err(|err| ConvertValueError {
@@ -1652,6 +1658,7 @@ impl PrimitiveValue {
         match self {
             PrimitiveValue::Str(s) => {
                 s.trim_end()
+                    .trim_start()
                     .parse()
                     .context(ParseFloatSnafu)
                     .map_err(|err| ConvertValueError {
@@ -1662,6 +1669,7 @@ impl PrimitiveValue {
             }
             PrimitiveValue::Strs(s) if !s.is_empty() => s[0]
                 .trim_end()
+                .trim_start()
                 .parse()
                 .context(ParseFloatSnafu)
                 .map_err(|err| ConvertValueError {
@@ -4080,6 +4088,22 @@ mod tests {
     }
 
     #[test]
+    fn primitive_value_to_float() {
+        // DS conversion to f32
+        assert_eq!(dicom_value!(Str, "-73.4 ").to_float32().ok(), Some(-73.4));
+
+        // DS conversion with leading whitespaces
+        assert_eq!(dicom_value!(Str, " -73.4 ").to_float32().ok(), Some(-73.4));
+
+
+        // DS conversion with leading whitespaces
+        assert_eq!(dicom_value!(Str, " -73.4 ").to_float64().ok(), Some(-73.4));
+
+        // DS conversion with exponential
+        assert_eq!(dicom_value!(Str, "1e1").to_float32().ok(), Some(10.0));
+    }
+
+    #[test]
     fn primitive_value_to_int() {
         assert!(PrimitiveValue::Empty.to_int::<i32>().is_err());
 
@@ -4107,6 +4131,9 @@ mod tests {
 
         // admits an integer as text
         assert_eq!(dicom_value!(Strs, ["-73", "2"]).to_int().ok(), Some(-73),);
+
+        // admits an integer as text with leading spaces
+        assert_eq!(dicom_value!(Strs, [" -73", " 2"]).to_int().ok(), Some(-73),);
 
         // does not admit destructive conversions
         assert!(PrimitiveValue::from(-1).to_int::<u32>().is_err());

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -923,7 +923,7 @@ impl PrimitiveValue {
     /// If the value is a string or sequence of strings,
     /// the first string is parsed to obtain an integer,
     /// potentially failing if the string does not represent a valid integer.
-    /// The string is stripped of trailing whitespace before parsing,
+    /// The string is stripped of leading/trailing whitespace before parsing,
     /// in order to account for the possible padding to even length.
     /// If the value is a sequence of U8 bytes,
     /// the bytes are individually interpreted as independent numbers.
@@ -1083,7 +1083,7 @@ impl PrimitiveValue {
     /// If the value is a string or sequence of strings,
     /// each string is parsed to obtain an integer,
     /// potentially failing if the string does not represent a valid integer.
-    /// The string is stripped of trailing whitespace before parsing,
+    /// The string is stripped of leading/trailing whitespace before parsing,
     /// in order to account for the possible padding to even length.
     /// If the value is a sequence of U8 bytes,
     /// the bytes are individually interpreted as independent numbers.
@@ -1273,7 +1273,7 @@ impl PrimitiveValue {
     /// If the value is a string or sequence of strings,
     /// the first string is parsed to obtain a number,
     /// potentially failing if the string does not represent a valid number.
-    /// The string is stripped of trailing whitespace before parsing,
+    /// The string is stripped of leading/trailing whitespace before parsing,
     /// in order to account for the possible padding to even length.
     /// If the value is a sequence of U8 bytes,
     /// the bytes are individually interpreted as independent numbers.
@@ -1434,7 +1434,7 @@ impl PrimitiveValue {
     /// If the value is a string or sequence of strings,
     /// the strings are parsed to obtain a number,
     /// potentially failing if the string does not represent a valid number.
-    /// The string is stripped of trailing whitespace before parsing,
+    /// The string is stripped of leading/trailing whitespace before parsing,
     /// in order to account for the possible padding to even length.
     /// If the value is a sequence of U8 bytes,
     /// the bytes are individually interpreted as independent numbers.
@@ -1625,6 +1625,7 @@ impl PrimitiveValue {
     /// If the value is a string or sequence of strings,
     /// the first string is parsed to obtain a number,
     /// potentially failing if the string does not represent a valid number.
+    /// The string is stripped of leading/trailing whitespace before parsing.
     /// If the value is a sequence of U8 bytes,
     /// the bytes are individually interpreted as independent numbers.
     /// Otherwise, the operation fails.
@@ -1784,7 +1785,7 @@ impl PrimitiveValue {
     /// If the value is a string or sequence of strings,
     /// the strings are parsed to obtain a number,
     /// potentially failing if the string does not represent a valid number.
-    /// The string is stripped of trailing whitespace before parsing,
+    /// The string is stripped of leading/trailing whitespace before parsing,
     /// in order to account for the possible padding to even length.
     /// If the value is a sequence of U8 bytes,
     /// the bytes are individually interpreted as independent numbers.

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -1128,8 +1128,7 @@ impl PrimitiveValue {
             PrimitiveValue::Empty => Ok(Vec::new()),
             PrimitiveValue::Str(s) => {
                 let out = s
-                    .trim_end()
-                    .trim_start()
+                    .trim()
                     .parse()
                     .context(ParseIntegerSnafu)
                     .map_err(|err| ConvertValueError {
@@ -1142,8 +1141,7 @@ impl PrimitiveValue {
             PrimitiveValue::Strs(s) => s
                 .iter()
                 .map(|v| {
-                    v.trim_end()
-                        .trim_start()
+                    v.trim()
                         .parse()
                         .context(ParseIntegerSnafu)
                         .map_err(|err| ConvertValueError {
@@ -1466,7 +1464,7 @@ impl PrimitiveValue {
             PrimitiveValue::Empty => Ok(Vec::new()),
             PrimitiveValue::Str(s) => {
                 let out = s
-                    .trim_end()
+                    .trim()
                     .parse()
                     .context(ParseFloatSnafu)
                     .map_err(|err| ConvertValueError {
@@ -1479,7 +1477,7 @@ impl PrimitiveValue {
             PrimitiveValue::Strs(s) => s
                 .iter()
                 .map(|v| {
-                    v.trim_end()
+                    v.trim()
                         .parse()
                         .context(ParseFloatSnafu)
                         .map_err(|err| ConvertValueError {
@@ -1815,7 +1813,7 @@ impl PrimitiveValue {
         match self {
             PrimitiveValue::Str(s) => {
                 let out = s
-                    .trim_end()
+                    .trim()
                     .parse()
                     .context(ParseFloatSnafu)
                     .map_err(|err| ConvertValueError {
@@ -1828,7 +1826,7 @@ impl PrimitiveValue {
             PrimitiveValue::Strs(s) => s
                 .iter()
                 .map(|v| {
-                    v.trim_end()
+                    v.trim()
                         .parse()
                         .context(ParseFloatSnafu)
                         .map_err(|err| ConvertValueError {

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -1082,8 +1082,7 @@ impl PrimitiveValue {
     /// If the value is a string or sequence of strings,
     /// each string is parsed to obtain an integer,
     /// potentially failing if the string does not represent a valid integer.
-    /// The string is stripped of leading/trailing whitespace before parsing,
-    /// in order to account for the possible padding to even length.
+    /// The string is stripped of leading/trailing whitespace before parsing.
     /// If the value is a sequence of U8 bytes,
     /// the bytes are individually interpreted as independent numbers.
     /// Otherwise, the operation fails.
@@ -1272,8 +1271,7 @@ impl PrimitiveValue {
     /// If the value is a string or sequence of strings,
     /// the first string is parsed to obtain a number,
     /// potentially failing if the string does not represent a valid number.
-    /// The string is stripped of leading/trailing whitespace before parsing,
-    /// in order to account for the possible padding to even length.
+    /// The string is stripped of leading/trailing whitespace before parsing.
     /// If the value is a sequence of U8 bytes,
     /// the bytes are individually interpreted as independent numbers.
     /// Otherwise, the operation fails.
@@ -1433,8 +1431,7 @@ impl PrimitiveValue {
     /// If the value is a string or sequence of strings,
     /// the strings are parsed to obtain a number,
     /// potentially failing if the string does not represent a valid number.
-    /// The string is stripped of leading/trailing whitespace before parsing,
-    /// in order to account for the possible padding to even length.
+    /// The string is stripped of leading/trailing whitespace before parsing.
     /// If the value is a sequence of U8 bytes,
     /// the bytes are individually interpreted as independent numbers.
     /// Otherwise, the operation fails.
@@ -1784,8 +1781,7 @@ impl PrimitiveValue {
     /// If the value is a string or sequence of strings,
     /// the strings are parsed to obtain a number,
     /// potentially failing if the string does not represent a valid number.
-    /// The string is stripped of leading/trailing whitespace before parsing,
-    /// in order to account for the possible padding to even length.
+    /// The string is stripped of leading/trailing whitespace before parsing.
     /// If the value is a sequence of U8 bytes,
     /// the bytes are individually interpreted as independent numbers.
     /// Otherwise, the operation fails.

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -923,8 +923,7 @@ impl PrimitiveValue {
     /// If the value is a string or sequence of strings,
     /// the first string is parsed to obtain an integer,
     /// potentially failing if the string does not represent a valid integer.
-    /// The string is stripped of leading/trailing whitespace before parsing,
-    /// in order to account for the possible padding to even length.
+    /// The string is stripped of leading/trailing whitespace before parsing.
     /// If the value is a sequence of U8 bytes,
     /// the bytes are individually interpreted as independent numbers.
     /// Otherwise, the operation fails.


### PR DESCRIPTION
Bug:
Leading whitespaces in DS or IS would cause errors in conversion from a string primitive. 
The issue is described here: https://github.com/Enet4/dicom-rs/issues/333

Cause:
Strings were not trimmed with leading spaces.

Fix:
Added `.trim_start()` before conversion to int or float.

Verification:
Added unit tests to ensure theses cases are now adequately handled.
