### PR TITLE
Extend transfer_syntax module and re-export inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,6 @@ dependencies = [
  "byteordered",
  "dicom-core",
  "dicom-encoding",
- "inventory",
  "jpeg-decoder",
  "lazy_static",
  "tracing",

--- a/encoding/src/lib.rs
+++ b/encoding/src/lib.rs
@@ -26,6 +26,7 @@ pub use adapters::NeverPixelAdapter;
 pub use byteordered::Endianness;
 pub use decode::Decode;
 pub use encode::Encode;
+pub use transfer_syntax::AdapterFreeTransferSyntax;
 pub use transfer_syntax::Codec;
 pub use transfer_syntax::DataRWAdapter;
 pub use transfer_syntax::NeverAdapter;
@@ -34,3 +35,7 @@ pub use transfer_syntax::TransferSyntaxIndex;
 
 // public dependency re-export
 pub use snafu;
+
+// public dependency re-export
+#[cfg(feature = "inventory-registry")]
+pub use inventory;

--- a/encoding/src/transfer_syntax/mod.rs
+++ b/encoding/src/transfer_syntax/mod.rs
@@ -231,16 +231,15 @@ macro_rules! submit_transfer_syntax {
 /// See the [`adapters`](crate::adapters) module
 /// to know how to write pixel data encoders and decoders.
 macro_rules! submit_ele_transfer_syntax {
-    ($uid: literal, $name: literal, $codec: expr) => {
-        $crate::inventory::submit! {
-            $crate::transfer_syntax::TransferSyntaxFactory(||
-                $crate::AdapterFreeTransferSyntax::new(
-                    $uid,
-                    $name,
-                    $crate::Endianness::Little,
-                    true,
-                    $codec
-                ).erased())
+    ($uid: expr, $name: expr, $codec: expr) => {
+        $crate::submit_transfer_syntax! {
+            $crate::AdapterFreeTransferSyntax::new(
+                $uid,
+                $name,
+                $crate::Endianness::Little,
+                true,
+                $codec
+            )
         }
     };
 }

--- a/encoding/src/transfer_syntax/mod.rs
+++ b/encoding/src/transfer_syntax/mod.rs
@@ -4,10 +4,19 @@
 //!
 //! This crate does not host specific transfer syntaxes. Instead, they are created in
 //! other crates and registered in the global transfer syntax registry, which implements
-//! [`TransferSyntaxIndex`]. For more
-//! information, please see the [`dicom-transfer-syntax-registry`] crate.
+//! [`TransferSyntaxIndex`][1].
+//! For more information, please see the [`dicom-transfer-syntax-registry`] crate,
+//! which provides built-in implementations.
 //!
-//! [`TransferSyntaxIndex`]: ./trait.TransferSyntaxIndex.html
+//! This module allows you to register your own transfer syntaxes.
+//! With the `inventory-registry` Cargo feature,
+//! you can use the macro [`submit_transfer_syntax`]
+//! to instruct the compiler to include your implementation in the registry.
+//! Without the `inventory`-based registry
+//! (in case your environment does not support it),
+//! you can still roll your own [transfer syntax index][1].
+//!
+//! [1]: TransferSyntaxIndex
 //! [`dicom-transfer-syntax-registry`]: https://docs.rs/dicom-transfer-syntax-registry
 
 use crate::adapters::{DynPixelRWAdapter, NeverPixelAdapter, PixelRWAdapter};
@@ -45,6 +54,8 @@ pub type DynEncoder<'w, W> = Box<dyn EncodeTo<W> + 'w>;
 /// which are type-erased before registration.
 /// If the transfer syntax requires no data set codec,
 /// `D` can be assigned to the utility type [`NeverAdapter`].
+/// If pixel data encoding/decoding is not needed or not supported,
+/// you can assign `P` to [`NeverPixelAdapter`].
 #[derive(Debug)]
 pub struct TransferSyntax<D = DynDataRWAdapter, P = DynPixelRWAdapter> {
     /// The unique identifier of the transfer syntax.
@@ -118,6 +129,39 @@ where
 /// The macro will type-erase these parameters automatically.
 ///
 /// [`TransferSyntax<D, P>`]: crate::transfer_syntax::TransferSyntax
+///
+/// # Example
+///
+/// One common use case is wanting to read data sets
+/// of DICOM objects in a private transfer syntax,
+/// even when a decoder for that pixel data is not available.
+/// By writing a simple stub at your project's root,
+/// the rest of the ecosystem will know
+/// how to read and write data sets in that transfer syntax.
+///
+/// ```
+/// use dicom_encoding::{
+///     submit_transfer_syntax, AdapterFreeTransferSyntax, Codec, Endianness, TransferSyntaxIndex,
+/// };
+/// 
+/// submit_transfer_syntax!(AdapterFreeTransferSyntax::new(
+///     // Transfer Syntax UID
+///     "1.3.46.670589.33.1.4.1",
+///     // Name/alias
+///     "CT Private ELE",
+///     // Data set byte order
+///     Endianness::Little,
+///     // Explicit VR (true) or Implicit VR (false)
+///     true,
+///     Codec::EncapsulatedPixelData,  // pixel data codec
+/// ));
+/// ```
+/// 
+/// With [`Codec::EncapsulatedPixelData`],
+/// we are indicating that it relies on encapsulated pixel data,
+/// albeit without the means to decode or encode it.
+/// See the [`adapters`](crate::adapters) module
+/// to know how to write pixel data encoders and decoders.
 macro_rules! submit_transfer_syntax {
     ($ts: expr) => {
         $crate::inventory::submit! {
@@ -341,7 +385,7 @@ impl<D, P> TransferSyntax<D, P> {
     }
 
     /// Check whether reading and writing the pixel data is unsupported.
-    /// If this is `true`, encoding and decoding of the data set will still
+    /// If this is `true`, encoding and decoding of the data set may still
     /// be possible, but the pixel data will only be available in its
     /// encapsulated form.
     pub fn unsupported_pixel_encapsulation(&self) -> bool {

--- a/encoding/src/transfer_syntax/mod.rs
+++ b/encoding/src/transfer_syntax/mod.rs
@@ -120,7 +120,7 @@ where
 /// [`TransferSyntax<D, P>`]: crate::transfer_syntax::TransferSyntax
 macro_rules! submit_transfer_syntax {
     ($ts: expr) => {
-        inventory::submit! {
+        $crate::inventory::submit! {
             $crate::transfer_syntax::TransferSyntaxFactory(|| ($ts).erased())
         }
     };

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 default = ["rayon"]
 
 # inventory for compile time plugin-based transfer syntax registration
-inventory-registry = ['dicom-encoding/inventory-registry', 'inventory']
+inventory-registry = ['dicom-encoding/inventory-registry']
 
 # natively implemented image encodings
 native = ["jpeg", "rle"]
@@ -28,7 +28,6 @@ dicom-core = { path = "../core", version = "0.5.2" }
 dicom-encoding = { path = "../encoding", version = "0.5.2" }
 lazy_static = "1.2.0"
 byteordered = "0.6"
-inventory = { version = "0.3.2", optional = true }
 tracing = "0.1.34"
 
 [dependencies.jpeg-decoder]

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -63,7 +63,7 @@
 //! These stubs may also be replaced by separate libraries
 //! if using the inventory-based registry.
 //!
-//! [inventory]: https://docs.rs/inventory/0.3.2/inventory
+//! [inventory]: https://docs.rs/inventory/0.3.6/inventory
 
 use byteordered::Endianness;
 use dicom_encoding::transfer_syntax::{
@@ -78,6 +78,9 @@ pub use dicom_encoding::TransferSyntax;
 pub mod entries;
 
 mod adapters;
+
+#[cfg(feature = "inventory-registry")]
+pub use dicom_encoding::inventory;
 
 /// Main implementation of a registry of DICOM transfer syntaxes.
 ///

--- a/transfer-syntax-registry/tests/submit_pixel_stub.rs
+++ b/transfer-syntax-registry/tests/submit_pixel_stub.rs
@@ -5,29 +5,25 @@
 #![cfg(feature = "inventory-registry")]
 
 use dicom_encoding::{
-    submit_transfer_syntax, AdapterFreeTransferSyntax, Codec, Endianness, TransferSyntaxIndex,
+    submit_ele_transfer_syntax, AdapterFreeTransferSyntax, Codec, Endianness, TransferSyntaxIndex,
 };
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 
 // install this dummy as a private transfer syntax
-submit_transfer_syntax! {
-    AdapterFreeTransferSyntax::new(
-        "1.2.840.10008.999.9999.99999",
-        "Dummy Little Endian",
-        Endianness::Little,
-        true,
-        Codec::EncapsulatedPixelData,
-    )
-}
+submit_ele_transfer_syntax!(
+    "1.2.840.10008.1.999.9999.99999",
+    "Dummy Little Endian",
+    Codec::EncapsulatedPixelData
+);
 
 #[test]
 fn contains_stub_ts() {
     // contains our stub TS, not fully fully supported,
     // but enough to read some datasets
-    let ts = TransferSyntaxRegistry.get("1.2.840.10008.999.9999.99999");
+    let ts = TransferSyntaxRegistry.get("1.2.840.10008.1.999.9999.99999");
     assert!(ts.is_some());
     let ts = ts.unwrap();
-    assert_eq!(ts.uid(), "1.2.840.10008.999.9999.99999");
+    assert_eq!(ts.uid(), "1.2.840.10008.1.999.9999.99999");
     assert_eq!(ts.name(), "Dummy Little Endian");
     assert!(!ts.fully_supported());
     assert!(ts.unsupported_pixel_encapsulation());

--- a/transfer-syntax-registry/tests/submit_pixel_stub.rs
+++ b/transfer-syntax-registry/tests/submit_pixel_stub.rs
@@ -1,0 +1,36 @@
+//! Independent test for submission of a dummy TS implementation
+//! withour adapters.
+//!
+//! Only applicable to the inventory-based registry.
+#![cfg(feature = "inventory-registry")]
+
+use dicom_encoding::{
+    submit_transfer_syntax, AdapterFreeTransferSyntax, Codec, Endianness, TransferSyntaxIndex,
+};
+use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
+
+// install this dummy as a private transfer syntax
+submit_transfer_syntax! {
+    AdapterFreeTransferSyntax::new(
+        "1.2.840.10008.999.9999.99999",
+        "Dummy Little Endian",
+        Endianness::Little,
+        true,
+        Codec::EncapsulatedPixelData,
+    )
+}
+
+#[test]
+fn contains_stub_ts() {
+    // contains our stub TS, not fully fully supported,
+    // but enough to read some datasets
+    let ts = TransferSyntaxRegistry.get("1.2.840.10008.999.9999.99999");
+    assert!(ts.is_some());
+    let ts = ts.unwrap();
+    assert_eq!(ts.uid(), "1.2.840.10008.999.9999.99999");
+    assert_eq!(ts.name(), "Dummy Little Endian");
+    assert!(!ts.fully_supported());
+    assert!(ts.unsupported_pixel_encapsulation());
+    // can obtain a data set decoder
+    assert!(ts.decoder().is_some());
+}

--- a/transfer-syntax-registry/tests/submit_pixel_stub.rs
+++ b/transfer-syntax-registry/tests/submit_pixel_stub.rs
@@ -16,6 +16,25 @@ submit_ele_transfer_syntax!(
     Codec::EncapsulatedPixelData
 );
 
+const ALWAYS_DUMMY: &str = "1.2.840.10008.1.999.9999.99999.2";
+
+// install more dummy as a private transfer syntax
+submit_ele_transfer_syntax!(
+    ALWAYS_DUMMY,
+    "Always Dummy Lossless Little Endian",
+    Codec::EncapsulatedPixelData
+);
+
+const FOREVER_DUMMY: &str = "1.2.840.10008.1.999.9999.99999.3";
+const FOREVER_DUMMY_NAME: &str = "Forever Dummy Hierarchical Little Endian";
+
+// install event more dummy as a private transfer syntax
+submit_ele_transfer_syntax!(
+    FOREVER_DUMMY,
+    FOREVER_DUMMY_NAME,
+    Codec::EncapsulatedPixelData
+);
+
 #[test]
 fn contains_stub_ts() {
     // contains our stub TS, not fully fully supported,
@@ -29,4 +48,13 @@ fn contains_stub_ts() {
     assert!(ts.unsupported_pixel_encapsulation());
     // can obtain a data set decoder
     assert!(ts.decoder().is_some());
+
+    let ts = TransferSyntaxRegistry.get("1.2.840.10008.1.999.9999.99999.2");
+    assert!(ts.is_some());
+    let ts = ts.unwrap();
+    assert_eq!(ts.name(), "Always Dummy Lossless Little Endian");
+    let ts = TransferSyntaxRegistry.get("1.2.840.10008.1.999.9999.99999.3");
+    assert!(ts.is_some());
+    let ts = ts.unwrap();
+    assert_eq!(ts.name(), "Forever Dummy Hierarchical Little Endian");
 }

--- a/transfer-syntax-registry/tests/submit_pixel_stub.rs
+++ b/transfer-syntax-registry/tests/submit_pixel_stub.rs
@@ -5,7 +5,7 @@
 #![cfg(feature = "inventory-registry")]
 
 use dicom_encoding::{
-    submit_ele_transfer_syntax, AdapterFreeTransferSyntax, Codec, Endianness, TransferSyntaxIndex,
+    submit_ele_transfer_syntax, Codec, TransferSyntaxIndex,
 };
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 


### PR DESCRIPTION
This makes a few quality of life improvements that make it easier to register new transfer syntax using the inventory-based registry.

- [encoding] re-export more things at crate root
   - `AdapterFreeTransferSyntax` and `inventory` crate (if `inventory-registry` feature is enabled.
- [transfer-syntax-registry] remove `inventory` as own dependency, use the `inventory` re-export from `dicom-encoding` instead
- [encoding] improve docs on `transfer_syntax` module
- [encoding] extend `transfer_syntax` with `submit_ele_transfer_syntax!`
   - like `submit_transfer_syntax!`, but specifically for explicit VR little endian.
