### PR TITLE
Changes to DicomValue API and sequences

### DIFF
--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -81,9 +81,11 @@ pub trait Header: HasLength {
 
 /// Stub type representing a non-existing DICOM object.
 ///
-/// This type implements `HasLength`, but cannot be instantiated.
-/// This makes it so that `Value<EmptyObject>` is sure to be either a primitive
-/// value or a sequence with no items.
+/// This type implements [`HasLength`], but cannot be instantiated.
+/// This makes it so that [`Value<EmptyObject>`] is sure to be either
+/// a primitive value,
+/// a pixel data fragment sequence,
+/// or a sequence with no items.
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub enum EmptyObject {}
 
@@ -290,7 +292,7 @@ where
     /// with no trailing whitespace.
     ///
     /// Returns an error if the value is not primitive.
-    pub fn to_str(&self) -> Result<Cow<str>, CastValueError> {
+    pub fn to_str(&self) -> Result<Cow<str>, ConvertValueError> {
         self.value.to_str()
     }
 
@@ -298,17 +300,8 @@ where
     /// with trailing whitespace kept.
     ///
     /// Returns an error if the value is not primitive.
-    pub fn to_raw_str(&self) -> Result<Cow<str>, CastValueError> {
+    pub fn to_raw_str(&self) -> Result<Cow<str>, ConvertValueError> {
         self.value.to_raw_str()
-    }
-
-    /// Retrieves the element's value as a clean string
-    #[deprecated(
-        note = "`to_clean_str()` is now deprecated in favour of using `to_str()` directly.
-        `to_raw_str()` replaces the old functionality of `to_str()` and maintains all trailing whitespace."
-    )]
-    pub fn to_clean_str(&self) -> Result<Cow<str>, CastValueError> {
-        self.value.to_str()
     }
 
     /// Convert the full primitive value into raw bytes.
@@ -317,8 +310,8 @@ where
     /// are provided in UTF-8.
     ///
     /// Returns an error if the value is not primitive.
-    pub fn to_bytes(&self) -> Result<Cow<[u8]>, CastValueError> {
-        self.value().to_bytes()
+    pub fn to_bytes(&self) -> Result<Cow<[u8]>, ConvertValueError> {
+        self.value.to_bytes()
     }
 
     /// Convert the full value of the data element into a sequence of strings.

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -4249,14 +4249,15 @@ impl PartialEq<&str> for PrimitiveValue {
 
 /// An enum representing an abstraction of a DICOM element's data value type.
 /// This should be the equivalent of `PrimitiveValue` without the content,
-/// plus the `Item` and `PixelSequence` entries.
+/// plus the `DataSetSequence` and `PixelSequence` entries.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ValueType {
     /// No data. Used for any value of length 0.
     Empty,
 
-    /// An item. Used for elements in a SQ, regardless of content.
-    Item,
+    /// A data set sequence.
+    /// Used for values with the SQ representation when not empty.
+    DataSetSequence,
 
     /// An item. Used for the values of encapsulated pixel data.
     PixelSequence,

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -752,68 +752,6 @@ impl PrimitiveValue {
         }
     }
 
-    /// Convert the primitive value into a clean string representation,
-    /// removing unwanted whitespaces.
-    ///
-    /// Leading whitespaces are preserved and are only removed at the end of a string
-    ///
-    /// String values already encoded with the `Str` and `Strs` variants
-    /// are provided as is without the unwanted whitespaces.
-    /// In the case of `Strs`, the strings are first cleaned from whitespaces
-    /// and then joined together with a backslash (`'\\'`).
-    /// All other type variants are first converted to a clean string,
-    /// then joined together with a backslash.
-    ///
-    /// **Note:**
-    /// As the process of reading a DICOM value
-    /// may not always preserve its original nature,
-    /// it is not guaranteed that `to_clean_str()` returns a string with
-    /// the exact same byte sequence as the one originally found
-    /// at the source of the value,
-    /// even for the string variants.
-    /// Therefore, this method is not reliable
-    /// for compliant DICOM serialization.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use dicom_core::dicom_value;
-    /// # use dicom_core::value::{C, PrimitiveValue, DicomDate};
-    /// # use smallvec::smallvec;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// assert_eq!(
-    ///     dicom_value!(Str, "Smith^John ").to_clean_str(),
-    ///     "Smith^John",
-    /// );
-    /// assert_eq!(
-    ///     dicom_value!(Str, " Smith^John").to_clean_str(),
-    ///     " Smith^John",
-    /// );
-    /// assert_eq!(
-    ///     dicom_value!(Date, DicomDate::from_ymd(2014, 10, 12)?).to_clean_str(),
-    ///     "2014-10-12",
-    /// );
-    /// assert_eq!(
-    ///     dicom_value!(Strs, [
-    ///         "DERIVED\0",
-    ///         "PRIMARY",
-    ///         " WHOLE BODY",
-    ///         "EMISSION",
-    ///     ])
-    ///     .to_clean_str(),
-    ///     "DERIVED\\PRIMARY\\ WHOLE BODY\\EMISSION",
-    /// );
-    /// Ok(())
-    /// }
-    /// ```
-    #[deprecated(
-        note = "`to_clean_str()` is now deprecated in favour of using `to_str()` directly. 
-        `to_raw_str()` replaces the old functionality of `to_str()` and maintains all trailing whitespace."
-    )]
-    pub fn to_clean_str(&self) -> Cow<str> {
-        self.to_str()
-    }
-
     /// Retrieve this DICOM value as raw bytes.
     ///
     /// Binary numeric values are returned with a reinterpretation

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -549,7 +549,7 @@ where
     };
 
     match elem.value() {
-        DicomValue::Sequence { items, .. } => {
+        DicomValue::Sequence(seq) => {
             writeln!(
                 to,
                 "{} {:28} {} ({} Item{})",
@@ -559,7 +559,7 @@ where
                 vm,
                 if vm == 1 { "" } else { "s" },
             )?;
-            for item in items {
+            for item in seq.items() {
                 dump_item(&mut *to, item, width, depth + 2, no_text_limit, no_limit)?;
             }
             to.write_all(&indent)?;
@@ -570,13 +570,10 @@ where
                 DumpValue::Alias("SequenceDelimitationItem"),
             )?;
         }
-        DicomValue::PixelSequence {
-            fragments,
-            offset_table,
-        } => {
+        DicomValue::PixelSequence(seq) => {
             // write pixel sequence start line
             let vr = elem.vr();
-            let num_items = 1 + fragments.len();
+            let num_items = 1 + seq.fragments().len();
             writeln!(
                 to,
                 "{} {:28} {} (PixelSequence, {} Item{})",
@@ -588,6 +585,7 @@ where
             )?;
 
             // write offset table
+            let offset_table = seq.offset_table();
             let byte_len = offset_table.len() * 4;
             let summary = offset_table_summary(
                 offset_table,
@@ -605,7 +603,7 @@ where
             )?;
 
             // write compressed fragments
-            for fragment in fragments {
+            for fragment in seq.fragments() {
                 let byte_len = fragment.len();
                 let summary = item_value_summary(
                     fragment,

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -268,7 +268,7 @@ pub enum Error {
     },
     /// Could not prepare file meta table
     PrepareMetaTable {
-        source: dicom_core::value::CastValueError,
+        source: dicom_core::value::ConvertValueError,
         backtrace: Backtrace,
     },
 }

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -553,23 +553,21 @@ where
         let pixel_data = self.element(dicom_dictionary_std::tags::PIXEL_DATA).ok()?;
         match pixel_data.value() {
             dicom_core::DicomValue::Primitive(_p) => Some(1),
-            dicom_core::DicomValue::PixelSequence {
-                offset_table: _,
-                fragments,
-            } => Some(fragments.len() as u32),
-            dicom_core::DicomValue::Sequence { items: _, size: _ } => None,
+            dicom_core::DicomValue::PixelSequence(v) => Some(v.fragments().len() as u32),
+            dicom_core::DicomValue::Sequence(..) => None,
         }
     }
 
     /// Return a specific encoded pixel fragment by index as Vec<u8>
     /// or None if no pixel data is found
+    /// 
+    /// Panics if `fragment` is out of bounds for the encapsulated pixel data fragments.
     fn fragment(&self, fragment: usize) -> Option<Vec<u8>> {
         let pixel_data = self.element(dicom_dictionary_std::tags::PIXEL_DATA).ok()?;
         match pixel_data.value() {
-            dicom_core::DicomValue::PixelSequence {
-                offset_table: _,
-                fragments,
-            } => Some(fragments[fragment].clone()),
+            dicom_core::DicomValue::PixelSequence(v) => {
+                Some(v.fragments()[fragment].clone())
+            }
             _ => None,
         }
     }
@@ -590,14 +588,14 @@ where
                     offset_table: SmallVec::new(),
                 })
             }
-            dicom_core::DicomValue::PixelSequence {
-                offset_table,
-                fragments,
-            } => Some(RawPixelData {
-                fragments: fragments.clone(),
-                offset_table: offset_table.clone(),
-            }),
-            dicom_core::DicomValue::Sequence { items: _, size: _ } => None,
+            dicom_core::DicomValue::PixelSequence(v) => {
+                let (offset_table, fragments) = v.clone().into_parts();
+                Some(RawPixelData {
+                    fragments,
+                    offset_table,
+                })
+            },
+            dicom_core::DicomValue::Sequence(..) => None,
         }
     }
 }

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -40,7 +40,7 @@ use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 pub type InMemElement<D = StandardDataDictionary> = DataElement<InMemDicomObject<D>, InMemFragment>;
 
 /// The type of a pixel data fragment.
-pub type InMemFragment = Vec<u8>;
+pub type InMemFragment = dicom_core::value::InMemFragment;
 
 type ParserResult<T> = std::result::Result<T, ParserError>;
 

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use dicom_core::dictionary::{DataDictionary, DictionaryEntry};
 use dicom_core::header::{HasLength, Header};
-use dicom_core::value::{Value, ValueType, C};
+use dicom_core::value::{DataSetSequence, PixelFragmentSequence, Value, ValueType, C};
 use dicom_core::{DataElement, Length, PrimitiveValue, Tag, VR};
 use dicom_dictionary_std::{tags, StandardDataDictionary};
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
@@ -717,12 +717,12 @@ where
                     Ok(())
                 }
 
-                Value::PixelSequence { .. } => IncompatibleTypesSnafu {
+                Value::PixelSequence(..) => IncompatibleTypesSnafu {
                     kind: ValueType::PixelSequence,
                 }
                 .fail(),
-                Value::Sequence { .. } => IncompatibleTypesSnafu {
-                    kind: ValueType::Item,
+                Value::Sequence(..) => IncompatibleTypesSnafu {
+                    kind: ValueType::DataSetSequence,
                 }
                 .fail(),
             }
@@ -750,12 +750,12 @@ where
                     Ok(())
                 }
 
-                Value::PixelSequence { .. } => IncompatibleTypesSnafu {
+                Value::PixelSequence(..) => IncompatibleTypesSnafu {
                     kind: ValueType::PixelSequence,
                 }
                 .fail(),
-                Value::Sequence { .. } => IncompatibleTypesSnafu {
-                    kind: ValueType::Item,
+                Value::Sequence(..) => IncompatibleTypesSnafu {
+                    kind: ValueType::DataSetSequence,
                 }
                 .fail(),
             }
@@ -783,12 +783,12 @@ where
                     Ok(())
                 }
 
-                Value::PixelSequence { .. } => IncompatibleTypesSnafu {
+                Value::PixelSequence(..) => IncompatibleTypesSnafu {
                     kind: ValueType::PixelSequence,
                 }
                 .fail(),
-                Value::Sequence { .. } => IncompatibleTypesSnafu {
-                    kind: ValueType::Item,
+                Value::Sequence(..) => IncompatibleTypesSnafu {
+                    kind: ValueType::DataSetSequence,
                 }
                 .fail(),
             }
@@ -816,12 +816,12 @@ where
                     Ok(())
                 }
 
-                Value::PixelSequence { .. } => IncompatibleTypesSnafu {
+                Value::PixelSequence(..) => IncompatibleTypesSnafu {
                     kind: ValueType::PixelSequence,
                 }
                 .fail(),
-                Value::Sequence { .. } => IncompatibleTypesSnafu {
-                    kind: ValueType::Item,
+                Value::Sequence(..) => IncompatibleTypesSnafu {
+                    kind: ValueType::DataSetSequence,
                 }
                 .fail(),
             }
@@ -849,12 +849,12 @@ where
                     Ok(())
                 }
 
-                Value::PixelSequence { .. } => IncompatibleTypesSnafu {
+                Value::PixelSequence(..) => IncompatibleTypesSnafu {
                     kind: ValueType::PixelSequence,
                 }
                 .fail(),
-                Value::Sequence { .. } => IncompatibleTypesSnafu {
-                    kind: ValueType::Item,
+                Value::Sequence(..) => IncompatibleTypesSnafu {
+                    kind: ValueType::DataSetSequence,
                 }
                 .fail(),
             }
@@ -882,12 +882,12 @@ where
                     Ok(())
                 }
 
-                Value::PixelSequence { .. } => IncompatibleTypesSnafu {
+                Value::PixelSequence(..) => IncompatibleTypesSnafu {
                     kind: ValueType::PixelSequence,
                 }
                 .fail(),
-                Value::Sequence { .. } => IncompatibleTypesSnafu {
-                    kind: ValueType::Item,
+                Value::Sequence(..) => IncompatibleTypesSnafu {
+                    kind: ValueType::DataSetSequence,
                 }
                 .fail(),
             }
@@ -915,12 +915,12 @@ where
                     Ok(())
                 }
 
-                Value::PixelSequence { .. } => IncompatibleTypesSnafu {
+                Value::PixelSequence(..) => IncompatibleTypesSnafu {
                     kind: ValueType::PixelSequence,
                 }
                 .fail(),
-                Value::Sequence { .. } => IncompatibleTypesSnafu {
-                    kind: ValueType::Item,
+                Value::Sequence(..) => IncompatibleTypesSnafu {
+                    kind: ValueType::DataSetSequence,
                 }
                 .fail(),
             }
@@ -1104,7 +1104,7 @@ where
                         tag,
                         VR::SQ,
                         len,
-                        Value::Sequence { items, size: len },
+                        Value::Sequence(DataSetSequence::new(items, len)),
                     )
                 }
                 DataToken::ItemEnd if in_item => {
@@ -1168,10 +1168,10 @@ where
             }
         }
 
-        Ok(Value::PixelSequence {
+        Ok(Value::PixelSequence(PixelFragmentSequence::new(
+            offset_table.unwrap_or_default(),
             fragments,
-            offset_table: offset_table.unwrap_or_default().into(),
-        })
+        )))
     }
 
     /// Build a DICOM sequence by consuming a data set parser.
@@ -1965,10 +1965,10 @@ mod tests {
             DataElement::new(
                 Tag(0x0018, 0x6011),
                 VR::SQ,
-                Value::Sequence {
-                    items: smallvec![obj_1, obj_2],
-                    size: Length::UNDEFINED,
-                },
+                Value::from(DataSetSequence::new(
+                    smallvec![obj_1, obj_2],
+                    Length::UNDEFINED,
+                )),
             ),
             DataElement::new(Tag(0x0020, 0x4000), VR::LT, Value::Primitive("TEST".into())),
         ]);
@@ -2044,10 +2044,10 @@ mod tests {
             DataElement::new(
                 Tag(0x0018, 0x6011),
                 VR::SQ,
-                Value::Sequence {
-                    items: smallvec![obj_1, obj_2],
-                    size: Length::UNDEFINED,
-                },
+                Value::from(DataSetSequence::new(
+                    smallvec![obj_1, obj_2],
+                    Length::UNDEFINED,
+                )),
             ),
             DataElement::new(Tag(0x0020, 0x4000), VR::LT, Value::Primitive("TEST".into())),
         ]);
@@ -2105,10 +2105,10 @@ mod tests {
         let gt_obj = InMemDicomObject::from_element_iter(vec![DataElement::new(
             Tag(0x7fe0, 0x0010),
             VR::OB,
-            Value::PixelSequence {
-                fragments: smallvec![vec![0x33; 32]],
-                offset_table: Default::default(),
-            },
+            Value::from(PixelFragmentSequence::new_fragments(smallvec![vec![
+                0x33;
+                32
+            ]])),
         )]);
 
         let tokens: Vec<_> = vec![
@@ -2140,10 +2140,10 @@ mod tests {
         let main_obj = InMemDicomObject::from_element_iter(vec![DataElement::new(
             Tag(0x7fe0, 0x0010),
             VR::OB,
-            Value::PixelSequence {
-                fragments: smallvec![vec![0x33; 32]],
-                offset_table: Default::default(),
-            },
+            Value::from(PixelFragmentSequence::new_fragments(smallvec![vec![
+                0x33;
+                32
+            ]])),
         )]);
 
         let tokens: Vec<_> = main_obj.into_tokens().collect();

--- a/object/tests/integration_test.rs
+++ b/object/tests/integration_test.rs
@@ -21,12 +21,10 @@ fn test_ob_value_with_unknown_length() {
     let element = object.element_by_name("PixelData").unwrap();
 
     match element.value() {
-        Value::PixelSequence {
-            fragments,
-            offset_table,
-        } => {
+        Value::PixelSequence(seq) => {
+            let fragments = seq.fragments();
             // check offset table
-            assert_eq!(offset_table.len(), 0);
+            assert_eq!(seq.offset_table().len(), 0);
 
             // check if the leading and trailing bytes look right
             assert_eq!(fragments.len(), 1);

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -502,19 +502,20 @@ where
                         // retrieve sequence value, begin item sequence
                         match elem.into_value() {
                             Value::Primitive(_) | Value::PixelSequence { .. } => unreachable!(),
-                            Value::Sequence { items, size: _ } => {
-                                let items: dicom_core::value::C<_> =
-                                    items.into_iter().map(|o| AsItem(o.length(), o)).collect();
+                            Value::Sequence(seq) => {
+                                let items: dicom_core::value::C<_> = seq
+                                    .into_items()
+                                    .into_iter()
+                                    .map(|o| AsItem(o.length(), o))
+                                    .collect();
                                 (Some(token), DataElementTokens::Items(items.into_tokens()))
                             }
                         }
                     }
                     DataToken::PixelSequenceStart => {
                         match elem.into_value() {
-                            Value::PixelSequence {
-                                fragments,
-                                offset_table,
-                            } => {
+                            Value::PixelSequence(seq) => {
+                                let (offset_table, fragments) = seq.into_parts();
                                 (
                                     // begin pixel sequence
                                     Some(DataToken::PixelSequenceStart),

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -57,10 +57,8 @@ where
         let voi_lut_function = voi_lut_function.and_then(|v| VoiLutFunction::try_from(&*v).ok());
 
         let decoded_pixel_data = match pixel_data.value() {
-            Value::PixelSequence {
-                fragments,
-                offset_table: _,
-            } => {
+            Value::PixelSequence(v) => {
+                let fragments = v.fragments();
                 let gdcm_error_mapper = |source: GDCMError| DecodeError::Custom {
                     message: source.to_string(),
                     source: Some(Box::new(source)),
@@ -105,7 +103,7 @@ where
                 // Non-encoded, just return the pixel data of the first frame
                 p.to_bytes().to_vec()
             }
-            Value::Sequence { items: _, size: _ } => InvalidPixelDataSnafu.fail()?,
+            Value::Sequence(_) => InvalidPixelDataSnafu.fail()?,
         };
 
         // pixels are already interpreted,

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1672,18 +1672,15 @@ where
         }
 
         let decoded_pixel_data = match pixel_data.value() {
-            Value::PixelSequence {
-                fragments,
-                offset_table: _,
-            } => {
+            Value::PixelSequence(v) => {
                 // Return all fragments concatenated
-                fragments.into_iter().flatten().copied().collect()
+                v.fragments().into_iter().flatten().copied().collect()
             }
             Value::Primitive(p) => {
                 // Non-encoded, just return the pixel data for all frames
                 p.to_bytes().to_vec()
             }
-            Value::Sequence { items: _, size: _ } => InvalidPixelDataSnafu.fail()?,
+            Value::Sequence(..) => InvalidPixelDataSnafu.fail()?,
         };
 
         Ok(DecodedPixelData {


### PR DESCRIPTION
This makes some usability improvements to the core value API. The main changes here are the enum `DicomValue<I, P>` now has a different default for the type parameter `P` (to the same value used by in-memory DICOM objects in `dicom_object`), and it uses struct definitions for data set sequences and pixel data fragment sequence, instead of declaring struct variants in the enum.

I also took this opportunity to remove deprecated functions, adjust the error types returned in some methods, and increase test coverage a bit.

### Summary

- Move `DicomValue` sequence variant fields to their own independent types (`DataSetSequence` and `PixelFragmentSequence`)
- Change default of Value type parameter `P` to `Vec<u8>` (also aliased to `InMemFragment`)
- Change the return error type of `Value::to_str`, `Value::to_raw_str`, `Value::to_bytes`
   - from `CastValueError` to `ConvertValueError`
- Change behavior of `PartialEq` for `DicomValue` between data set items: recorded length is ignored, only items are compared.