### PR TITLE
[core] Extend value/element API a bit more

### DIFF
--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -243,14 +243,14 @@ impl<I, P> DataElement<I, P> {
     ///
     /// Once updated, the header is automatically updated
     /// based on this set of rules:
-    /// 
+    ///
     /// - if the value is a data set sequence,
     ///   the VR is set to `SQ` and the length is reset to undefined;
     /// - if the value is a pixel data fragment sequence,
     ///   the VR is set to `OB` and the lenght is reset to undefined;
     /// - if the value is primitive,
     ///   the length is recalculated, leaving the VR as is.
-    /// 
+    ///
     /// If these rules do not result in a valid element,
     /// consider reconstructing the data element instead.
     pub fn update_value(&mut self, mut f: impl FnMut(&mut Value<I, P>)) {
@@ -259,15 +259,15 @@ impl<I, P> DataElement<I, P> {
             Value::Primitive(v) => {
                 let byte_len = v.calculate_byte_len();
                 self.header.len = Length(byte_len as u32);
-            },
+            }
             Value::Sequence(_) => {
                 self.header.vr = VR::SQ;
                 self.header.len = Length::UNDEFINED;
-            },
+            }
             Value::PixelSequence(_) => {
                 self.header.vr = VR::OB;
                 self.header.len = Length::UNDEFINED;
-            },
+            }
         }
     }
 }
@@ -1460,14 +1460,11 @@ mod tests {
     #[test]
     fn test_update_value() {
         // can update a string value
-        let mut e: DataElement<EmptyObject, InMemFragment> = DataElement::new(
-            Tag(0x0010, 0x0010),
-            VR::PN,
-            PrimitiveValue::from("Doe^John"),
-        );
+        let mut e: DataElement<EmptyObject, InMemFragment> =
+            DataElement::new(Tag(0x0010, 0x0010), VR::PN, "Doe^John");
         assert_eq!(e.length(), Length(8));
         e.update_value(|e| {
-            *e = PrimitiveValue::from("Smith^John").into();
+            *e = "Smith^John".into();
         });
         assert_eq!(e.length(), Length(10));
 

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -153,6 +153,14 @@ impl<I, P> Value<I, P> {
         }
     }
 
+    /// Gets a mutable reference to the primitive value.
+    pub fn primitive_mut(&mut self) -> Option<&mut PrimitiveValue> {
+        match self {
+            Value::Primitive(v) => Some(v),
+            _ => None,
+        }
+    }
+
     /// Gets a reference to the items of a sequence.
     ///
     /// Returns `None` if the value is not a data set sequence.
@@ -163,12 +171,32 @@ impl<I, P> Value<I, P> {
         }
     }
 
+    /// Gets a mutable reference to the items of a sequence.
+    ///
+    /// Returns `None` if the value is not a data set sequence.
+    pub fn items_mut(&mut self) -> Option<&mut C<I>> {
+        match self {
+            Value::Sequence(v) => Some(v.items_mut()),
+            _ => None,
+        }
+    }
+
     /// Gets a reference to the fragments of a pixel data sequence.
     ///
     /// Returns `None` if the value is not a pixel data sequence.
     pub fn fragments(&self) -> Option<&[P]> {
         match self {
             Value::PixelSequence(v) => Some(v.fragments()),
+            _ => None,
+        }
+    }
+
+    /// Gets a mutable reference to the fragments of a pixel data sequence.
+    ///
+    /// Returns `None` if the value is not a pixel data sequence.
+    pub fn fragments_mut(&mut self) -> Option<&mut C<P>> {
+        match self {
+            Value::PixelSequence(v) => Some(v.fragments_mut()),
             _ => None,
         }
     }
@@ -207,6 +235,16 @@ impl<I, P> Value<I, P> {
     pub fn offset_table(&self) -> Option<&[u32]> {
         match self {
             Value::PixelSequence(v) => Some(v.offset_table()),
+            _ => None,
+        }
+    }
+
+    /// Gets a mutable reference to the encapsulated pixel data's offset table.
+    ///
+    /// Returns `None` if the value is not a pixel data sequence.
+    pub fn offset_table_mut(&mut self) -> Option<&mut C<u32>> {
+        match self {
+            Value::PixelSequence(v) => Some(v.offset_table_mut()),
             _ => None,
         }
     }
@@ -758,6 +796,12 @@ impl<I> DataSetSequence<I> {
         &self.items
     }
 
+    /// Gets a mutable reference to the items of a sequence.
+    #[inline]
+    pub fn items_mut(&mut self) -> &mut C<I> {
+        &mut self.items
+    }
+
     /// Obtain the number of items in the sequence.
     #[inline]
     pub fn multiplicity(&self) -> u32 {
@@ -895,9 +939,6 @@ impl<P> PixelFragmentSequence<P> {
     /// Construct a DICOM pixel sequence sequence value
     /// from a list of fragments,
     /// with an empty basic offset table.
-    ///
-    /// **Note:** This function does not validate the offset table
-    /// against the given fragments.
     #[inline]
     pub fn new_fragments(fragments: impl Into<C<P>>) -> Self {
         PixelFragmentSequence {
@@ -912,6 +953,14 @@ impl<P> PixelFragmentSequence<P> {
     #[inline]
     pub fn fragments(&self) -> &[P] {
         &self.fragments
+    }
+
+    /// Gets a mutable reference to the pixel data fragments.
+    ///
+    /// This sequence does not include the offset table.
+    #[inline]
+    pub fn fragments_mut(&mut self) -> &mut C<P> {
+        &mut self.fragments
     }
 
     /// Retrieve the pixel data fragments,
@@ -930,10 +979,13 @@ impl<P> PixelFragmentSequence<P> {
     }
 
     /// Gets a reference to the encapsulated pixel data's offset table.
-    ///
-    /// Returns `None` if the value is not a pixel data sequence.
     pub fn offset_table(&self) -> &[u32] {
         &self.offset_table
+    }
+
+    /// Gets a mutable reference to the encapsulated pixel data's offset table.
+    pub fn offset_table_mut(&mut self) -> &mut C<u32> {
+        &mut self.offset_table
     }
 
     /// Get the value data's length

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -250,6 +250,20 @@ impl<I, P> Value<I, P> {
     }
 }
 
+impl<I, P> From<&str> for Value<I, P> {
+    /// Converts a string into a primitive textual value.
+    fn from(value: &str) -> Self {
+        Value::Primitive(PrimitiveValue::from(value))
+    }
+}
+
+impl<I, P> From<String> for Value<I, P> {
+    /// Converts a string into a primitive textual value.
+    fn from(value: String) -> Self {
+        Value::Primitive(PrimitiveValue::from(value))
+    }
+}
+
 impl<I, P> HasLength for Value<I, P> {
     fn length(&self) -> Length {
         match self {
@@ -1250,7 +1264,9 @@ mod tests {
         // declarations are equivalent
         let v3 = Value::from(PrimitiveValue::from("Something"));
         let v4 = Value::new(dicom_value!(Str, "Something"));
+        let v3_2: Value = "Something".into();
         assert_eq!(v3, v4);
+        assert_eq!(v3, v3_2);
 
         // redeclare with different type parameters
         let v3: Value<DummyItem, _> = PrimitiveValue::from("Something").into();


### PR DESCRIPTION
### Summary

- Add `DataElement::update_value`, a utility for modifying a value inline within a data element
- Add impls `From<&str>` and `From<String>` for `DicomValue`, which makes text value construction leaner
