### PR TITLE
Change attribute actions (Set, SetIfMissing, Replace)

### DIFF
--- a/core/src/ops.rs
+++ b/core/src/ops.rs
@@ -37,7 +37,7 @@
 //! // hide patient name
 //! obj.apply(AttributeOp {
 //!     tag: (0x0010, 0x0010).into(),
-//!     action: AttributeAction::ReplaceStr("Patient^Anonymous".into()),
+//!     action: AttributeAction::SetStr("Patient^Anonymous".into()),
 //! })?;
 //! # Ok(())
 //! # }
@@ -83,12 +83,18 @@ pub enum AttributeAction {
     /// it cannot be done or it does not make sense
     /// for the given implementation.
     SetVr(VR),
-    /// Fully replace the value with the given DICOM value,
+    /// Fully reset the value with the given DICOM value,
     /// creating the attribute if it does not exist yet.
     Set(PrimitiveValue),
-    /// Fully replace a textual value with the given string,
+    /// Fully reset a textual value with the given string,
     /// creating the attribute if it does not exist yet.
     SetStr(Cow<'static, str>),
+    /// Fully replace the value with the given DICOM value,
+    /// but only if the attribute already exists.
+    Replace(PrimitiveValue),
+    /// Fully replace a textual value with the given string,
+    /// but only if the attribute already exists.
+    ReplaceStr(Cow<'static, str>),
     /// Append a string as an additional textual value,
     /// creating the attribute if it does not exist yet.
     ///

--- a/core/src/ops.rs
+++ b/core/src/ops.rs
@@ -85,10 +85,10 @@ pub enum AttributeAction {
     SetVr(VR),
     /// Fully replace the value with the given DICOM value,
     /// creating the attribute if it does not exist yet.
-    Replace(PrimitiveValue),
+    Set(PrimitiveValue),
     /// Fully replace a textual value with the given string,
     /// creating the attribute if it does not exist yet.
-    ReplaceStr(Cow<'static, str>),
+    SetStr(Cow<'static, str>),
     /// Append a string as an additional textual value,
     /// creating the attribute if it does not exist yet.
     ///

--- a/core/src/ops.rs
+++ b/core/src/ops.rs
@@ -55,10 +55,13 @@ use crate::{Tag, PrimitiveValue, VR};
 /// against the attribute's previous state.
 ///
 /// The operations themselves are provided
-/// alongside DICOM objec or DICOM data set implementations.
+/// alongside DICOM object or DICOM data set implementations,
+/// such as the `InMemDicomObject` from the [`dicom_object`] crate.
 /// 
 /// Attribute operations can only select shallow attributes,
 /// but the operation may be implemented when applied against nested data sets.
+/// 
+/// [`dicom_object`]: https://docs.rs/dicom_object
 #[derive(Debug, Clone, PartialEq)]
 pub struct AttributeOp {
     /// the tag of the attribute to apply

--- a/core/src/ops.rs
+++ b/core/src/ops.rs
@@ -83,12 +83,18 @@ pub enum AttributeAction {
     /// it cannot be done or it does not make sense
     /// for the given implementation.
     SetVr(VR),
-    /// Fully reset the value with the given DICOM value,
-    /// creating the attribute if it does not exist yet.
+    /// Fully reset the attribute with the given DICOM value,
+    /// creating it if it does not exist yet.
     Set(PrimitiveValue),
-    /// Fully reset a textual value with the given string,
-    /// creating the attribute if it does not exist yet.
+    /// Fully reset a textual attribute with the given string,
+    /// creating it if it does not exist yet.
     SetStr(Cow<'static, str>),
+    /// Provide the attribute with the given DICOM value,
+    /// if it does not exist yet.
+    SetIfMissing(PrimitiveValue),
+    /// Provide the textual attribute with the given string,
+    /// creating it if it does not exist yet.
+    SetStrIfMissing(Cow<'static, str>),
     /// Fully replace the value with the given DICOM value,
     /// but only if the attribute already exists.
     Replace(PrimitiveValue),

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -16,11 +16,12 @@ use crate::ops::{
 };
 use crate::{meta::FileMetaTable, FileMetaTableBuilder};
 use crate::{
-    BuildMetaTableSnafu, CreateParserSnafu, CreatePrinterSnafu, DicomObject, FileDicomObject,
-    MissingElementValueSnafu, NoSuchAttributeNameSnafu, NoSuchDataElementAliasSnafu,
-    NoSuchDataElementTagSnafu, OpenFileSnafu, ParseMetaDataSetSnafu, PrematureEndSnafu,
-    PrepareMetaTableSnafu, PrintDataSetSnafu, ReadError, ReadFileSnafu, ReadPreambleBytesSnafu,
-    ReadTokenSnafu, ReadUnsupportedTransferSyntaxSnafu, UnexpectedTokenSnafu, WriteError, AccessError, WithMetaError, AccessByNameError,
+    AccessByNameError, AccessError, BuildMetaTableSnafu, CreateParserSnafu, CreatePrinterSnafu,
+    DicomObject, FileDicomObject, MissingElementValueSnafu, NoSuchAttributeNameSnafu,
+    NoSuchDataElementAliasSnafu, NoSuchDataElementTagSnafu, OpenFileSnafu, ParseMetaDataSetSnafu,
+    PrematureEndSnafu, PrepareMetaTableSnafu, PrintDataSetSnafu, ReadError, ReadFileSnafu,
+    ReadPreambleBytesSnafu, ReadTokenSnafu, ReadUnsupportedTransferSyntaxSnafu,
+    UnexpectedTokenSnafu, WithMetaError, WriteError,
 };
 use dicom_core::dictionary::{DataDictionary, DictionaryEntry};
 use dicom_core::header::{HasLength, Header};
@@ -88,8 +89,7 @@ where
 
     fn element_by_name(&self, name: &str) -> Result<Self::Element, AccessByNameError> {
         let tag = self.lookup_name(name)?;
-        self.element(tag)
-            .map_err(|e| e.into_access_by_name(name))
+        self.element(tag).map_err(|e| e.into_access_by_name(name))
     }
 }
 
@@ -598,7 +598,10 @@ where
     /// If the attribute is known in advance,
     /// using [`element_opt`](InMemDicomObject::element_opt)
     /// with a tag constant is preferred.
-    pub fn element_by_name_opt(&self, name: &str) -> Result<Option<&InMemElement<D>>, AccessByNameError> {
+    pub fn element_by_name_opt(
+        &self,
+        name: &str,
+    ) -> Result<Option<&InMemElement<D>>, AccessByNameError> {
         match self.element_by_name(name) {
             Ok(e) => Ok(Some(e)),
             Err(AccessByNameError::NoSuchDataElementAlias { .. }) => Ok(None),
@@ -646,7 +649,10 @@ where
     }
 
     /// Remove and return a particular DICOM element by its name.
-    pub fn take_element_by_name(&mut self, name: &str) -> Result<InMemElement<D>, AccessByNameError> {
+    pub fn take_element_by_name(
+        &mut self,
+        name: &str,
+    ) -> Result<InMemElement<D>, AccessByNameError> {
         let tag = self.lookup_name(name)?;
         self.entries
             .remove(&tag)
@@ -734,6 +740,19 @@ where
             AttributeAction::SetStr(string) => {
                 let new_value = PrimitiveValue::from(&*string);
                 self.apply_change_value_impl(tag, new_value);
+                Ok(())
+            }
+            AttributeAction::SetIfMissing(new_value) => {
+                if self.get(tag).is_none() {
+                    self.apply_change_value_impl(tag, new_value);
+                }
+                Ok(())
+            }
+            AttributeAction::SetStrIfMissing(string) => {
+                if self.get(tag).is_none() {
+                    let new_value = PrimitiveValue::from(&*string);
+                    self.apply_change_value_impl(tag, new_value);
+                }
                 Ok(())
             }
             AttributeAction::Replace(new_value) => {
@@ -1092,7 +1111,10 @@ where
     /// if the attribute _SOP Instance UID_  is present.
     /// A complete file meta group should still provide
     /// the media storage SOP class UID and transfer syntax.0
-    pub fn with_meta(self, mut meta: FileMetaTableBuilder) -> Result<FileDicomObject<Self>, WithMetaError> {
+    pub fn with_meta(
+        self,
+        mut meta: FileMetaTableBuilder,
+    ) -> Result<FileDicomObject<Self>, WithMetaError> {
         if let Some(elem) = self.get(tags::SOP_INSTANCE_UID) {
             meta = meta.media_storage_sop_instance_uid(
                 elem.value().to_str().context(PrepareMetaTableSnafu)?,
@@ -2296,8 +2318,27 @@ mod tests {
             assert_eq!(obj.get(tags::STUDY_DESCRIPTION), None);
         }
         {
-            // replace string
             let mut obj = base_obj.clone();
+
+            // set if missing does nothing
+            // on an existing string
+            let op = AttributeOp {
+                tag: tags::INSTITUTION_NAME,
+                action: AttributeAction::SetIfMissing("Nope Hospital".into()),
+            };
+
+            obj.apply(op).unwrap();
+
+            assert_eq!(
+                obj.get(tags::INSTITUTION_NAME),
+                Some(&DataElement::new(
+                    tags::INSTITUTION_NAME,
+                    VR::LO,
+                    PrimitiveValue::from("Test Hospital")
+                ))
+            );
+
+            // replace string
             let op = AttributeOp {
                 tag: tags::INSTITUTION_NAME,
                 action: AttributeAction::ReplaceStr("REMOVED".into()),
@@ -2324,6 +2365,23 @@ mod tests {
             obj.apply(op).unwrap();
 
             assert_eq!(obj.get(tags::REQUESTING_PHYSICIAN), None);
+
+            // but DetIfMissing works
+            let op = AttributeOp {
+                tag: tags::REQUESTING_PHYSICIAN,
+                action: AttributeAction::SetStrIfMissing("Doctor^Anonymous".into()),
+            };
+
+            obj.apply(op).unwrap();
+
+            assert_eq!(
+                obj.get(tags::REQUESTING_PHYSICIAN),
+                Some(&DataElement::new(
+                    tags::REQUESTING_PHYSICIAN,
+                    VR::PN,
+                    PrimitiveValue::from("Doctor^Anonymous")
+                ))
+            );
         }
         {
             // reset string

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -727,11 +727,11 @@ where
                 }
                 Ok(())
             }
-            AttributeAction::Replace(new_value) => {
+            AttributeAction::Set(new_value) => {
                 self.apply_change_value_impl(tag, new_value);
                 Ok(())
             }
-            AttributeAction::ReplaceStr(string) => {
+            AttributeAction::SetStr(string) => {
                 let new_value = PrimitiveValue::from(&*string);
                 self.apply_change_value_impl(tag, new_value);
                 Ok(())
@@ -2287,7 +2287,7 @@ mod tests {
             let mut obj = base_obj.clone();
             let op = AttributeOp {
                 tag: tags::INSTITUTION_NAME,
-                action: AttributeAction::ReplaceStr("REMOVED".into()),
+                action: AttributeAction::SetStr("REMOVED".into()),
             };
 
             obj.apply(op).unwrap();

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -365,6 +365,28 @@ impl FileMetaTable {
                 *target_attribute = Some(value.to_string());
                 Ok(())
             }
+            AttributeAction::Replace(value) => {
+                if target_attribute.is_none() {
+                    return Ok(());
+                }
+
+                // require value to be textual
+                if let Ok(value) = value.string() {
+                    *target_attribute = Some(value.to_string());
+                    Ok(())
+                } else {
+                    IncompatibleTypesSnafu {
+                        kind: ValueType::Str,
+                    }
+                    .fail()
+                }
+            }
+            AttributeAction::ReplaceStr(value) => {
+                if target_attribute.is_some() {
+                    *target_attribute = Some(value.to_string());
+                }
+                Ok(())
+            }
             AttributeAction::PushStr(_) => IllegalExtendSnafu.fail(),
             AttributeAction::PushI32(_)
             | AttributeAction::PushU32(_)

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -300,7 +300,7 @@ impl FileMetaTable {
                 // ignore
                 Ok(())
             }
-            AttributeAction::Replace(value) => {
+            AttributeAction::Set(value) => {
                 // require value to be textual
                 if let Ok(value) = value.string() {
                     *target_attribute = value.to_string();
@@ -312,7 +312,7 @@ impl FileMetaTable {
                     .fail()
                 }
             }
-            AttributeAction::ReplaceStr(string) => {
+            AttributeAction::SetStr(string) => {
                 *target_attribute = string.to_string();
                 Ok(())
             }
@@ -349,7 +349,7 @@ impl FileMetaTable {
                 // ignore
                 Ok(())
             }
-            AttributeAction::Replace(value) => {
+            AttributeAction::Set(value) => {
                 // require value to be textual
                 if let Ok(value) = value.string() {
                     *target_attribute = Some(value.to_string());
@@ -361,7 +361,7 @@ impl FileMetaTable {
                     .fail()
                 }
             }
-            AttributeAction::ReplaceStr(value) => {
+            AttributeAction::SetStr(value) => {
                 *target_attribute = Some(value.to_string());
                 Ok(())
             }

--- a/object/src/ops.rs
+++ b/object/src/ops.rs
@@ -87,7 +87,7 @@ mod tests {
         // apply operation on main data set
         obj.apply(AttributeOp {
             tag: dicom_dictionary_std::tags::PATIENT_NAME,
-            action: AttributeAction::ReplaceStr("Patient^Anonymous".into()),
+            action: AttributeAction::SetStr("Patient^Anonymous".into()),
         })
         .unwrap();
 
@@ -104,7 +104,7 @@ mod tests {
         // apply operation on file meta information
         obj.apply(AttributeOp {
             tag: dicom_dictionary_std::tags::MEDIA_STORAGE_SOP_INSTANCE_UID,
-            action: AttributeAction::ReplaceStr(
+            action: AttributeAction::SetStr(
                 "2.25.153241429675951194530939969687300037165".into(),
             ),
         })


### PR DESCRIPTION
This makes a few changes to the upcoming attribute operations API. `Replace` and `ReplaceStr` now have a different behavior, in that they do not set the value unless the attribute already exists (as in, is present in the receiving object, regardless of being empty or not). `Set` and `SetStr` should be used when the intent is to define the attribute regardless of whether it exists yet.