### PR TITLE
Extend value retrieval API for encapsulated pixel data

### DIFF
--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -486,10 +486,25 @@ where
 
     /// Retrieve the items stored in a sequence value.
     ///
-    /// Returns `None` if the value is not a sequence.
+    /// Returns `None` if the value is not a data set sequence.
     pub fn items(&self) -> Option<&[I]> {
         self.value().items()
     }
+
+    /// Retrieve the fragments stored in a pixel data sequence value.
+    ///
+    /// Returns `None` if the value is not a pixel data sequence.
+    pub fn fragments(&self) -> Option<&[P]> {
+        self.value().fragments()
+    }
+
+    /// Obtain a reference to the encapsulated pixel data's basic offset table.
+    ///
+    /// Returns `None` if the value is not a pixel data sequence.
+    pub fn offset_table(&self) -> Option<&[u32]> {
+        self.value().offset_table()
+    }
+
 }
 
 impl<'v, I, P> DataElementRef<'v, I, P>

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -136,10 +136,22 @@ impl<I, P> Value<I, P> {
         }
     }
 
-    /// Gets a reference to the items.
+    /// Gets a reference to the items of a sequence.
+    /// 
+    /// Returns `None` if the value is not a data set sequence.
     pub fn items(&self) -> Option<&[I]> {
         match *self {
             Value::Sequence { ref items, .. } => Some(items),
+            _ => None,
+        }
+    }
+
+    /// Gets a reference to the fragments of a pixel data sequence.
+    /// 
+    /// Returns `None` if the value is not a pixel data sequence.
+    pub fn fragments(&self) -> Option<&[P]> {
+        match self {
+            Value::PixelSequence { fragments, .. } => Some(fragments),
             _ => None,
         }
     }
@@ -160,7 +172,17 @@ impl<I, P> Value<I, P> {
         }
     }
 
+    /// Retrieves the pixel data fragments.
+    pub fn into_fragments(self) -> Option<C<P>> {
+        match self {
+            Value::PixelSequence { fragments, .. } => Some(fragments),
+            _ => None,
+        }
+    }
+
     /// Gets a reference to the encapsulated pixel data's offset table.
+    /// 
+    /// Returns `None` if the value is not a pixel data sequence.
     pub fn offset_table(&self) -> Option<&[u32]> {
         match self {
             Value::PixelSequence { offset_table, .. } => Some(offset_table),


### PR DESCRIPTION
This extends `dicom-core` with a few convenience methods for retrieving specific parts from a DICOM value, namely pixel data fragments and the basic offset table. Originally, one would need to go through `data_element.value()`, and sometimes even match against the value. Inspired by #336.