### PR TITLE
Change PDU association variants and association types

### DIFF
--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -332,32 +332,16 @@ pub enum UserVariableItem {
     SopClassExtendedNegotiationSubItem(String, Vec<u8>)
 }
 
-#[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
+/// An in-memory representation of a full Protocol Data Unit (PDU)
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash)]
 pub enum Pdu {
     Unknown {
         pdu_type: u8,
         data: Vec<u8>,
     },
-    AssociationRQ {
-        protocol_version: u16,
-        calling_ae_title: String,
-        called_ae_title: String,
-        application_context_name: String,
-        presentation_contexts: Vec<PresentationContextProposed>,
-        user_variables: Vec<UserVariableItem>,
-    },
-    AssociationAC {
-        protocol_version: u16,
-        calling_ae_title: String,
-        called_ae_title: String,
-        application_context_name: String,
-        presentation_contexts: Vec<PresentationContextResult>,
-        user_variables: Vec<UserVariableItem>,
-    },
-    AssociationRJ {
-        result: AssociationRJResult,
-        source: AssociationRJSource,
-    },
+    AssociationRQ(AssociationRQ),
+    AssociationAC(AssociationAC),
+    AssociationRJ(AssociationRJ),
     PData {
         data: Vec<PDataValue>,
     },
@@ -384,26 +368,50 @@ impl Pdu {
         }
     }
 }
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
-struct AssociationRQ {
-    protocol_version: u16,
-    calling_ae_title: String,
-    called_ae_title: String,
-    application_context_name: String,
-    presentation_contexts: Vec<PresentationContextProposed>,
-    user_variables: Vec<UserVariableItem>,
+
+/// An in-memory representation of an association request
+#[derive(Debug, Clone, Eq, Hash, PartialEq, PartialOrd)]
+pub struct AssociationRQ {
+    pub protocol_version: u16,
+    pub calling_ae_title: String,
+    pub called_ae_title: String,
+    pub application_context_name: String,
+    pub presentation_contexts: Vec<PresentationContextProposed>,
+    pub user_variables: Vec<UserVariableItem>,
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
-struct AssociationAC {
-    protocol_version: u16,
-    application_context_name: String,
-    presentation_contexts: Vec<PresentationContextResult>,
-    user_variables: Vec<UserVariableItem>,
+impl From<AssociationRQ> for Pdu {
+    fn from(value: AssociationRQ) -> Self {
+        Pdu::AssociationRQ(value)
+    }
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
-struct AssociationRJ {
-    result: AssociationRJResult,
-    source: AssociationRJSource,
+/// An in-memory representation of an association acknowledgement
+#[derive(Debug, Clone, Eq, Hash, PartialEq, PartialOrd)]
+pub struct AssociationAC {
+    pub protocol_version: u16,
+    pub calling_ae_title: String,
+    pub called_ae_title: String,
+    pub application_context_name: String,
+    pub presentation_contexts: Vec<PresentationContextResult>,
+    pub user_variables: Vec<UserVariableItem>,
+}
+
+impl From<AssociationAC> for Pdu {
+    fn from(value: AssociationAC) -> Self {
+        Pdu::AssociationAC(value)
+    }
+}
+
+/// An in-memory representation of an association rejection.
+#[derive(Debug, Clone, Eq, Hash, PartialEq, PartialOrd)]
+pub struct AssociationRJ {
+    pub result: AssociationRJResult,
+    pub source: AssociationRJSource,
+}
+
+impl From<AssociationRJ> for Pdu {
+    fn from(value: AssociationRJ) -> Self {
+        Pdu::AssociationRJ(value)
+    }
 }

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -247,7 +247,7 @@ where
                 }
             }
 
-            Ok(Pdu::AssociationRQ {
+            Ok(Pdu::AssociationRQ(AssociationRQ {
                 protocol_version,
                 application_context_name: application_context_name
                     .context(MissingApplicationContextNameSnafu)?,
@@ -255,7 +255,7 @@ where
                 calling_ae_title,
                 presentation_contexts,
                 user_variables,
-            })
+            }))
         }
         0x02 => {
             // A-ASSOCIATE-AC PDU Structure
@@ -341,7 +341,7 @@ where
                 }
             }
 
-            Ok(Pdu::AssociationAC {
+            Ok(Pdu::AssociationAC(AssociationAC {
                 protocol_version,
                 application_context_name: application_context_name
                     .context(MissingApplicationContextNameSnafu)?,
@@ -349,7 +349,7 @@ where
                 calling_ae_title,
                 presentation_contexts,
                 user_variables,
-            })
+            }))
         }
         0x03 => {
             // A-ASSOCIATE-RJ PDU Structure
@@ -402,7 +402,7 @@ where
             )
             .context(InvalidRejectSourceOrReasonSnafu)?;
 
-            Ok(Pdu::AssociationRJ { result, source })
+            Ok(Pdu::AssociationRJ(AssociationRJ { result, source }))
         }
         0x04 => {
             // P-DATA-TF PDU Structure

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -102,14 +102,14 @@ where
 {
     let codec = dicom_encoding::text::DefaultCharacterSetCodec;
     match pdu {
-        Pdu::AssociationRQ {
+        Pdu::AssociationRQ(AssociationRQ {
             protocol_version,
             calling_ae_title,
             called_ae_title,
             application_context_name,
             presentation_contexts,
             user_variables,
-        } => {
+        }) => {
             // A-ASSOCIATE-RQ PDU Structure
 
             // 1 - PDU-type - 01H
@@ -199,14 +199,14 @@ where
 
             Ok(())
         }
-        Pdu::AssociationAC {
+        Pdu::AssociationAC(AssociationAC {
             protocol_version,
             application_context_name,
             called_ae_title,
             calling_ae_title,
             presentation_contexts,
             user_variables,
-        } => {
+        }) => {
             // A-ASSOCIATE-AC PDU Structure
 
             // 1 - PDU-type - 02H
@@ -294,7 +294,7 @@ where
                 name: "A-ASSOCIATE-AC",
             })
         }
-        Pdu::AssociationRJ { result, source } => {
+        Pdu::AssociationRJ(AssociationRJ { result, source }) => {
             // 1 - PDU-type - 03H
             writer
                 .write_u8(0x03)
@@ -1012,7 +1012,7 @@ fn write_pdu_variable_user_variables(
 
                         write_chunk_u16(writer, |writer| {
                             // xxx-xxx Service-class-application-information - This field shall contain
-                            // the application information specific to the Service Class specification 
+                            // the application information specific to the Service Class specification
                             // identified by the SOP-class-uid. The semantics and value of this field is
                             // defined in the identified Service Class specification.
                             writer.write_all(data).context(WriteFieldSnafu {

--- a/ul/tests/pdu.rs
+++ b/ul/tests/pdu.rs
@@ -1,14 +1,14 @@
 use dicom_ul::pdu::reader::{read_pdu, DEFAULT_MAX_PDU};
 use dicom_ul::pdu::writer::write_pdu;
 use dicom_ul::pdu::{
-    PDataValue, PDataValueType, Pdu, PresentationContextProposed, UserVariableItem,
+    PDataValue, PDataValueType, Pdu, PresentationContextProposed, UserVariableItem, AssociationRQ,
 };
 use matches::matches;
 use std::io::Cursor;
 
 #[test]
 fn can_read_write_associate_rq() -> Result<(), Box<dyn std::error::Error>> {
-    let association_rq = Pdu::AssociationRQ {
+    let association_rq = AssociationRQ {
         protocol_version: 2,
         calling_ae_title: "calling ae".to_string(),
         called_ae_title: "called ae".to_string(),
@@ -37,18 +37,18 @@ fn can_read_write_associate_rq() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let mut bytes = vec![0u8; 0];
-    write_pdu(&mut bytes, &association_rq)?;
+    write_pdu(&mut bytes, &association_rq.into())?;
 
     let result = read_pdu(&mut Cursor::new(&bytes), DEFAULT_MAX_PDU, true)?;
 
-    if let Pdu::AssociationRQ {
+    if let Pdu::AssociationRQ(AssociationRQ {
         protocol_version,
         calling_ae_title,
         called_ae_title,
         application_context_name,
         presentation_contexts,
         user_variables,
-    } = result
+    }) = result
     {
         assert_eq!(protocol_version, 2);
         assert_eq!(calling_ae_title, "calling ae");


### PR DESCRIPTION
- Use subtypes to describe PDU association variants
- Change client/server error types to have a smaller size and use new public types
