### PR TITLE
Change ReadPreamble::Auto to automatic preamble detection

### DIFF
--- a/object/src/file.rs
+++ b/object/src/file.rs
@@ -158,12 +158,13 @@ impl<D, T> OpenFileOptions<D, T> {
 
 /// An enumerate of supported options for
 /// whether to read the 128-byte DICOM file preamble.
-#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
 pub enum ReadPreamble {
     /// Try to detect the presence of the preamble automatically.
     /// If detection fails, it will revert to always reading the preamble
     /// when opening a file by path,
     /// and not reading it when reading from a byte source.
+    #[default]
     Auto,
     /// Never read the preamble,
     /// thus assuming that the original source does not have it.
@@ -171,10 +172,4 @@ pub enum ReadPreamble {
     /// Always read the preamble first,
     /// thus assuming that the original source always has it.
     Always,
-}
-
-impl Default for ReadPreamble {
-    fn default() -> Self {
-        ReadPreamble::Auto
-    }
 }

--- a/object/src/file.rs
+++ b/object/src/file.rs
@@ -38,7 +38,9 @@ where
 ///
 /// Create a `OpenFileOptions`,
 /// call adaptor methods in a chain,
-/// and finish the operation with [`.open_file()`](OpenFileOptions::open_file).
+/// and finish the operation with
+/// either [`open_file()`](OpenFileOptions::open_file)
+/// or [`from_reader()`](OpenFileOptions::from_reader).
 ///
 /// ```no_run
 /// # use dicom_object::OpenFileOptions;
@@ -158,8 +160,10 @@ impl<D, T> OpenFileOptions<D, T> {
 /// whether to read the 128-byte DICOM file preamble.
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
 pub enum ReadPreamble {
-    /// Read the preamble only when opening a file by path,
-    /// and do not read the preamble when reading from a byte source.
+    /// Try to detect the presence of the preamble automatically.
+    /// If detection fails, it will revert to always reading the preamble
+    /// when opening a file by path,
+    /// and not reading it when reading from a byte source.
     Auto,
     /// Never read the preamble,
     /// thus assuming that the original source does not have it.

--- a/object/tests/integration_test.rs
+++ b/object/tests/integration_test.rs
@@ -77,6 +77,21 @@ fn test_read_data_with_preamble() {
 }
 
 #[test]
+fn test_read_data_with_preamble_auto() {
+    let path = dicom_test_files::path("pydicom/liver.dcm").expect("test DICOM file should exist");
+    let source = BufReader::new(File::open(path).unwrap());
+
+    // should read preamble even though it's from a reader
+    let object = OpenFileOptions::new()
+        .from_reader(source)
+        .expect("Should read from source successfully");
+
+    // contains elements such as study date
+    let element = object.element(tags::STUDY_DATE).unwrap();
+    assert_eq!(element.value().to_str().unwrap(), "20030417");
+}
+
+#[test]
 fn test_read_data_without_preamble() {
     let path = dicom_test_files::path("pydicom/liver.dcm").expect("test DICOM file should exist");
     let mut source = BufReader::new(File::open(path).unwrap());
@@ -86,8 +101,29 @@ fn test_read_data_without_preamble() {
 
     source.read_exact(&mut preamble).unwrap();
 
+    // explicitly do not read preamble
     let object = OpenFileOptions::new()
         .read_preamble(ReadPreamble::Never)
+        .from_reader(source)
+        .expect("Should read from source successfully");
+
+    // contains elements such as study date
+    let element = object.element(tags::STUDY_DATE).unwrap();
+    assert_eq!(element.value().to_str().unwrap(), "20030417");
+}
+
+#[test]
+fn test_read_data_without_preamble_auto() {
+    let path = dicom_test_files::path("pydicom/liver.dcm").expect("test DICOM file should exist");
+    let mut source = BufReader::new(File::open(path).unwrap());
+
+    // skip preamble
+    let mut preamble = [0; 128];
+
+    source.read_exact(&mut preamble).unwrap();
+
+    // detect lack of preamble automatically
+    let object = OpenFileOptions::new()
         .from_reader(source)
         .expect("Should read from source successfully");
 


### PR DESCRIPTION
This makes the default behavior of automatically detecting whether the 128-byte preamble is present, making DICOM object reading functions easier to use.  

### Summary

- When `ReadPreamble` is `Auto`, try to find the preamble by filling the reader buffer and looking for the `DICM` magic string.
- Update documentation and tests accordingly.