### PR TITLE
New command_from_element_iter constructor functions for DICOM objects

### DIFF
--- a/echoscu/src/main.rs
+++ b/echoscu/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use dicom_core::{dicom_value, DataElement, PrimitiveValue, VR};
+use dicom_core::{dicom_value, DataElement, VR};
 use dicom_dictionary_std::tags;
 use dicom_object::{mem::InMemDicomObject, StandardDataDictionary};
 use dicom_ul::{
@@ -178,41 +178,24 @@ fn run() -> Result<(), Whatever> {
 }
 
 fn create_echo_command(message_id: u16) -> InMemDicomObject<StandardDataDictionary> {
-    let mut obj = InMemDicomObject::new_empty();
-
-    // group length
-    obj.put(DataElement::new(
-        tags::COMMAND_GROUP_LENGTH,
-        VR::UL,
-        PrimitiveValue::from(8 + 18 + 8 + 2 + 8 + 2 + 8 + 2),
-    ));
-
-    // service
-    obj.put(DataElement::new(
-        tags::AFFECTED_SOP_CLASS_UID,
-        VR::UI,
-        dicom_value!(Str, "1.2.840.10008.1.1\0"),
-    ));
-    // command
-    obj.put(DataElement::new(
-        tags::COMMAND_FIELD,
-        VR::US,
-        dicom_value!(U16, [0x0030]),
-    ));
-    // message ID
-    obj.put(DataElement::new(
-        tags::MESSAGE_ID,
-        VR::US,
-        dicom_value!(U16, [message_id]),
-    ));
-    // data set type
-    obj.put(DataElement::new(
-        tags::COMMAND_DATA_SET_TYPE,
-        VR::US,
-        dicom_value!(U16, [0x0101]),
-    ));
-
-    obj
+    InMemDicomObject::command_from_element_iter([
+        // service
+        DataElement::new(
+            tags::AFFECTED_SOP_CLASS_UID,
+            VR::UI,
+            dicom_value!(Str, "1.2.840.10008.1.1\0"),
+        ),
+        // command
+        DataElement::new(tags::COMMAND_FIELD, VR::US, dicom_value!(U16, [0x0030])),
+        // message ID
+        DataElement::new(tags::MESSAGE_ID, VR::US, dicom_value!(U16, [message_id])),
+        // data set type
+        DataElement::new(
+            tags::COMMAND_DATA_SET_TYPE,
+            VR::US,
+            dicom_value!(U16, [0x0101]),
+        ),
+    ])
 }
 
 #[cfg(test)]

--- a/findscu/src/main.rs
+++ b/findscu/src/main.rs
@@ -332,83 +332,45 @@ fn find_req_command(
     sop_class_uid: &str,
     message_id: u16,
 ) -> InMemDicomObject<StandardDataDictionary> {
-    let mut obj = InMemDicomObject::new_empty();
-
-    // group length
-    obj.put(DataElement::new(
-        tags::COMMAND_GROUP_LENGTH,
-        VR::UL,
-        PrimitiveValue::from(
-            8 + even_len(sop_class_uid.len())   // SOP Class UID
-            + 8 + 2 // command field
-            + 8 + 2 // message ID
-            + 8 + 2 // priority
-            + 8 + 2, // data set type
+    InMemDicomObject::command_from_element_iter([
+        // SOP Class UID
+        DataElement::new(
+            tags::AFFECTED_SOP_CLASS_UID,
+            VR::UI,
+            PrimitiveValue::from(sop_class_uid),
         ),
-    ));
-
-    // SOP Class UID
-    obj.put(DataElement::new(
-        tags::AFFECTED_SOP_CLASS_UID,
-        VR::UI,
-        PrimitiveValue::from(sop_class_uid),
-    ));
-
-    // command field
-    obj.put(DataElement::new(
-        tags::COMMAND_FIELD,
-        VR::US,
-        // 0020H: C-FIND-RQ message
-        dicom_value!(U16, [0x0020]),
-    ));
-
-    // message ID
-    obj.put(DataElement::new(
-        tags::MESSAGE_ID,
-        VR::US,
-        dicom_value!(U16, [message_id]),
-    ));
-
-    //priority
-    obj.put(DataElement::new(
-        tags::PRIORITY,
-        VR::US,
-        // medium
-        dicom_value!(U16, [0x0000]),
-    ));
-
-    // data set type
-    obj.put(DataElement::new(
-        tags::COMMAND_DATA_SET_TYPE,
-        VR::US,
-        dicom_value!(U16, [0x0001]),
-    ));
-
-    obj
-}
-
-fn even_len(l: usize) -> u32 {
-    ((l + 1) & !1) as u32
+        // command field
+        DataElement::new(
+            tags::COMMAND_FIELD,
+            VR::US,
+            // 0020H: C-FIND-RQ message
+            dicom_value!(U16, [0x0020]),
+        ),
+        // message ID
+        DataElement::new(tags::MESSAGE_ID, VR::US, dicom_value!(U16, [message_id])),
+        //priority
+        DataElement::new(
+            tags::PRIORITY,
+            VR::US,
+            // medium
+            dicom_value!(U16, [0x0000]),
+        ),
+        // data set type
+        DataElement::new(
+            tags::COMMAND_DATA_SET_TYPE,
+            VR::US,
+            dicom_value!(U16, [0x0001]),
+        ),
+    ])
 }
 
 #[cfg(test)]
 mod tests {
-    use super::even_len;
     use crate::App;
     use clap::CommandFactory;
 
     #[test]
     fn verify_cli() {
         App::command().debug_assert();
-    }
-
-    #[test]
-    fn test_even_len() {
-        assert_eq!(even_len(0), 0);
-        assert_eq!(even_len(1), 2);
-        assert_eq!(even_len(2), 2);
-        assert_eq!(even_len(3), 4);
-        assert_eq!(even_len(4), 4);
-        assert_eq!(even_len(5), 6);
     }
 }

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -2772,4 +2772,14 @@ mod tests {
             Some(126)
         );
     }
+
+    #[test]
+    fn test_even_len() {
+        assert_eq!(even_len(0), 0);
+        assert_eq!(even_len(1), 2);
+        assert_eq!(even_len(2), 2);
+        assert_eq!(even_len(3), 4);
+        assert_eq!(even_len(4), 4);
+        assert_eq!(even_len(5), 6);
+    }
 }

--- a/storescp/src/main.rs
+++ b/storescp/src/main.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use clap::Parser;
-use dicom_core::{dicom_value, DataElement, PrimitiveValue, VR};
+use dicom_core::{dicom_value, DataElement, VR};
 use dicom_dictionary_std::tags;
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_object::{FileMetaTableBuilder, InMemDicomObject, StandardDataDictionary};
@@ -270,23 +270,7 @@ fn create_cstore_response(
     sop_class_uid: &str,
     sop_instance_uid: &str,
 ) -> InMemDicomObject<StandardDataDictionary> {
-    InMemDicomObject::from_element_iter([
-        DataElement::new(
-            tags::COMMAND_GROUP_LENGTH,
-            VR::UL,
-            PrimitiveValue::from(
-                8 + sop_class_uid.len() as i32
-                    + 8
-                    + 2
-                    + 8
-                    + 2
-                    + 8
-                    + 2
-                    + 8
-                    + 2
-                    + sop_instance_uid.len() as i32,
-            ),
-        ),
+    InMemDicomObject::command_from_element_iter([
         DataElement::new(
             tags::AFFECTED_SOP_CLASS_UID,
             VR::UI,
@@ -313,12 +297,7 @@ fn create_cstore_response(
 }
 
 fn create_cecho_response(message_id: u16) -> InMemDicomObject<StandardDataDictionary> {
-    InMemDicomObject::from_element_iter([
-        DataElement::new(
-            tags::COMMAND_GROUP_LENGTH,
-            VR::UL,
-            PrimitiveValue::from(8 + 8 + 2 + 8 + 2 + 8 + 2),
-        ),
+    InMemDicomObject::command_from_element_iter([
         DataElement::new(tags::COMMAND_FIELD, VR::US, dicom_value!(U16, [0x8030])),
         DataElement::new(
             tags::MESSAGE_ID_BEING_RESPONDED_TO,


### PR DESCRIPTION
This adds new functions for construction DICOM objects which represent command sets. The main perk of `InMemDicomObject::command_from_element_iter` over just `InMemDicomObject::from_element_iter` is that a Command Group Length (0000, 0000) is automatically calculated and added to the output object.

This also updates `echoscu`, `storescu`, `findscu` and `storescp` to use this function, making them a bit leaner.
