### PR TITLE
Optimize WithMetaError

### DIFF
--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -313,7 +313,8 @@ pub enum WithMetaError {
     },
     /// Could not prepare file meta table
     PrepareMetaTable {
-        source: dicom_core::value::ConvertValueError,
+        #[snafu(source(from(dicom_core::value::ConvertValueError, Box::from)))]
+        source: Box<dicom_core::value::ConvertValueError>,
         backtrace: Backtrace,
     },
 }


### PR DESCRIPTION
Box `ConvertValueError` on `PrepareMetaTable` so that stack memory usage is reduced, warned by Clippy.
