### PR TITLE
Extend value sequence implementations

### DIFF
--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -947,6 +947,22 @@ impl<P> PixelFragmentSequence<P> {
     }
 }
 
+impl<T, F, P> From<(T, F)> for PixelFragmentSequence<P>
+where
+    T: Into<C<u32>>,
+    F: Into<C<P>>,
+{
+    /// Construct a pixel data fragment sequence,
+    /// interpreting the first tuple element as a basic offset table
+    /// and the second element as the vector of fragments.
+    ///
+    /// **Note:** This function does not validate the offset table
+    /// against the given fragments.
+    fn from((offset_table, fragments): (T, F)) -> Self {
+        PixelFragmentSequence::new(offset_table, fragments)
+    }
+}
+
 impl<I, P> From<PixelFragmentSequence<P>> for Value<I, P> {
     #[inline]
     fn from(value: PixelFragmentSequence<P>) -> Self {

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -742,6 +742,16 @@ impl<I> DataSetSequence<I> {
         }
     }
 
+    /// Construct an empty DICOM data sequence,
+    /// with the length explicitly defined to zero.
+    #[inline]
+    pub fn empty() -> Self {
+        DataSetSequence {
+            items: Default::default(),
+            length: Length(0),
+        }
+    }
+
     /// Gets a reference to the items of a sequence.
     #[inline]
     pub fn items(&self) -> &[I] {
@@ -791,6 +801,46 @@ impl<I> DicomValueType for DataSetSequence<I> {
     }
 }
 
+impl<I> From<Vec<I>> for DataSetSequence<I> {
+    /// Converts a vector of items
+    /// into a data set sequence with an undefined length.
+    #[inline]
+    fn from(items: Vec<I>) -> Self {
+        DataSetSequence {
+            items: items.into(),
+            length: Length::UNDEFINED,
+        }
+    }
+}
+
+impl<A, I> From<SmallVec<A>> for DataSetSequence<I>
+where
+    A: smallvec::Array<Item = I>,
+    C<I>: From<SmallVec<A>>,
+{
+    /// Converts a smallvec of items
+    /// into a data set sequence with an undefined length.
+    #[inline]
+    fn from(items: SmallVec<A>) -> Self {
+        DataSetSequence {
+            items: items.into(),
+            length: Length::UNDEFINED,
+        }
+    }
+}
+
+impl<I> From<[I; 1]> for DataSetSequence<I> {
+    /// Constructs a data set sequence with a single item
+    /// and an undefined length.
+    #[inline]
+    fn from([item]: [I; 1]) -> Self {
+        DataSetSequence {
+            items: smallvec::smallvec![item],
+            length: Length::UNDEFINED,
+        }
+    }
+}
+
 impl<I, P> From<DataSetSequence<I>> for Value<I, P> {
     #[inline]
     fn from(value: DataSetSequence<I>) -> Self {
@@ -807,6 +857,7 @@ where
     ///
     /// This implementation only checks for item equality,
     /// disregarding the byte length.
+    #[inline]
     fn eq(&self, other: &DataSetSequence<I>) -> bool {
         self.items() == other.items()
     }


### PR DESCRIPTION
- Extend impls for `DataSetSequence` to facilitate constructing nested data sets without an explicitly defined length.
   - impl `From<Vec<I>>`, `From<SmallVec<A>>` aand `From<[I; 1]>` for `DataSetSequence<I>`
   - Function `DataSetSequence::empty`
- Add impl From<(table, fragments)> for `PixelFragmentSequence`
