### PR TITLE
Support group length tags in dictionary, update dictionary-std documentation and implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ name = "dicom-dictionary-std"
 version = "0.5.0"
 dependencies = [
  "dicom-core",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]

--- a/core/src/dictionary/mod.rs
+++ b/core/src/dictionary/mod.rs
@@ -29,7 +29,12 @@ pub enum TagRange {
     /// `(GGGG,EExx)`
     Element100(Tag),
     /// Generic group length tag,
-    /// refers to any attribute of the form `(GGGG,0000)`
+    /// refers to any attribute of the form `(GGGG,0000)`,
+    /// _save for the following exceptions_
+    /// which have their own single tag record:
+    /// 
+    /// - _Command Group Length_ (0000,0000)
+    /// - _File Meta Information Group Length_ (0002,0000)
     GroupLength,
 }
 

--- a/core/src/dictionary/mod.rs
+++ b/core/src/dictionary/mod.rs
@@ -10,9 +10,14 @@ use std::fmt::Debug;
 use std::str::FromStr;
 
 /// Specification of a range of tags pertaining to an attribute.
-/// Very often, the dictionary of attributes indicates a unique `(group,elem)`
-/// for a specific attribute, but occasionally a range of groups or elements
-/// is indicated instead (e.g. _Pixel Data_ is associated with ).
+/// Very often, the dictionary of attributes indicates a unique
+/// group part and element part `(group,elem)`,
+/// but occasionally an attribute may cover
+/// a range of groups or elements instead.
+/// For example,
+/// _Overlay Data_ (60xx,3000) has more than one possible tag,
+/// since it is part of a repeating group.
+/// Moreover, a unique variant is defined for group length tags.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TagRange {
     /// Only a specific tag
@@ -23,7 +28,8 @@ pub enum TagRange {
     /// The two rightmost digits of the _element_ portion are open:
     /// `(GGGG,EExx)`
     Element100(Tag),
-    /// Generic group length tag, does not refer to any specific attribute.
+    /// Generic group length tag,
+    /// refers to any attribute of the form `(GGGG,0000)`
     GroupLength,
 }
 
@@ -31,7 +37,9 @@ impl TagRange {
     /// Retrieve the inner tag representation of this range.
     ///
     /// Open components are zeroed out.
-    /// Returns a zeroed out tag (CommandGroupLength) if it is a `GroupLength`.
+    /// Returns a zeroed out tag
+    /// (equivalent to _Command Group Length_)
+    /// if it is a group length tag.
     pub fn inner(self) -> Tag {
         match self {
             TagRange::Single(tag) => tag,

--- a/dictionary-std/Cargo.toml
+++ b/dictionary-std/Cargo.toml
@@ -11,4 +11,4 @@ readme = "README.md"
 
 [dependencies]
 dicom-core = { path = "../core", version = "0.5.0" }
-lazy_static = "1.2.0"
+once_cell = "1.18.0"

--- a/dictionary-std/src/lib.rs
+++ b/dictionary-std/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod tags;
 
 use crate::tags::ENTRIES;
+use dicom_core::VR;
 use dicom_core::dictionary::{DataDictionary, DictionaryEntryRef, TagRange::*};
 use dicom_core::header::Tag;
 use lazy_static::lazy_static;
@@ -65,6 +66,13 @@ impl StandardDictionaryRegistry {
     }
 }
 
+/// Generic Group Length dictionary entry.
+static GROUP_LENGTH_ENTRY: DictionaryEntryRef<'static> = DictionaryEntryRef {
+    tag: GroupLength,
+    alias: "GenericGroupLength",
+    vr: VR::UL,
+};
+
 /// A data dictionary which consults the library's global DICOM attribute registry.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct StandardDataDictionary;
@@ -90,6 +98,13 @@ impl StandardDataDictionary {
                 }
             })
             .cloned()
+            .or_else(|| {
+                if tag.element() == 0x0000 {
+                    Some(&GROUP_LENGTH_ENTRY)
+                } else {
+                    None
+                }
+            })
     }
 }
 
@@ -128,6 +143,9 @@ fn init_dictionary() -> StandardDictionaryRegistry {
     for entry in ENTRIES {
         d.index(entry);
     }
+    // generic group length is not a generated entry,
+    // inserting it manually
+    d.by_name.insert("GenericGroupLength", &GROUP_LENGTH_ENTRY);
     d
 }
 
@@ -251,4 +269,50 @@ mod tests {
         assert_eq!(dict.parse_tag("OPERATORSNAME"), None);
     }
 
+    #[test]
+    fn has_group_length_tags() {
+        use crate::tags::*;
+        assert_eq!(COMMAND_GROUP_LENGTH, Tag(0x0000, 0x0000));
+        assert_eq!(FILE_META_INFORMATION_GROUP_LENGTH, Tag(0x0002, 0x0000));
+
+        let dict = StandardDataDictionary::default();
+        
+        assert_eq!(
+            dict.by_tag(FILE_META_INFORMATION_GROUP_LENGTH),
+            Some(&DictionaryEntryRef {
+                tag: Single(FILE_META_INFORMATION_GROUP_LENGTH),
+                alias: "FileMetaInformationGroupLength",
+                vr: VR::UL,
+            }),
+        );
+
+        assert_eq!(
+            dict.by_tag(COMMAND_GROUP_LENGTH),
+            Some(&DictionaryEntryRef {
+                tag: Single(COMMAND_GROUP_LENGTH),
+                alias: "CommandGroupLength",
+                vr: VR::UL,
+            }),
+        );
+
+        // generic group length
+
+        assert_eq!(
+            dict.by_tag(Tag(0x7FE0, 0x0000)),
+            Some(&DictionaryEntryRef {
+                tag: GroupLength,
+                alias: "GenericGroupLength",
+                vr: VR::UL,
+            }),
+        );
+
+        assert_eq!(
+            dict.by_name("GenericGroupLength"),
+            Some(&DictionaryEntryRef {
+                tag: GroupLength,
+                alias: "GenericGroupLength",
+                vr: VR::UL,
+            }),
+        );
+    }
 }

--- a/dictionary-std/src/lib.rs
+++ b/dictionary-std/src/lib.rs
@@ -12,21 +12,28 @@ use crate::tags::ENTRIES;
 use dicom_core::VR;
 use dicom_core::dictionary::{DataDictionary, DictionaryEntryRef, TagRange::*};
 use dicom_core::header::Tag;
-use lazy_static::lazy_static;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::fmt::{Display, Formatter};
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    static ref DICT: StandardDictionaryRegistry = init_dictionary();
-}
+static DICT: Lazy<StandardDictionaryRegistry> = Lazy::new(init_dictionary);
 
 /// Retrieve a singleton instance of the standard dictionary registry.
+///
+/// Note that one does not generally have to call this
+/// unless when retrieving the underlying registry is important.
+/// The unit type [`StandardDataDictionary`]
+/// already provides a lazy loaded singleton implementing the necessary traits.
+#[inline]
 pub fn registry() -> &'static StandardDictionaryRegistry {
     &DICT
 }
 
-/// The data struct containing the standard dictionary.
+/// The data struct actually containing the standard dictionary.
+/// 
+/// This structure is made opaque via the unit type [`StandardDataDictionary`],
+/// which provides a lazy loaded singleton.
 #[derive(Debug)]
 pub struct StandardDictionaryRegistry {
     /// mapping: name → entry
@@ -73,7 +80,14 @@ static GROUP_LENGTH_ENTRY: DictionaryEntryRef<'static> = DictionaryEntryRef {
     vr: VR::UL,
 };
 
-/// A data dictionary which consults the library's global DICOM attribute registry.
+/// A data element dictionary which consults
+/// the library's global DICOM attribute registry.
+/// 
+/// This is the type which would generally be used
+/// whenever a data element dictionary is needed,
+/// such as when reading DICOM objects.
+/// 
+/// The dictionary index is automatically initialized upon the first use.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct StandardDataDictionary;
 


### PR DESCRIPTION
This makes a few changes to the dictionary API and to the implementation of `dictionary-std`.


### Summary

- (breaking change) `TagRange` now describes group length tags (gggg,0000) in a separate variant, so that applications such as dicom-dump know its alias when it occurs.
- Improved the documentation of `TagRange` and its methods.
- Changed dictionary-std to use `once_cell` instead of `lazy_static`. `OnceCell` is already part of `std` as of Rust 1.70.0, and `LazyCell` might become available eventually, making this a smooth transition in the future.
- Also improved the documentation of public `dictionary-std` items.