### PR TITLE
Extend data set readers

### DIFF
--- a/parser/src/dataset/lazy_read.rs
+++ b/parser/src/dataset/lazy_read.rs
@@ -210,12 +210,16 @@ where
         })
     }
 
-    /** Advance and retrieve the next DICOM data token.
-     *
-     * **Note:** For the data set to be successfully parsed,
-     * the resulting data tokens needs to be consumed
-     * if they are of a value type.
-     */
+    /// Retrieve the inner stateful decoder from this data set reader.
+    pub fn into_decoder(self) -> S {
+        self.parser
+    }
+
+    /// Advance and retrieve the next DICOM data token.
+    ///
+    /// **Note:** For the data set to be successfully parsed,
+    /// the resulting data tokens needs to be consumed
+    /// if they are of a value type.
     pub fn next(&mut self) -> Option<Result<LazyDataToken<&mut S>>> {
         if self.hard_break {
             return None;

--- a/parser/src/dataset/lazy_read.rs
+++ b/parser/src/dataset/lazy_read.rs
@@ -220,7 +220,7 @@ where
     /// **Note:** For the data set to be successfully parsed,
     /// the resulting data tokens needs to be consumed
     /// if they are of a value type.
-    pub fn next(&mut self) -> Option<Result<LazyDataToken<&mut S>>> {
+    pub fn advance(&mut self) -> Option<Result<LazyDataToken<&mut S>>> {
         if self.hard_break {
             return None;
         }
@@ -482,7 +482,7 @@ mod tests {
         let mut dset_reader = LazyDataSetReader::new(parser);
 
         let mut gt_iter = ground_truth.into_iter();
-        while let Some(res) = dset_reader.next() {
+        while let Some(res) = dset_reader.advance() {
             let gt_token = gt_iter.next().expect("ground truth is shorter");
             let token = res.expect("should parse without an error");
             let token = token.into_owned().unwrap();
@@ -1029,7 +1029,7 @@ mod tests {
         let mut dset_reader = LazyDataSetReader::new(parser);
 
         let mut gt_iter = ground_truth.into_iter();
-        while let Some(res) = dset_reader.next() {
+        while let Some(res) = dset_reader.advance() {
             let token = res.expect("should parse without an error");
             let gt_token = gt_iter.next().expect("ground truth is shorter");
             match token {
@@ -1082,7 +1082,7 @@ mod tests {
         let mut dset_reader = LazyDataSetReader::new(parser);
 
         let token = dset_reader
-            .next()
+            .advance()
             .expect("Expected token 1")
             .expect("Failed to read token 1");
 
@@ -1094,7 +1094,7 @@ mod tests {
         };
 
         let token = dset_reader
-            .next()
+            .advance()
             .expect("Expected token 2")
             .expect("Failed to read token 2");
 
@@ -1114,7 +1114,7 @@ mod tests {
         );
 
         let token = dset_reader
-            .next()
+            .advance()
             .expect("Expected token 3")
             .expect("Failed to read token 3");
 
@@ -1126,7 +1126,7 @@ mod tests {
         };
 
         let token = dset_reader
-            .next()
+            .advance()
             .expect("Expected token 4")
             .expect("Failed to read token 4");
 
@@ -1146,7 +1146,7 @@ mod tests {
         );
 
         assert!(
-            dset_reader.next().is_none(),
+            dset_reader.advance().is_none(),
             "unexpected number of tokens remaining"
         );
     }

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -200,14 +200,14 @@ impl<D> LazyDataToken<D>
 where
     D: decode::StatefulDecode,
 {
-    pub fn skip(self) -> Result<()> {
+    pub fn skip(self) -> crate::stateful::decode::Result<()> {
         match self {
             LazyDataToken::LazyValue {
                 header,
                 mut decoder,
-            } => decoder.skip_bytes(header.len.0).context(SkipValueSnafu),
+            } => decoder.skip_bytes(header.len.0),
             LazyDataToken::LazyItemValue { len, mut decoder } => {
-                decoder.skip_bytes(len).context(SkipValueSnafu)
+                decoder.skip_bytes(len)
             }
             _ => Ok(()), // do nothing
         }


### PR DESCRIPTION
This moves some independent contributions from #180 and adds a peeking mechanism to the baseline data set reader in `dicom-parser`.

### Summary

- simplify `DataSetReader::skip`
- rename `LazyDataSetReader::next` to `advance`
- add `LazyDataSetReader::into_decoder` and tweak documentation of `advance`
- implement peeking in the baseline `DataSetReader`