### PR TITLE
Split errors in object crate

### DIFF
--- a/findscu/src/main.rs
+++ b/findscu/src/main.rs
@@ -69,10 +69,10 @@ enum Error {
     },
 
     /// Could not construct DICOM command
-    CreateCommand { source: dicom_object::Error },
+    CreateCommand { source: dicom_object::ReadError },
 
     /// Could not read DICOM command
-    ReadCommand { source: dicom_object::Error },
+    ReadCommand { source: dicom_object::ReadError },
 
     /// Could not dump DICOM output
     DumpOutput { source: std::io::Error },

--- a/object/src/file.rs
+++ b/object/src/file.rs
@@ -3,9 +3,11 @@ use dicom_dictionary_std::StandardDataDictionary;
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 
-use crate::{DefaultDicomObject, Result};
+use crate::{DefaultDicomObject, ReadError};
 use std::io::Read;
 use std::path::Path;
+
+pub type Result<T, E = ReadError> = std::result::Result<T, E>;
 
 /// Create a DICOM object by reading from a byte source.
 ///

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -275,11 +275,6 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// A root DICOM object contains additional meta information about the object
-/// in a separate table.
-#[deprecated(since = "0.4.0", note = "use `FileDicomObject` instead")]
-pub type RootDicomObject<O> = FileDicomObject<O>;
-
 /// A root DICOM object retrieved from a standard DICOM file,
 /// containing additional information from the file meta group
 /// in a separate table value.

--- a/object/tests/integration_test.rs
+++ b/object/tests/integration_test.rs
@@ -54,7 +54,7 @@ fn test_read_until_pixel_data() {
     // but does not contain pixel data
     assert!(matches!(
         object.element(tags::PIXEL_DATA),
-        Err(dicom_object::Error::NoSuchDataElementTag { .. })
+        Err(dicom_object::AccessError::NoSuchDataElementTag { .. })
     ));
 }
 

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -51,8 +51,8 @@ pub enum GetAttributeError {
     Retrieve {
         name: AttributeName,
         #[snafu(backtrace)]
-        #[snafu(source(from(dicom_object::Error, Box::from)))]
-        source: Box<dicom_object::Error>,
+        #[snafu(source(from(dicom_object::AccessError, Box::from)))]
+        source: Box<dicom_object::AccessError>,
     },
 
     #[snafu(display("Could not get attribute `{}`", name))]

--- a/storescu/src/main.rs
+++ b/storescu/src/main.rs
@@ -76,7 +76,7 @@ enum Error {
     },
 
     /// Could not construct DICOM command
-    CreateCommand { source: dicom_object::Error },
+    CreateCommand { source: dicom_object::WriteError },
 
     #[snafu(whatever, display("{}", message))]
     Other {


### PR DESCRIPTION
- remove `RootDicomObject` alias
   - deprecated since 0.4.0
- replace `dicom_object::Error` with more error types
   - make them more manageable and more constrained to the operations in question
- add test to ensure `AccessError` is not too large
- propagate changes onto `findscu`, `storescu` and `pixeldata`