### PR TITLE
Change transfer syntax API for more pixel data codec flexibility

### DIFF
--- a/encoding/src/adapters.rs
+++ b/encoding/src/adapters.rs
@@ -135,22 +135,25 @@ pub trait PixelDataObject {
     /// Return the object's transfer syntax UID.
     fn transfer_syntax_uid(&self) -> &str;
 
-    /// Return the Rows attribute or None if it is not found
+    /// Return the _Rows_, or `None` if it is not found
     fn rows(&self) -> Option<u16>;
 
-    /// Return the Columns attribute or None if it is not found
+    /// Return the _Columns_, or `None` if it is not found
     fn cols(&self) -> Option<u16>;
 
-    /// Return the SamplesPerPixel attribute or None if it is not found
+    /// Return the _Samples Per Pixel_, or `None` if it is not found
     fn samples_per_pixel(&self) -> Option<u16>;
 
-    /// Return the BitsAllocated attribute or None if it is not set
+    /// Return the _Bits Allocated_, or `None` if it is not defined
     fn bits_allocated(&self) -> Option<u16>;
 
-    /// Return the NumberOfFrames attribute or None if it is not set
+    /// Return the _Bits Stored_, or `None` if it is not defined
+    fn bits_stored(&self) -> Option<u16>;
+
+    /// Return the _Number Of Frames_, or `None` if it is not defined
     fn number_of_frames(&self) -> Option<u32>;
 
-    /// Returns the number of fragments or None for native pixel data
+    /// Returns the _Number of Fragments_, or `None` for native pixel data
     fn number_of_fragments(&self) -> Option<u32>;
 
     /// Return a specific encoded pixel fragment by index
@@ -169,9 +172,10 @@ pub trait PixelDataObject {
     /// or `None` if no offset table is available.
     fn offset_table(&self) -> Option<Cow<[u32]>>;
 
-    /// Should return either a byte slice/vector if native pixel data
-    /// or byte fragments if encapsulated.
-    /// Returns None if no pixel data is found
+    /// Should return either a byte slice/vector if the pixel data is native
+    /// or the list of byte fragments and offset table if encapsulated.
+    ///
+    /// Returns `None` if no pixel data is found.
     fn raw_pixel_data(&self) -> Option<RawPixelData>;
 }
 

--- a/encoding/src/adapters.rs
+++ b/encoding/src/adapters.rs
@@ -157,6 +157,10 @@ pub trait PixelDataObject {
     /// (where 0 is the first fragment after the basic offset table)
     /// as a [`Cow<[u8]>`][1],
     /// or `None` if no such fragment is available.
+    /// 
+    /// In the case of native (non-encapsulated) pixel data,
+    /// the whole data may be obtained
+    /// by requesting fragment number 0.
     ///
     /// [1]: std::borrow::Cow
     fn fragment(&self, fragment: usize) -> Option<Cow<[u8]>>;

--- a/encoding/src/adapters.rs
+++ b/encoding/src/adapters.rs
@@ -145,7 +145,7 @@ pub trait PixelDataObject {
     fn bits_allocated(&self) -> Option<u16>;
 
     /// Return the NumberOfFrames attribute or None if it is not set
-    fn number_of_frames(&self) -> Option<u16>;
+    fn number_of_frames(&self) -> Option<u32>;
 
     /// Returns the number of fragments or None for native pixel data
     fn number_of_fragments(&self) -> Option<u32>;

--- a/encoding/src/adapters.rs
+++ b/encoding/src/adapters.rs
@@ -296,13 +296,19 @@ pub trait PixelDataWriter {
     ) -> EncodeResult<Vec<AttributeOp>>;
 }
 
-/// Alias type for a dynamically dispatched pixel data decoder.
+/// Alias type for a dynamically dispatched pixel data reader.
 pub type DynPixelDataReader = Box<dyn PixelDataReader + Send + Sync + 'static>;
 
-/// Alias type for a dynamically dispatched pixel data encoder.
+/// Alias type for a dynamically dispatched pixel data writer.
 pub type DynPixelDataWriter = Box<dyn PixelDataWriter + Send + Sync + 'static>;
 
-/// An immaterial type representing an adapter which is never required.
+/// An immaterial type representing an adapter which is never provided.
+/// 
+/// This type may be used as the type parameters `R` and `W`
+/// of [`TransferSyntax`](crate::transfer_syntax::TransferSyntax)
+/// when representing a transfer syntax which
+/// either does not support reading and writing imaging data,
+/// or when such support is not needed in the first place.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum NeverPixelAdapter {}
 
@@ -322,6 +328,42 @@ impl PixelDataReader for NeverPixelAdapter {
 }
 
 impl PixelDataWriter for NeverPixelAdapter {
+    fn encode(
+        &self,
+        _src: &dyn PixelDataObject,
+        _options: EncodeOptions,
+        _dst: &mut Vec<u8>,
+    ) -> EncodeResult<Vec<AttributeOp>> {
+        unreachable!()
+    }
+
+    fn encode_frame(
+        &self,
+        _src: &dyn PixelDataObject,
+        _frame: u32,
+        _options: EncodeOptions,
+        _dst: &mut Vec<u8>,
+    ) -> EncodeResult<Vec<AttributeOp>> {
+        unreachable!()
+    }
+}
+
+impl PixelDataReader for crate::transfer_syntax::NeverAdapter {
+    fn decode(&self, _src: &dyn PixelDataObject, _dst: &mut Vec<u8>) -> DecodeResult<()> {
+        unreachable!()
+    }
+
+    fn decode_frame(
+        &self,
+        _src: &dyn PixelDataObject,
+        _frame: u32,
+        _dst: &mut Vec<u8>,
+    ) -> DecodeResult<()> {
+        unreachable!()
+    }
+}
+
+impl PixelDataWriter for crate::transfer_syntax::NeverAdapter {
     fn encode(
         &self,
         _src: &dyn PixelDataObject,

--- a/encoding/src/adapters.rs
+++ b/encoding/src/adapters.rs
@@ -132,6 +132,9 @@ pub struct RawPixelData {
 ///
 /// [`dicom_object`]: https://docs.rs/dicom_object
 pub trait PixelDataObject {
+    /// Return the object's transfer syntax UID.
+    fn transfer_syntax_uid(&self) -> &str;
+
     /// Return the Rows attribute or None if it is not found
     fn rows(&self) -> Option<u16>;
 
@@ -158,6 +161,10 @@ pub trait PixelDataObject {
     /// [1]: std::borrow::Cow
     fn fragment(&self, fragment: usize) -> Option<Cow<[u8]>>;
 
+    /// Return the object's offset table,
+    /// or `None` if no offset table is available.
+    fn offset_table(&self) -> Option<Cow<[u32]>>;
+
     /// Should return either a byte slice/vector if native pixel data
     /// or byte fragments if encapsulated.
     /// Returns None if no pixel data is found
@@ -174,7 +181,8 @@ pub struct EncodeOptions {
     /// with an increasingly higher error.
     /// It is ignored if the transfer syntax only supports lossless compression.
     /// If it does support lossless compression,
-    /// it is expected that a quality of 100 results in a lossless encoding.
+    /// it is expected that a quality of 100 results in
+    /// a mathematically lossless encoding.
     ///
     /// If this option is not specified,
     /// the output quality is decided automatically by the underlying adapter.

--- a/encoding/src/transfer_syntax/mod.rs
+++ b/encoding/src/transfer_syntax/mod.rs
@@ -556,7 +556,7 @@ impl<D, R, W> TransferSyntax<D, R, W> {
     pub fn can_decode_dataset(&self) -> bool {
         matches!(
             self.codec,
-            Codec::None | Codec::Dataset(Some(_))
+            Codec::None | Codec::Dataset(Some(_)) | Codec::EncapsulatedPixelData(..)
         )
     }
 

--- a/encoding/src/transfer_syntax/mod.rs
+++ b/encoding/src/transfer_syntax/mod.rs
@@ -10,8 +10,8 @@
 //!
 //! This module allows you to register your own transfer syntaxes.
 //! With the `inventory-registry` Cargo feature,
-//! you can use the macro [`submit_transfer_syntax`]
-//! or [`submit_ele_transfer_syntax`]
+//! you can use the macro [`submit_transfer_syntax!`]
+//! or [`submit_ele_transfer_syntax!`]
 //! to instruct the compiler to include your implementation in the registry.
 //! Without the `inventory`-based registry
 //! (in case your environment does not support it),
@@ -81,7 +81,7 @@ pub struct TransferSyntax<D = DynDataRWAdapter, R = DynPixelDataReader, W = DynP
 /// Implementers and consumers of transfer syntaxes
 /// will usually not interact with it directly.
 /// In order to register a new transfer syntax,
-/// see the macro [`submit_transfer_syntax`].
+/// see the macro [`submit_transfer_syntax!`].
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransferSyntaxFactory(pub fn() -> TransferSyntax);
 
@@ -195,7 +195,7 @@ macro_rules! submit_transfer_syntax {
 /// Submit an explicit VR little endian transfer syntax specifier
 /// to be supported by the program's runtime.
 ///
-/// This macro is equivalent in behavior as [`submit_transfer_syntax`],
+/// This macro is equivalent in behavior as [`submit_transfer_syntax!`],
 /// but it is easier to use when
 /// writing support for compressed pixel data formats,
 /// which are usually in explicit VR little endian.
@@ -414,7 +414,7 @@ impl<D, R, W> TransferSyntax<D, R, W> {
     /// # Example
     ///
     /// To register a private transfer syntax in your program,
-    /// use [`submit_transfer_syntax`] outside of a function body:
+    /// use [`submit_transfer_syntax!`] outside of a function body:
     ///  
     /// ```no_run
     /// # use dicom_encoding::{

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -606,7 +606,7 @@ where
     }
 
     /// Return the NumberOfFrames attribute or None if it is not set
-    fn number_of_frames(&self) -> Option<u16> {
+    fn number_of_frames(&self) -> Option<u32> {
         self.element(dicom_dictionary_std::tags::NUMBER_OF_FRAMES)
             .ok()?
             .to_int()

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -158,6 +158,7 @@ use dicom_parser::dataset::{DataSetWriter, IntoTokens};
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use smallvec::SmallVec;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
+use std::borrow::Cow;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
@@ -626,11 +627,11 @@ where
     /// or None if no pixel data is found
     /// 
     /// Panics if `fragment` is out of bounds for the encapsulated pixel data fragments.
-    fn fragment(&self, fragment: usize) -> Option<Vec<u8>> {
+    fn fragment(&self, fragment: usize) -> Option<Cow<[u8]>> {
         let pixel_data = self.element(dicom_dictionary_std::tags::PIXEL_DATA).ok()?;
         match pixel_data.value() {
             dicom_core::DicomValue::PixelSequence(v) => {
-                Some(v.fragments()[fragment].clone())
+                Some(Cow::Borrowed(v.fragments()[fragment].as_ref()))
             }
             _ => None,
         }

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -251,7 +251,7 @@ impl FileMetaTable {
 
     /// Apply the given attribute operation on this file meta information table.
     ///
-    /// See the [`dicom_encoding::ops`] module
+    /// See the [`dicom_core::ops`] module
     /// for more information.
     fn apply(&mut self, op: AttributeOp) -> ApplyResult {
         let AttributeSelectorStep::Tag(tag) = op.selector.first_step() else {
@@ -790,7 +790,7 @@ impl ApplyOp for FileMetaTable {
 
     /// Apply the given attribute operation on this file meta information table.
     ///
-    /// See the [`dicom_encoding::ops`] module
+    /// See the [`dicom_core::ops`] module
     /// for more information.
     fn apply(&mut self, op: AttributeOp) -> ApplyResult {
         self.apply(op)

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -35,9 +35,13 @@ rstest = "0.16"
 dicom-test-files = "0.2.1"
 
 [features]
-default = ["rayon", "dicom-transfer-syntax-registry/native"]
-gdcm = ["gdcm-rs"]
+default = ["rayon", "native"]
+
 ndarray = ["dep:ndarray"]
+image = ["dep:image"]
+
+native = ["dicom-transfer-syntax-registry/native"]
+gdcm = ["gdcm-rs"]
 rayon = ["dep:rayon", "image?/jpeg_rayon", "dicom-transfer-syntax-registry/rayon"]
 
 [package.metadata.docs.rs]

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1631,7 +1631,7 @@ where
                 ts_uid: transfer_syntax,
             })?;
 
-        if !ts.fully_supported() {
+        if !ts.can_decode_all() {
             return UnsupportedTransferSyntaxSnafu {
                 ts: transfer_syntax,
             }
@@ -1639,7 +1639,7 @@ where
         }
 
         // Try decoding it using a native Rust decoder
-        if let Codec::PixelData(decoder) = ts.codec() {
+        if let Codec::EncapsulatedPixelData(Some(decoder), _) = ts.codec() {
             let mut data: Vec<u8> = Vec::new();
             (*decoder)
                 .decode(self, &mut data)
@@ -1718,7 +1718,6 @@ mod tests {
         is_send_and_sync::<Error>();
     }
 
-    #[cfg(feature = "ndarray")]
     #[test]
     fn test_to_vec_rgb() {
         let test_file = dicom_test_files::path("pydicom/SC_rgb_16bit.dcm").unwrap();

--- a/pixeldata/tests/image_reader.rs
+++ b/pixeldata/tests/image_reader.rs
@@ -1,0 +1,117 @@
+//! Test module for pixel data readers (adapters).
+//!
+//! This test suite deliberately avoids the use of the decoded pixel data API
+//! for a greater focus on covering
+//! pixel data reading and writing capabilities
+//! from transfer syntax implementations.
+
+#[cfg(feature = "native")]
+mod jpeg {
+
+    // always compare with an error margin,
+    // since JPEG baseline is lossy
+    const L1_ERROR_THRESHOLD: u32 = 8;
+    fn pixel_value_matches(got: [u8; 3], expected: [u8; 3]) {
+        let error = got[0].abs_diff(expected[0]) as u32
+            + got[1].abs_diff(expected[1]) as u32
+            + got[2].abs_diff(expected[2]) as u32;
+
+        assert!(
+            error <= L1_ERROR_THRESHOLD,
+            "pixel values {:?} does not match with expected {:?}",
+            got,
+            expected
+        );
+    }
+
+    use std::convert::TryInto;
+
+    use dicom_encoding::adapters::DecodeError;
+    use dicom_encoding::adapters::PixelDataObject;
+    use dicom_encoding::transfer_syntax::Codec;
+    use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
+    use dicom_object::open_file;
+    use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
+
+    #[test]
+    fn can_read_jpeg() {
+        let file_path = dicom_test_files::path("pydicom/color3d_jpeg_baseline.dcm").unwrap();
+        let obj = open_file(file_path).unwrap();
+
+        let ts_jpeg = TransferSyntaxRegistry
+            .get("1.2.840.10008.1.2.4.50")
+            .expect("Transfer syntax _JPEG Baseline_ should be registered for this test");
+
+        // can fetch reader
+
+        let Codec::EncapsulatedPixelData(Some(img_reader), _img_writer) = ts_jpeg.codec() else {
+            panic!("Missing image reader in _JPEG Baseline_ transfer syntax impl");
+        };
+
+        // can read one frame
+        let mut dst = Vec::new();
+        img_reader
+            .decode_frame(&obj, 0, &mut dst)
+            .expect("Failed to decode frame");
+
+        let columns = obj.cols().expect("DICOM object should have Columns");
+        assert_eq!(columns, 640, "Unexpected image width");
+        let rows = obj.rows().expect("DICOM object should have Columns");
+        assert_eq!(rows, 480, "Unexpected image height");
+        let columns = columns as usize;
+        let rows = rows as usize;
+
+        // curated expected pixel data values at the given X,Y coordinates
+        // in frame 0
+        let pixel_gt = [
+            // pixel at (0,0): (1,1,3)
+            ((0, 0), [1, 1, 3]),
+            // and so on
+            ((15, 19), [81, 115, 163]),
+            ((70, 33), [118, 118, 118]),
+            ((380, 39), [74, 166, 125]),
+            // begin ultrasound region
+            ((313, 190), [104, 104, 104]),
+            ((350, 256), [122, 122, 122]),
+            // end ultrasound region
+            ((512, 460), [28, 35, 45]),
+        ];
+
+        for ((x, y), expected) in pixel_gt {
+            let i = (y * columns + x) * 3;
+            pixel_value_matches(dst[i..i + 3].try_into().unwrap(), expected);
+        }
+        let frame_size = columns * rows * 3;
+        assert_eq!(dst.len(), frame_size);
+
+        // decode a different frame, keeping the previous one in memory
+        img_reader
+            .decode_frame(&obj, 63, &mut dst)
+            .expect("Failed to decode frame");
+
+        // curated expected pixel data values at the given X,Y coordinates
+        // in frame 63
+        let pixel_gt = [
+            ((0, 0), [1, 1, 3]),
+            ((15, 19), [81, 115, 163]),
+            ((70, 33), [118, 118, 118]),
+            ((380, 39), [74, 166, 125]),
+            // only the ultrasound region changes
+            ((313, 190), [84, 84, 84]),
+            ((350, 256), [6, 6, 6]),
+            // end ultrasound region
+            ((512, 460), [28, 35, 45]),
+        ];
+        for ((x, y), expected) in pixel_gt {
+            let i = frame_size + (y * columns + x) * 3;
+            pixel_value_matches(dst[i..i + 3].try_into().unwrap(), expected);
+        }
+        assert_eq!(dst.len(), frame_size * 2);
+
+        // cannot read out of bounds
+        assert!(matches!(
+            img_reader.decode_frame(&obj, 120, &mut dst),
+            Err(DecodeError::FrameRangeOutOfBounds),
+        ));
+    }
+}

--- a/storescp/src/main.rs
+++ b/storescp/src/main.rs
@@ -73,7 +73,7 @@ fn run(scu_stream: TcpStream, args: &App) -> Result<(), Whatever> {
             .with_transfer_syntax("1.2.840.10008.1.2.1");
     } else {
         for ts in TransferSyntaxRegistry.iter() {
-            if !ts.unsupported() {
+            if !ts.is_unsupported() {
                 options = options.with_transfer_syntax(ts.uid());
             }
         }

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -24,8 +24,8 @@ rle = []
 rayon = ["jpeg-decoder?/rayon"]
 
 [dependencies]
-dicom-core = { path = "../core", version = "0.5.2" }
-dicom-encoding = { path = "../encoding", version = "0.5.2" }
+dicom-core = { path = "../core", version = "0.5.4" }
+dicom-encoding = { path = "../encoding", version = "0.5.3" }
 lazy_static = "1.2.0"
 byteordered = "0.6"
 tracing = "0.1.34"

--- a/transfer-syntax-registry/src/adapters/jpeg.rs
+++ b/transfer-syntax-registry/src/adapters/jpeg.rs
@@ -1,15 +1,15 @@
 //! Support for JPG image decoding.
 
 use dicom_encoding::snafu::prelude::*;
-use dicom_encoding::adapters::{DecodeResult, PixelDataObject, PixelRWAdapter, decode_error};
+use dicom_encoding::adapters::{DecodeResult, PixelDataObject, decode_error, PixelDataReader};
 use jpeg_decoder::Decoder;
 use std::io::Cursor;
 
 /// Pixel data adapter for JPEG-based transfer syntaxes.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct JPEGAdapter;
+pub struct JpegAdapter;
 
-impl PixelRWAdapter for JPEGAdapter {
+impl PixelDataReader for JpegAdapter {
     /// Decode DICOM image data with jpeg encoding.
     fn decode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> DecodeResult<()> {
         let cols = src
@@ -32,7 +32,8 @@ impl PixelRWAdapter for JPEGAdapter {
 
         // `stride` it the total number of bytes for each sample plane
         let stride: usize = bytes_per_sample as usize * cols as usize * rows as usize;
-        dst.resize((samples_per_pixel as usize * stride) * nr_frames, 0);
+        let base_offset = dst.len();
+        dst.resize(base_offset + (samples_per_pixel as usize * stride) * nr_frames, 0);
 
         // Embedded jpegs can span multiple fragments
         // Hence we collect all fragments into single vector
@@ -47,7 +48,7 @@ impl PixelRWAdapter for JPEGAdapter {
 
         let fragments_len = fragments.len() as u64;
         let mut cursor = Cursor::new(fragments);
-        let mut dst_offset = 0;
+        let mut dst_offset = base_offset;
 
         loop {
             let mut decoder = Decoder::new(&mut cursor);
@@ -67,6 +68,73 @@ impl PixelRWAdapter for JPEGAdapter {
             }
 
             if cursor.position() >= fragments_len {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Decode DICOM image data with jpeg encoding.
+    fn decode_frame(&self, src: &dyn PixelDataObject, frame: u32, dst: &mut Vec<u8>) -> DecodeResult<()> {
+        let cols = src
+            .cols()
+            .context(decode_error::MissingAttributeSnafu { name: "Columns" })?;
+        let rows = src.rows().context(decode_error::MissingAttributeSnafu { name: "Rows" })?;
+        let samples_per_pixel = src.samples_per_pixel().context(decode_error::MissingAttributeSnafu {
+            name: "SamplesPerPixel",
+        })?;
+        let bits_allocated = src.bits_allocated().context(decode_error::MissingAttributeSnafu {
+            name: "BitsAllocated",
+        })?;
+
+        if bits_allocated != 8 && bits_allocated != 16 {
+            whatever!("BitsAllocated other than 8 or 16 is not supported");
+        }
+
+        let nr_frames = src.number_of_frames().unwrap_or(1) as usize;
+
+        ensure!(nr_frames > frame as usize, decode_error::FrameRangeOutOfBoundsSnafu);
+
+        let bytes_per_sample = bits_allocated / 8;
+
+        // `stride` it the total number of bytes for each sample plane
+        let stride: usize = bytes_per_sample as usize * cols as usize * rows as usize;
+        let base_offset = dst.len();
+        dst.resize(base_offset + (samples_per_pixel as usize * stride), 0);
+
+        // Embedded jpegs can span multiple fragments
+        // Hence we collect all fragments into single vector
+        // and then just iterate a cursor for each frame
+        let raw_pixeldata = src.raw_pixel_data()
+            .whatever_context("Expected to have raw pixel data available")?;
+        let fragment = raw_pixeldata
+            .fragments
+            .get(frame as usize)
+            .whatever_context("Missing fragment for the frame requested")?;
+
+        let fragment_len = fragment.len() as u64;
+        let mut cursor = Cursor::new(fragment);
+        let mut dst_offset = base_offset;
+
+        loop {
+            let mut decoder = Decoder::new(&mut cursor);
+            let decoded = decoder
+                .decode()
+                .map_err(|e| Box::new(e) as Box<_>)
+                .whatever_context("JPEG decoder failure")?;
+
+            let decoded_len = decoded.len();
+            dst[dst_offset..(dst_offset + decoded_len)].copy_from_slice(&decoded);
+            dst_offset += decoded_len;
+
+            // dicom fields always have to have an even length and fill this space with padding
+            // if uneven we have to move one position further to consume this padding
+            if cursor.position() % 2 > 0 {
+                cursor.set_position(cursor.position() + 1);
+            }
+
+            if cursor.position() >= fragment_len {
                 break;
             }
         }

--- a/transfer-syntax-registry/src/adapters/rle_lossless.rs
+++ b/transfer-syntax-registry/src/adapters/rle_lossless.rs
@@ -8,7 +8,7 @@
 //! License: <https://github.com/pydicom/pydicom/blob/master/LICENSE>
 use byteordered::byteorder::{ByteOrder, LittleEndian};
 
-use dicom_encoding::adapters::{decode_error, DecodeResult, PixelDataObject, PixelRWAdapter};
+use dicom_encoding::adapters::{decode_error, DecodeResult, PixelDataObject, PixelDataReader};
 use dicom_encoding::snafu::prelude::*;
 use std::io::{self, Read, Seek};
 
@@ -16,8 +16,8 @@ use std::io::{self, Read, Seek};
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RleLosslessAdapter;
 
-/// Decode TS: 1.2.840.10008.1.2.5 (RLE Lossless)
-impl PixelRWAdapter for RleLosslessAdapter {
+/// Pixel data decoder for RLE Lossless (UID `1.2.840.10008.1.2.5`)
+impl PixelDataReader for RleLosslessAdapter {
     /// Decode the DICOM image from RLE Lossless completely.
     ///
     /// See <http://dicom.nema.org/medical/Dicom/2018d/output/chtml/part05/chapter_G.html>
@@ -50,9 +50,14 @@ impl PixelRWAdapter for RleLosslessAdapter {
         let bytes_per_sample = (bits_allocated / 8) as usize;
         let samples_per_pixel = samples_per_pixel as usize;
         // `stride` it the total number of bytes for each sample plane
-        let stride = bytes_per_sample * cols as usize * rows as usize;
+        let stride = bytes_per_sample * cols * rows;
         let frame_size = stride * samples_per_pixel;
-        dst.resize(samples_per_pixel * stride * nr_frames, 0x00);
+        // extend `dst` to make room for decoded pixel data
+        let base_offset = dst.len();
+        dst.resize(
+            base_offset + (samples_per_pixel * stride) as usize * nr_frames,
+            0,
+        );
 
         // RLE encoded data is ordered like this (for 16-bit, 3 sample):
         //  Segment: 0     | 1     | 2     | 3     | 4     | 5
@@ -103,7 +108,7 @@ impl PixelRWAdapter for RleLosslessAdapter {
                         .step_by(bytes_per_sample * samples_per_pixel)
                         .enumerate()
                     {
-                        dst[dst_index] = decoded_segment[decoded_index];
+                        dst[base_offset + dst_index] = decoded_segment[decoded_index];
                     }
                 }
             }
@@ -111,8 +116,111 @@ impl PixelRWAdapter for RleLosslessAdapter {
         Ok(())
     }
 
-    // TODO(#125) implement `encode`
+    /// Decode a singe frame of the DICOM image from RLE Lossless.
+    ///
+    /// See <http://dicom.nema.org/medical/Dicom/2018d/output/chtml/part05/chapter_G.html>
+    fn decode_frame(
+        &self,
+        src: &dyn PixelDataObject,
+        frame: u32,
+        dst: &mut Vec<u8>,
+    ) -> DecodeResult<()> {
+        let cols = src
+            .cols()
+            .context(decode_error::MissingAttributeSnafu { name: "Columns" })?;
+        let rows = src
+            .rows()
+            .context(decode_error::MissingAttributeSnafu { name: "Rows" })?;
+        let samples_per_pixel =
+            src.samples_per_pixel()
+                .context(decode_error::MissingAttributeSnafu {
+                    name: "SamplesPerPixel",
+                })?;
+        let bits_allocated = src
+            .bits_allocated()
+            .context(decode_error::MissingAttributeSnafu {
+                name: "BitsAllocated",
+            })?;
+
+        if bits_allocated != 8 && bits_allocated != 16 {
+            whatever!("BitsAllocated other than 8 or 16 is not supported");
+        }
+        // For RLE the number of fragments = number of frames
+        // therefore, we can fetch the fragments one by one
+        let nr_frames =
+            src.number_of_fragments()
+                .whatever_context("Invalid pixel data, no fragments found")? as usize;
+        ensure!(nr_frames > frame as usize, decode_error::FrameRangeOutOfBoundsSnafu);
+
+        let bytes_per_sample = (bits_allocated / 8) as usize;
+        // `stride` it the total number of bytes for each sample plane
+        let stride = bytes_per_sample * cols as usize * rows as usize;
+        let frame_size = stride * samples_per_pixel as usize;
+        // extend `dst` to make room for decoded pixel data
+        let base_offset = dst.len();
+        dst.resize(base_offset + frame_size, 0);
+
+        // RLE encoded data is ordered like this (for 16-bit, 3 sample):
+        //  Segment: 0     | 1     | 2     | 3     | 4     | 5
+        //           R MSB | R LSB | G MSB | G LSB | B MSB | B LSB
+        //  A segment contains only the MSB or LSB parts of all the sample pixels
+
+        // As currently required,
+        // we need to rearrange the pixel data to standard planar configuration.
+        // (and use little endian byte ordering):
+        //    Pixel 1                             | ... Pixel N
+        //    Red         Green       Blue        | ...
+        //    LSB R MSB R LSB G MSB G LSB B MSB B | ...
+
+        let fragment = &src
+            .fragment(frame as usize)
+            .whatever_context("No pixel data found for frame")?;
+        let mut offsets = read_rle_header(fragment);
+        offsets.push(fragment.len() as u32);
+
+        for sample_number in 0..samples_per_pixel as usize {
+            for byte_offset in (0..bytes_per_sample).rev() {
+                // ii is 1, 0, 3, 2, 5, 4 for the example above
+                // This is where the segment order correction occurs
+                let ii = sample_number * bytes_per_sample + byte_offset;
+                let segment =
+                    &fragment[offsets[ii] as usize..offsets[ii + 1] as usize];
+                let buff = io::Cursor::new(segment);
+                let (_, mut decoder) = PackBitsReader::new(buff, segment.len())
+                    .map_err(|e| Box::new(e) as Box<_>)
+                    .whatever_context("Failed to read RLE segments")?;
+                let mut decoded_segment = Vec::with_capacity(rows as usize * cols as usize);
+                decoder
+                    .take(rows as u64 * cols as u64)
+                    .read_to_end(&mut decoded_segment)
+                    .unwrap();
+
+                // Interleave pixels as described in the example above.
+                let byte_offset = bytes_per_sample - byte_offset - 1;
+                let start = byte_offset as usize + (sample_number * stride) as usize;
+                let end = start + stride as usize;
+                for (decoded_index, dst_index) in (start..end)
+                    .step_by(bytes_per_sample as usize).enumerate()
+                {
+                    dst[base_offset + dst_index] = decoded_segment[decoded_index];
+                }
+
+                let start = sample_number * bytes_per_sample + byte_offset;
+                let end = frame_size;
+                for (decoded_index, dst_index) in (start..end)
+                    .step_by(bytes_per_sample * samples_per_pixel)
+                    .enumerate()
+                {
+                    dst[base_offset + dst_index] = decoded_segment[decoded_index];
+                }
+
+            }
+        }
+        Ok(())
+    }
 }
+
+// TODO(#125) implement `encode`
 
 // Read the RLE header and return the offsets
 fn read_rle_header(fragment: &[u8]) -> Vec<u32> {

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -26,10 +26,9 @@ use byteordered::Endianness;
 use dicom_encoding::transfer_syntax::{AdapterFreeTransferSyntax as Ts, Codec};
 
 #[cfg(any(feature = "jpeg", feature = "rle"))]
-use dicom_encoding::{
-    transfer_syntax::{NeverAdapter, TransferSyntax},
-    NeverPixelAdapter,
-};
+use dicom_encoding::transfer_syntax::{NeverAdapter, TransferSyntax};
+#[cfg(feature = "rle")]
+use dicom_encoding::NeverPixelAdapter;
 
 #[cfg(feature = "jpeg")]
 use crate::adapters::jpeg::JpegAdapter;

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -48,11 +48,9 @@ pub const IMPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
 );
 
 /// **Fully implemented:** Explicit VR Little Endian
-pub const EXPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
+pub const EXPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new_ele(
     "1.2.840.10008.1.2.1",
     "Explicit VR Little Endian",
-    Endianness::Little,
-    true,
     Codec::None,
 );
 
@@ -70,11 +68,9 @@ pub const EXPLICIT_VR_BIG_ENDIAN: Ts = Ts::new(
 /// **Implemented:** RLE Lossless
 #[cfg(feature = "rle")]
 pub const RLE_LOSSLESS: TransferSyntax<NeverAdapter, RleLosslessAdapter, NeverPixelAdapter> =
-    TransferSyntax::new(
+    TransferSyntax::new_ele(
         "1.2.840.10008.1.2.5",
         "RLE Lossless",
-        Endianness::Little,
-        true,
         Codec::EncapsulatedPixelData(Some(RleLosslessAdapter), None),
     );
 /// **Stub:** RLE Lossless
@@ -94,11 +90,9 @@ type JpegTs<R = JpegAdapter, W = NeverPixelAdapter> = TransferSyntax<NeverAdapte
 /// Create a transfer syntax with JPEG encapsulated pixel data
 #[cfg(feature = "jpeg")]
 const fn create_ts_jpeg(uid: &'static str, name: &'static str) -> JpegTs {
-    TransferSyntax::new(
+    TransferSyntax::new_ele(
         uid,
         name,
-        Endianness::Little,
-        true,
         Codec::EncapsulatedPixelData(Some(JpegAdapter), None),
     )
 }
@@ -165,20 +159,16 @@ pub const JPEG_LOSSLESS_NON_HIERARCHICAL_FIRST_ORDER_PREDICTION: Ts = create_ts_
 // --- stub transfer syntaxes, known but not supported ---
 
 /// **Stub descriptor:** Deflated Explicit VR Little Endian
-pub const DEFLATED_EXPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new(
+pub const DEFLATED_EXPLICIT_VR_LITTLE_ENDIAN: Ts = Ts::new_ele(
     "1.2.840.10008.1.2.1.99",
     "Deflated Explicit VR Little Endian",
-    Endianness::Little,
-    true,
     Codec::Dataset(None),
 );
 
 /// **Stub descriptor:** JPIP Referenced Deflate
-pub const JPIP_REFERENCED_DEFLATE: Ts = Ts::new(
+pub const JPIP_REFERENCED_DEFLATE: Ts = Ts::new_ele(
     "1.2.840.10008.1.2.4.95",
     "JPIP Referenced Deflate",
-    Endianness::Little,
-    true,
     Codec::Dataset(None),
 );
 

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -23,10 +23,13 @@
 
 use crate::create_ts_stub;
 use byteordered::Endianness;
-use dicom_encoding::{transfer_syntax::{AdapterFreeTransferSyntax as Ts, Codec}, NeverPixelAdapter};
+use dicom_encoding::transfer_syntax::{AdapterFreeTransferSyntax as Ts, Codec};
 
 #[cfg(any(feature = "jpeg", feature = "rle"))]
-use dicom_encoding::transfer_syntax::{NeverAdapter, TransferSyntax};
+use dicom_encoding::{
+    transfer_syntax::{NeverAdapter, TransferSyntax},
+    NeverPixelAdapter,
+};
 
 #[cfg(feature = "jpeg")]
 use crate::adapters::jpeg::JpegAdapter;
@@ -66,13 +69,14 @@ pub const EXPLICIT_VR_BIG_ENDIAN: Ts = Ts::new(
 
 /// **Implemented:** RLE Lossless
 #[cfg(feature = "rle")]
-pub const RLE_LOSSLESS: TransferSyntax<NeverAdapter, RleLosslessAdapter, NeverPixelAdapter> = TransferSyntax::new(
-    "1.2.840.10008.1.2.5",
-    "RLE Lossless",
-    Endianness::Little,
-    true,
-    Codec::EncapsulatedPixelData(Some(RleLosslessAdapter), None),
-);
+pub const RLE_LOSSLESS: TransferSyntax<NeverAdapter, RleLosslessAdapter, NeverPixelAdapter> =
+    TransferSyntax::new(
+        "1.2.840.10008.1.2.5",
+        "RLE Lossless",
+        Endianness::Little,
+        true,
+        Codec::EncapsulatedPixelData(Some(RleLosslessAdapter), None),
+    );
 /// **Stub:** RLE Lossless
 ///
 /// A native implementation is available

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -65,7 +65,6 @@
 //!
 //! [inventory]: https://docs.rs/inventory/0.3.6/inventory
 
-use byteordered::Endianness;
 use dicom_encoding::transfer_syntax::{
     AdapterFreeTransferSyntax as Ts, Codec, TransferSyntaxIndex,
 };
@@ -277,11 +276,9 @@ pub(crate) fn get_registry() -> &'static TransferSyntaxRegistryImpl {
 
 /// create a TS with an unsupported pixel encapsulation
 pub(crate) const fn create_ts_stub(uid: &'static str, name: &'static str) -> Ts {
-    TransferSyntax::new(
+    TransferSyntax::new_ele(
         uid,
         name,
-        Endianness::Little,
-        true,
         Codec::EncapsulatedPixelData(None, None),
     )
 }

--- a/transfer-syntax-registry/tests/base.rs
+++ b/transfer-syntax-registry/tests/base.rs
@@ -16,7 +16,7 @@ where
     }
     assert_eq!(ts.uid(), uid);
     assert_eq!(ts.name(), name);
-    assert!(ts.fully_supported());
+    assert!(ts.is_fully_supported());
 }
 
 #[test]

--- a/transfer-syntax-registry/tests/submit_dataset.rs
+++ b/transfer-syntax-registry/tests/submit_dataset.rs
@@ -41,7 +41,7 @@ submit_transfer_syntax! {
         "Dummy Explicit VR Little Endian",
         Endianness::Little,
         true,
-        Codec::Dataset::<_, NeverPixelAdapter>(DummyCodecAdapter)
+        Codec::Dataset::<_, NeverPixelAdapter, NeverPixelAdapter>(Some(DummyCodecAdapter))
     )
 }
 
@@ -53,5 +53,7 @@ fn contains_dummy_ts() {
     let ts = ts.unwrap();
     assert_eq!(ts.uid(), "1.2.840.10008.9999.9999.1");
     assert_eq!(ts.name(), "Dummy Explicit VR Little Endian");
-    assert!(ts.fully_supported());
+    assert!(ts.is_fully_supported());
+    assert!(ts.can_decode_dataset());
+    assert!(ts.can_decode_all());
 }

--- a/transfer-syntax-registry/tests/submit_pixel.rs
+++ b/transfer-syntax-registry/tests/submit_pixel.rs
@@ -5,7 +5,10 @@
 #![cfg(feature = "inventory-registry")]
 
 use dicom_encoding::{
-    adapters::{DecodeResult, EncodeOptions, EncodeResult, PixelDataObject, PixelRWAdapter},
+    adapters::{
+        DecodeResult, EncodeOptions, EncodeResult, PixelDataReader, PixelDataWriter,
+        PixelDataObject,
+    },
     submit_transfer_syntax, Codec, Endianness, NeverAdapter, TransferSyntax, TransferSyntaxIndex,
 };
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
@@ -14,29 +17,50 @@ use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 #[derive(Debug)]
 struct DummyPixelAdapter;
 
-impl PixelRWAdapter for DummyPixelAdapter {
+impl PixelDataReader for DummyPixelAdapter {
     fn decode(&self, _src: &dyn PixelDataObject, _dst: &mut Vec<u8>) -> DecodeResult<()> {
-        panic!("Implementation is for testing purposes, this was not meant to be called");
+        panic!("Stub, not supposed to be called")
     }
 
+    fn decode_frame(
+        &self,
+        _src: &dyn PixelDataObject,
+        _frame: u32,
+        _dst: &mut Vec<u8>,
+    ) -> DecodeResult<()> {
+        panic!("Stub, not supposed to be called")
+    }
+}
+
+impl PixelDataWriter for DummyPixelAdapter {
     fn encode(
         &self,
         _src: &dyn PixelDataObject,
         _options: EncodeOptions,
         _dst: &mut Vec<u8>,
-    ) -> EncodeResult<()> {
-        Err(dicom_encoding::adapters::EncodeError::NotImplemented)
+    ) -> EncodeResult<Vec<dicom_core::ops::AttributeOp>> {
+        panic!("Stub, not supposed to be called")
+    }
+
+    fn encode_frame(
+        &self,
+        _src: &dyn PixelDataObject,
+        _frame: u32,
+        _options: EncodeOptions,
+        _dst: &mut Vec<u8>,
+    ) -> EncodeResult<Vec<dicom_core::ops::AttributeOp>> {
+        panic!("Stub, not supposed to be called")
     }
 }
 
 // install this dummy as a private transfer syntax
 submit_transfer_syntax! {
-    TransferSyntax::<NeverAdapter, _>::new(
+    TransferSyntax::<NeverAdapter, _, _>::new(
         "1.2.840.10008.9999.9999.2",
         "Dummy Lossless",
         Endianness::Little,
         true,
-        Codec::PixelData(DummyPixelAdapter)
+        Codec::EncapsulatedPixelData(Some(DummyPixelAdapter), Some(DummyPixelAdapter))
     )
 }
 
@@ -48,5 +72,5 @@ fn contains_dummy_ts() {
     let ts = ts.unwrap();
     assert_eq!(ts.uid(), "1.2.840.10008.9999.9999.2");
     assert_eq!(ts.name(), "Dummy Lossless");
-    assert!(ts.fully_supported());
+    assert!(ts.is_fully_supported());
 }

--- a/transfer-syntax-registry/tests/submit_pixel.rs
+++ b/transfer-syntax-registry/tests/submit_pixel.rs
@@ -6,10 +6,10 @@
 
 use dicom_encoding::{
     adapters::{
-        DecodeResult, EncodeOptions, EncodeResult, PixelDataReader, PixelDataWriter,
-        PixelDataObject,
+        DecodeResult, EncodeOptions, EncodeResult, PixelDataObject, PixelDataReader,
+        PixelDataWriter,
     },
-    submit_transfer_syntax, Codec, Endianness, NeverAdapter, TransferSyntax, TransferSyntaxIndex,
+    submit_transfer_syntax, Codec, NeverAdapter, TransferSyntax, TransferSyntaxIndex,
 };
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 
@@ -55,11 +55,9 @@ impl PixelDataWriter for DummyPixelAdapter {
 
 // install this dummy as a private transfer syntax
 submit_transfer_syntax! {
-    TransferSyntax::<NeverAdapter, _, _>::new(
+    TransferSyntax::<NeverAdapter, _, _>::new_ele(
         "1.2.840.10008.9999.9999.2",
         "Dummy Lossless",
-        Endianness::Little,
-        true,
         Codec::EncapsulatedPixelData(Some(DummyPixelAdapter), Some(DummyPixelAdapter))
     )
 }
@@ -72,5 +70,8 @@ fn contains_dummy_ts() {
     let ts = ts.unwrap();
     assert_eq!(ts.uid(), "1.2.840.10008.9999.9999.2");
     assert_eq!(ts.name(), "Dummy Lossless");
+    assert!(!ts.is_codec_free());
     assert!(ts.is_fully_supported());
+    assert!(ts.can_decode_dataset());
+    assert!(ts.can_decode_all());
 }

--- a/transfer-syntax-registry/tests/submit_pixel.rs
+++ b/transfer-syntax-registry/tests/submit_pixel.rs
@@ -37,7 +37,8 @@ impl PixelDataWriter for DummyPixelAdapter {
         &self,
         _src: &dyn PixelDataObject,
         _options: EncodeOptions,
-        _dst: &mut Vec<u8>,
+        _dst: &mut Vec<Vec<u8>>,
+        _offset_table: &mut Vec<u32>,
     ) -> EncodeResult<Vec<dicom_core::ops::AttributeOp>> {
         panic!("Stub, not supposed to be called")
     }

--- a/transfer-syntax-registry/tests/submit_pixel_stub.rs
+++ b/transfer-syntax-registry/tests/submit_pixel_stub.rs
@@ -4,16 +4,14 @@
 //! Only applicable to the inventory-based registry.
 #![cfg(feature = "inventory-registry")]
 
-use dicom_encoding::{
-    submit_ele_transfer_syntax, Codec, TransferSyntaxIndex,
-};
+use dicom_encoding::{submit_ele_transfer_syntax, Codec, TransferSyntaxIndex};
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 
 // install this dummy as a private transfer syntax
 submit_ele_transfer_syntax!(
     "1.2.840.10008.1.999.9999.99999",
     "Dummy Little Endian",
-    Codec::EncapsulatedPixelData
+    Codec::EncapsulatedPixelData(None, None)
 );
 
 const ALWAYS_DUMMY: &str = "1.2.840.10008.1.999.9999.99999.2";
@@ -22,7 +20,7 @@ const ALWAYS_DUMMY: &str = "1.2.840.10008.1.999.9999.99999.2";
 submit_ele_transfer_syntax!(
     ALWAYS_DUMMY,
     "Always Dummy Lossless Little Endian",
-    Codec::EncapsulatedPixelData
+    Codec::EncapsulatedPixelData(None, None)
 );
 
 const FOREVER_DUMMY: &str = "1.2.840.10008.1.999.9999.99999.3";
@@ -32,7 +30,7 @@ const FOREVER_DUMMY_NAME: &str = "Forever Dummy Hierarchical Little Endian";
 submit_ele_transfer_syntax!(
     FOREVER_DUMMY,
     FOREVER_DUMMY_NAME,
-    Codec::EncapsulatedPixelData
+    Codec::EncapsulatedPixelData(None, None)
 );
 
 #[test]
@@ -44,8 +42,8 @@ fn contains_stub_ts() {
     let ts = ts.unwrap();
     assert_eq!(ts.uid(), "1.2.840.10008.1.999.9999.99999");
     assert_eq!(ts.name(), "Dummy Little Endian");
-    assert!(!ts.fully_supported());
-    assert!(ts.unsupported_pixel_encapsulation());
+    assert!(!ts.is_fully_supported());
+    assert!(ts.is_unsupported_pixel_encapsulation());
     // can obtain a data set decoder
     assert!(ts.decoder().is_some());
 

--- a/transfer-syntax-registry/tests/submit_replace.rs
+++ b/transfer-syntax-registry/tests/submit_replace.rs
@@ -43,7 +43,7 @@ submit_transfer_syntax! {
         "JPIP Referenced Deflate (Override)",
         Endianness::Little,
         true,
-        Codec::Dataset::<_, NeverPixelAdapter>(DummyCodecAdapter)
+        Codec::Dataset::<_, NeverPixelAdapter, NeverPixelAdapter>(Some(DummyCodecAdapter))
     )
 }
 
@@ -55,5 +55,7 @@ fn contains_dummy_ts() {
     let ts = ts.unwrap();
     assert_eq!(ts.uid(), "1.2.840.10008.1.2.4.95");
     assert_eq!(ts.name(), "JPIP Referenced Deflate (Override)");
-    assert!(ts.fully_supported());
+    assert!(ts.is_fully_supported());
+    assert!(ts.can_decode_dataset());
+    assert!(ts.can_decode_all());
 }

--- a/transfer-syntax-registry/tests/submit_replace_precondition.rs
+++ b/transfer-syntax-registry/tests/submit_replace_precondition.rs
@@ -21,6 +21,9 @@ fn registry_has_stub_ts_by_default() {
     assert_eq!(ts.name(), "JPIP Referenced Deflate");
     assert!(matches!(
         ts.codec(),
-        Codec::Unsupported | Codec::EncapsulatedPixelData
+        Codec::Dataset(None) | Codec::EncapsulatedPixelData(None, None)
     ));
+
+    assert_eq!(ts.can_decode_dataset(), false);
+    assert_eq!(ts.can_decode_all(), false);
 }

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -616,7 +616,7 @@ pub fn is_supported_with_repo<R>(ts_repo: R, ts_uid: &str) -> bool
 where
     R: TransferSyntaxIndex,
 {
-    ts_repo.get(ts_uid).filter(|ts| !ts.unsupported()).is_some()
+    ts_repo.get(ts_uid).filter(|ts| !ts.is_unsupported()).is_some()
 }
 
 /// Check that the main transfer syntax registry


### PR DESCRIPTION
This makes some changes to the types `TransferSyntax` and `Codec`. The noteworthy changes are:

- It is now possible to specify that a transfer syntax can only read/write pixel data (no more need for methods returning a `NotImplemented` error). This was done by splitting `PixelRWAdapter` and the parameter type `P` into two independent traits `PixelDataReader` and `PixelDataWriter`
- `PixelDataReader` has a new method for reading a single frame.
- `PixelDataWriter` has been redesigned to return a sequence of attribute operations to perform on an object that will host the encapsulated pixel data produced.

### Summary

- Split `PixelRWAdapter` into `PixelDataReader` and `PixelDataWriter`
- Change `Codec`
   - type parameters become `<D, R, W>`
   -  Change variants to  `None`, `Dataset`, and `EncapsulatedPixelData`, which can describe different levels and implementations
   - also add a few more helper methods to `TransferSyntax`
- Change `TransferSyntax` type parameters to `D`, `R`, `W`
- Update RLE and JPEG adapters to conform to the new API
- change `PixelDataObject::fragment` to return `Cow<[u8]>`
   - may save an allocation in case of in-memory DICOM objects
   - [object] update impl accordingly
- [ts-registry] update registry according to changes
- Change method names in `TransferSyntax`
   - [ul][ts-registry][pixeldata] update according to changes
