### PR TITLE
Expand DataDictionary trait with new default methods

### DIFF
--- a/core/src/dictionary/mod.rs
+++ b/core/src/dictionary/mod.rs
@@ -125,7 +125,21 @@ pub trait DataDictionary: Debug {
     type Entry: DictionaryEntry;
 
     /// Fetch an entry by its usual alias (e.g. "PatientName" or "SOPInstanceUID").
-    /// Aliases are usually case sensitive and not separated by spaces.
+    /// Aliases (or keyword)
+    /// are usually in UpperCamelCase,
+    /// not separated by spaces,
+    /// and are case sensitive.
+    /// 
+    /// If the parameter provided is a string literal
+    /// (e.g. `"StudyInstanceUID"`),
+    /// note that it may be more efficient to use [`by_tag()`][1]
+    /// with a known tag constant
+    /// (such as [`tags::STUDY_INSTANCE_UID`][2]
+    /// from the [`dicom-dictionary-std`][3] crate).
+    /// 
+    /// [1]: DataDictionary::by_tag
+    /// [2]: https://docs.rs/dicom-dictionary-std/0.5.0/dicom_dictionary_std/tags/constant.STUDY_INSTANCE_UID.html
+    /// [3]: https://docs.rs/dicom-dictionary-std/0.5.0
     fn by_name(&self, name: &str) -> Option<&Self::Entry>;
 
     /// Fetch an entry by its tag.

--- a/core/src/dictionary/mod.rs
+++ b/core/src/dictionary/mod.rs
@@ -131,9 +131,9 @@ pub trait DataDictionary: Debug {
     /// Fetch an entry by its tag.
     fn by_tag(&self, tag: Tag) -> Option<&Self::Entry>;
 
-    /// Use this data element dictionary to interpret a DICOM tag.
+    /// Fetch an entry by its alias or by DICOM tag expression.
     ///
-    /// This method accepts tags in any of the following formats:
+    /// This method accepts a tag descriptor in any of the following formats:
     ///
     /// - `(gggg,eeee)`:
     ///   a 4-digit hexadecimal group part
@@ -145,7 +145,31 @@ pub trait DataDictionary: Debug {
     ///   not surrounded by parentheses
     /// - _`KeywordName`_:
     ///   an exact match (case sensitive) by DICOM tag keyword
-    /// 
+    ///
+    /// When failing to identify the intended syntax or the tag keyword,
+    /// `None` is returned.
+    fn by_expr(&self, tag: &str) -> Option<&Self::Entry> {
+        match tag.parse() {
+            Ok(tag) => self.by_tag(tag),
+            Err(_) => self.by_name(tag),
+        }
+    }
+
+    /// Use this data element dictionary to interpret a DICOM tag.
+    ///
+    /// This method accepts a tag descriptor in any of the following formats:
+    ///
+    /// - `(gggg,eeee)`:
+    ///   a 4-digit hexadecimal group part
+    ///   and a 4-digit hexadecimal element part
+    ///   surrounded by parentheses
+    /// - `gggg,eeee`:
+    ///   a 4-digit hexadecimal group part
+    ///   and a 4-digit hexadecimal element part
+    ///   not surrounded by parentheses
+    /// - _`KeywordName`_:
+    ///   an exact match (case sensitive) by DICOM tag keyword
+    ///
     /// When failing to identify the intended syntax or the tag keyword,
     /// `None` is returned.
     fn parse_tag(&self, tag: &str) -> Option<Tag> {

--- a/core/src/dictionary/mod.rs
+++ b/core/src/dictionary/mod.rs
@@ -130,6 +130,30 @@ pub trait DataDictionary: Debug {
 
     /// Fetch an entry by its tag.
     fn by_tag(&self, tag: Tag) -> Option<&Self::Entry>;
+
+    /// Use this data element dictionary to interpret a DICOM tag.
+    ///
+    /// This method accepts tags in any of the following formats:
+    ///
+    /// - `(gggg,eeee)`:
+    ///   a 4-digit hexadecimal group part
+    ///   and a 4-digit hexadecimal element part
+    ///   surrounded by parentheses
+    /// - `gggg,eeee`:
+    ///   a 4-digit hexadecimal group part
+    ///   and a 4-digit hexadecimal element part
+    ///   not surrounded by parentheses
+    /// - _`KeywordName`_:
+    ///   an exact match (case sensitive) by DICOM tag keyword
+    /// 
+    /// When failing to identify the intended syntax or the tag keyword,
+    /// `None` is returned.
+    fn parse_tag(&self, tag: &str) -> Option<Tag> {
+        tag.parse().ok().or_else(|| {
+            // look for tag in standard data dictionary
+            self.by_name(tag).map(|e| e.tag())
+        })
+    }
 }
 
 /// The dictionary entry data type, representing a DICOM attribute.

--- a/dictionary-std/src/lib.rs
+++ b/dictionary-std/src/lib.rs
@@ -195,4 +195,21 @@ mod tests {
         assert_eq!(PIXEL_DATA, Tag(0x7FE0, 0x0010));
         assert_eq!(STATUS, Tag(0x0000, 0x0900));
     }
+
+    #[test]
+    fn can_parse_tags() {
+        let dict = StandardDataDictionary;
+
+        assert_eq!(dict.parse_tag("(7FE0,0010)"), Some(crate::tags::PIXEL_DATA));
+        assert_eq!(dict.parse_tag("0010,21C0"), Some(Tag(0x0010, 0x21C0)));
+        assert_eq!(
+            dict.parse_tag("OperatorsName"),
+            Some(crate::tags::OPERATORS_NAME)
+        );
+
+        // can't parse these
+        assert_eq!(dict.parse_tag(""), None,);
+        assert_eq!(dict.parse_tag("1111,2222,3333"), None,);
+        assert_eq!(dict.parse_tag("OperatorNickname"), None,);
+    }
 }

--- a/dictionary-std/src/lib.rs
+++ b/dictionary-std/src/lib.rs
@@ -28,9 +28,9 @@ pub fn registry() -> &'static StandardDictionaryRegistry {
 /// The data struct containing the standard dictionary.
 #[derive(Debug)]
 pub struct StandardDictionaryRegistry {
-    /// mapping: name → tag
+    /// mapping: name → entry
     by_name: HashMap<&'static str, &'static DictionaryEntryRef<'static>>,
-    /// mapping: tag → name
+    /// mapping: tag → entry
     by_tag: HashMap<Tag, &'static DictionaryEntryRef<'static>>,
     /// repeating elements of the form (ggxx, eeee). The `xx` portion is zeroed.
     repeating_ggxx: HashSet<Tag>,

--- a/dictionary-std/src/lib.rs
+++ b/dictionary-std/src/lib.rs
@@ -208,8 +208,47 @@ mod tests {
         );
 
         // can't parse these
-        assert_eq!(dict.parse_tag(""), None,);
-        assert_eq!(dict.parse_tag("1111,2222,3333"), None,);
-        assert_eq!(dict.parse_tag("OperatorNickname"), None,);
+        assert_eq!(dict.parse_tag(""), None);
+        assert_eq!(dict.parse_tag("1111,2222,3333"), None);
+        assert_eq!(dict.parse_tag("OperatorNickname"), None);
     }
+
+
+    #[test]
+    fn can_query_by_expression() {
+        let dict = StandardDataDictionary;
+
+        assert_eq!(
+            dict.by_expr("(0010,0010)"),
+            Some(&DictionaryEntryRef {
+                tag: Single(crate::tags::PATIENT_NAME),
+                alias: "PatientName",
+                vr: VR::PN,
+            })
+        );
+
+        assert_eq!(
+            dict.by_expr("0008,0060"),
+            Some(&DictionaryEntryRef {
+                tag: Single(crate::tags::MODALITY),
+                alias: "Modality",
+                vr: VR::CS,
+            })
+        );
+
+        assert_eq!(
+            dict.by_expr("OperatorsName"),
+            Some(&DictionaryEntryRef {
+                tag: Single(crate::tags::OPERATORS_NAME),
+                alias: "OperatorsName",
+                vr: VR::PN,
+            })
+        );
+
+        // can't handle these
+        assert_eq!(dict.parse_tag("0080 0010"), None);
+        assert_eq!(dict.parse_tag("(0000.0600)"), None);
+        assert_eq!(dict.parse_tag("OPERATORSNAME"), None);
+    }
+
 }

--- a/findscu/src/query.rs
+++ b/findscu/src/query.rs
@@ -32,13 +32,9 @@ impl FromStr for TermQuery {
         let tag_part = parts.next().whatever_context("empty query")?;
         let value_part = parts.next().unwrap_or_default();
 
-        let field: Tag = tag_part.parse().or_else(|_| {
-            // look for tag in standard data dictionary
-            let data_entry = StandardDataDictionary
-                .by_name(tag_part)
-                .whatever_context("could not resolve query field name")?;
-            Ok(data_entry.tag.inner())
-        })?;
+        let field: Tag = StandardDataDictionary
+            .parse_tag(tag_part)
+            .whatever_context("could not resolve query field name")?;
 
         Ok(TermQuery {
             field,


### PR DESCRIPTION
Supports tag formats `gggg,eeee`, `(gggg,eeee)`, and naming them by keyword
It's a default implementation so that it doesn't break.
