### PR TITLE
Enhance  attribute operations to support sequential attribute selectors

### DIFF
--- a/core/src/dictionary/data_element.rs
+++ b/core/src/dictionary/data_element.rs
@@ -264,23 +264,18 @@ pub trait DataDictionary {
     ///
     /// Attribute selectors are defined by the syntax
     /// `( «key»[«item»] . )* «key» `
-    /// where:
-    ///
-    /// - _`«key»`_ is either a DICOM tag or keyword
-    ///   as accepted by the method [`parse_tag`](DataDictionary::parse_tag);
-    /// - _`«item»`_ is an unsigned integer representing the item index;
-    /// - _`[`_, _`]`_, and _`.`_ are literally their own characters
-    ///   as part of the string.
-    ///
-    /// The first part in parentheses may appear zero or more times.
-    /// Whitespace is not admitted in any position.
+    /// where_`«key»`_ is either a DICOM tag or keyword
+    /// as accepted by this dictionary
+    /// when calling the method [`parse_tag`](DataDictionary::parse_tag).
+    /// More details about the syntax can be found
+    /// in the documentation of [`AttributeSelector`][1].
     ///
     /// Returns an error if the string does not follow the given syntax,
     /// or one of the key components could not be resolved.
     ///
     /// [1]: crate::ops::AttributeSelector
     ///
-    /// ## Examples of valid input:
+    /// ### Examples of valid input:
     ///
     /// - `(0002,00010)`:
     ///   _Transfer Syntax UID_
@@ -288,8 +283,6 @@ pub trait DataDictionary {
     ///   _Patient Age_
     /// - `0040A168[0].CodeValue`:
     ///   _Code Value_ in first item of _Concept Code Sequence_
-    /// - `0040,A730[1].ContentSequence`:
-    ///   _Content Sequence_ in second item of _Content Sequence_
     /// - `SequenceOfUltrasoundRegions[0].RegionSpatialFormat`:
     ///   _Region Spatial Format_ in first item of _Sequence of Ultrasound Regions_
     fn parse_selector(&self, selector_text: &str) -> Result<AttributeSelector, ParseSelectorError> {

--- a/core/src/dictionary/data_element.rs
+++ b/core/src/dictionary/data_element.rs
@@ -140,6 +140,7 @@ impl FromStr for TagRange {
     }
 }
 
+/// An error during attribute selector parsing
 #[derive(Debug, Snafu)]
 pub struct ParseSelectorError(ParseSelectorErrorInner);
 

--- a/core/src/dictionary/data_element.rs
+++ b/core/src/dictionary/data_element.rs
@@ -295,7 +295,7 @@ pub trait DataDictionary {
     fn parse_selector(&self, selector_text: &str) -> Result<AttributeSelector, ParseSelectorError> {
         let mut steps = crate::value::C::new();
         let mut parts = selector_text.split('.');
-        while let Some(part) = parts.next() {
+        for part in parts.by_ref() {
             // detect if intermediate
             if part.ends_with(']') {
                 let split_i = part.find('[').context(MissingItemDelimiterSnafu)?;

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -4,6 +4,7 @@
 
 use crate::value::{
     CastValueError, ConvertValueError, DicomDate, DicomDateTime, DicomTime, PrimitiveValue, Value,
+    C,
 };
 use chrono::FixedOffset;
 use num_traits::NumCast;
@@ -519,9 +520,20 @@ where
 
     /// Retrieve the items stored in a sequence value.
     ///
-    /// Returns `None` if the value is not a data set sequence.
+    /// Returns `None` if the underlying value is not a data set sequence.
     pub fn items(&self) -> Option<&[I]> {
         self.value().items()
+    }
+
+    /// Gets a mutable reference to the items of a sequence value.
+    ///
+    /// The header's recorded length is automatically reset to undefined,
+    /// in order to prevent inconsistencies.
+    ///
+    /// Returns `None` if the underlying value is not a data set sequence.
+    pub fn items_mut(&mut self) -> Option<&mut C<I>> {
+        self.header.len = Length::UNDEFINED;
+        self.value.items_mut()
     }
 
     /// Retrieve the fragments stored in a pixel data sequence value.
@@ -531,9 +543,21 @@ where
         self.value().fragments()
     }
 
-    /// Obtain a reference to the encapsulated pixel data's basic offset table.
+    /// Obtain a mutable reference to the fragments
+    /// stored in a pixel data sequence value.
+    ///
+    /// The header's recorded length is automatically reset to undefined,
+    /// in order to prevent inconsistencies.
     ///
     /// Returns `None` if the value is not a pixel data sequence.
+    pub fn fragments_mut(&mut self) -> Option<&mut C<P>> {
+        self.header.len = Length::UNDEFINED;
+        self.value.fragments_mut()
+    }
+
+    /// Obtain a reference to the encapsulated pixel data's basic offset table.
+    ///
+    /// Returns `None` if the underlying value is not a pixel data sequence.
     pub fn offset_table(&self) -> Option<&[u32]> {
         self.value().offset_table()
     }

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -4,7 +4,7 @@
 
 use crate::value::{
     CastValueError, ConvertValueError, DicomDate, DicomDateTime, DicomTime, PrimitiveValue, Value,
-    C,
+    C, DataSetSequence,
 };
 use chrono::FixedOffset;
 use num_traits::NumCast;
@@ -205,7 +205,11 @@ impl<I, P> DataElement<I, P> {
                 vr,
                 len: Length(0),
             },
-            value: PrimitiveValue::Empty.into(),
+            value: if vr == VR::SQ {
+                DataSetSequence::empty().into()
+            } else {
+                PrimitiveValue::Empty.into()
+            },
         }
     }
 

--- a/core/src/ops.rs
+++ b/core/src/ops.rs
@@ -353,7 +353,25 @@ impl AttributeSelector {
     /// Obtain a reference to the first attribute selection step.
     pub fn first_step(&self) -> &AttributeSelectorStep {
         // guaranteed not to be empty
-        &self.0[0]
+        self.0
+            .first()
+            .expect("invariant broken: attribute selector should have at least one step")
+    }
+
+    /// Obtain a reference to the last attribute selection step.
+    pub fn last_step(&self) -> &AttributeSelectorStep {
+        // guaranteed not to be empty
+        self.0
+            .last()
+            .expect("invariant broken: attribute selector should have at least one step")
+    }
+
+    /// Obtain the tag of the last attribute selection step.
+    pub fn last_tag(&self) -> Tag {
+        match self.last_step() {
+            AttributeSelectorStep::Tag(tag) => *tag,
+            _ => unreachable!("invariant broken: last attribute selector step should be Tag"),
+        }
     }
 }
 
@@ -538,7 +556,7 @@ pub enum AttributeAction {
     SetVr(VR),
     /// Fully reset the attribute with the given DICOM value,
     /// creating it if it does not exist yet.
-    /// 
+    ///
     /// For objects supporting nested data sets,
     /// passing [`PrimitiveValue::Empty`] will create
     /// an empty data set sequence.
@@ -548,7 +566,7 @@ pub enum AttributeAction {
     SetStr(Cow<'static, str>),
     /// Provide the attribute with the given DICOM value,
     /// if it does not exist yet.
-    /// 
+    ///
     /// For objects supporting nested data sets,
     /// passing [`PrimitiveValue::Empty`] will create
     /// an empty data set sequence.
@@ -558,7 +576,7 @@ pub enum AttributeAction {
     SetStrIfMissing(Cow<'static, str>),
     /// Fully replace the value with the given DICOM value,
     /// but only if the attribute already exists.
-    /// 
+    ///
     /// For objects supporting nested data sets,
     /// passing [`PrimitiveValue::Empty`] will clear the items
     /// of an existing data set sequence.

--- a/core/src/ops.rs
+++ b/core/src/ops.rs
@@ -36,10 +36,10 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut obj = open_file("1/2/0003.dcm")?;
 //! // hide patient name
-//! obj.apply(AttributeOp {
-//!     selector: Tag(0x0010, 0x0010).into(),
-//!     action: AttributeAction::SetStr("Patient^Anonymous".into()),
-//! })?;
+//! obj.apply(AttributeOp::new(
+//!     Tag(0x0010, 0x0010),
+//!     AttributeAction::SetStr("Patient^Anonymous".into()),
+//! ))?;
 //! # Ok(())
 //! # }
 //! ```

--- a/core/src/ops.rs
+++ b/core/src/ops.rs
@@ -538,18 +538,30 @@ pub enum AttributeAction {
     SetVr(VR),
     /// Fully reset the attribute with the given DICOM value,
     /// creating it if it does not exist yet.
+    /// 
+    /// For objects supporting nested data sets,
+    /// passing [`PrimitiveValue::Empty`] will create
+    /// an empty data set sequence.
     Set(PrimitiveValue),
     /// Fully reset a textual attribute with the given string,
     /// creating it if it does not exist yet.
     SetStr(Cow<'static, str>),
     /// Provide the attribute with the given DICOM value,
     /// if it does not exist yet.
+    /// 
+    /// For objects supporting nested data sets,
+    /// passing [`PrimitiveValue::Empty`] will create
+    /// an empty data set sequence.
     SetIfMissing(PrimitiveValue),
     /// Provide the textual attribute with the given string,
     /// creating it if it does not exist yet.
     SetStrIfMissing(Cow<'static, str>),
     /// Fully replace the value with the given DICOM value,
     /// but only if the attribute already exists.
+    /// 
+    /// For objects supporting nested data sets,
+    /// passing [`PrimitiveValue::Empty`] will clear the items
+    /// of an existing data set sequence.
     Replace(PrimitiveValue),
     /// Fully replace a textual value with the given string,
     /// but only if the attribute already exists.

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -343,6 +343,14 @@ impl<'a> From<PersonName<'a>> for PrimitiveValue {
     }
 }
 
+impl From<()> for PrimitiveValue {
+    /// constructs an empty DICOM value
+    #[inline]
+    fn from(_value: ()) -> Self {
+        PrimitiveValue::Empty
+    }
+}
+
 macro_rules! impl_from_array_for_primitive {
     ($typ: ty, $variant: ident) => {
         impl From<$typ> for PrimitiveValue {

--- a/dictionary-std/src/data_element.rs
+++ b/dictionary-std/src/data_element.rs
@@ -370,10 +370,10 @@ mod tests {
             AttributeSelector::from((tags::CONTENT_SEQUENCE, 1, tags::CONTENT_SEQUENCE,)),
         );
 
-        // - `SequenceOfUltrasoundRegions[0].RegionSpatialFormat`:
+        // - `SequenceOfUltrasoundRegions.RegionSpatialFormat`:
         //   _Region Spatial Format_ in first item of _Sequence of Ultrasound Regions_
         let selector: AttributeSelector = dict
-            .parse_selector("SequenceOfUltrasoundRegions[0].RegionSpatialFormat")
+            .parse_selector("SequenceOfUltrasoundRegions.RegionSpatialFormat")
             .unwrap();
         assert_eq!(
             selector,

--- a/dictionary-std/src/data_element.rs
+++ b/dictionary-std/src/data_element.rs
@@ -169,9 +169,12 @@ fn init_dictionary() -> StandardDataDictionaryRegistry {
 
 #[cfg(test)]
 mod tests {
+    use crate::tags;
+
     use super::StandardDataDictionary;
     use dicom_core::dictionary::{DataDictionary, DataDictionaryEntryRef, TagRange::*};
     use dicom_core::header::{Tag, VR};
+    use dicom_core::ops::AttributeSelector;
 
     // tests for just a few attributes to make sure that the entries
     // were well installed into the crate
@@ -336,5 +339,72 @@ mod tests {
         assert_eq!(dict.by_tag(Tag(0x0009, 0x0011)), Some(&private_creator));
         assert_eq!(dict.by_tag(Tag(0x000B, 0x0010)), Some(&private_creator));
         assert_eq!(dict.by_tag(Tag(0x00ED, 0x00FF)), Some(&private_creator));
+    }
+
+    #[test]
+    fn can_parse_selectors() {
+        let dict = StandardDataDictionary;
+        // - `(0002,0010)`:
+        //   _Transfer Syntax UID_
+        let selector: AttributeSelector = dict.parse_selector("(0002,0010)").unwrap();
+        assert_eq!(selector, AttributeSelector::from(tags::TRANSFER_SYNTAX_UID));
+
+        // - `00101010`:
+        //   _Patient Age_
+        let selector: AttributeSelector = dict.parse_selector("00101010").unwrap();
+        assert_eq!(selector, AttributeSelector::from(tags::PATIENT_AGE));
+
+        // - `0040A168[0].CodeValue`:
+        //   _Code Value_ in first item of _Concept Code Sequence_
+        let selector: AttributeSelector = dict.parse_selector("0040A168[0].CodeValue").unwrap();
+        assert_eq!(
+            selector,
+            AttributeSelector::from((tags::CONCEPT_CODE_SEQUENCE, 0, tags::CODE_VALUE)),
+        );
+        // - `0040,A730[1].ContentSequence`:
+        //   _Content Sequence_ in second item of _Content Sequence_
+        let selector: AttributeSelector =
+            dict.parse_selector("0040,A730[1].ContentSequence").unwrap();
+        assert_eq!(
+            selector,
+            AttributeSelector::from((tags::CONTENT_SEQUENCE, 1, tags::CONTENT_SEQUENCE,)),
+        );
+
+        // - `SequenceOfUltrasoundRegions[0].RegionSpatialFormat`:
+        //   _Region Spatial Format_ in first item of _Sequence of Ultrasound Regions_
+        let selector: AttributeSelector = dict
+            .parse_selector("SequenceOfUltrasoundRegions[0].RegionSpatialFormat")
+            .unwrap();
+        assert_eq!(
+            selector,
+            AttributeSelector::from((
+                tags::SEQUENCE_OF_ULTRASOUND_REGIONS,
+                0,
+                tags::REGION_SPATIAL_FORMAT
+            )),
+        );
+    }
+
+    /// Can go to is text form and back without losing info
+    #[test]
+    fn print_and_parse_selectors() {
+        let selectors = [
+            AttributeSelector::from((tags::CONTENT_SEQUENCE, 1, tags::CONTENT_SEQUENCE)),
+            AttributeSelector::new([
+                (tags::CONTENT_SEQUENCE, 1).into(),
+                (tags::CONTENT_SEQUENCE, 3).into(),
+                (tags::CONTENT_SEQUENCE, 5).into(),
+                (tags::CONCEPT_NAME_CODE_SEQUENCE, 0).into(),
+                tags::CODE_VALUE.into(),
+            ])
+            .unwrap(),
+        ];
+
+        for selector in selectors {
+            let selector2: AttributeSelector = StandardDataDictionary
+                .parse_selector(&selector.to_string())
+                .unwrap();
+            assert_eq!(selector, selector2);
+        }
     }
 }

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -884,7 +884,7 @@ where
                 AttributeSelectorStep::Nested { tag, item } => {
                     let e =
                         obj.entries
-                            .get_mut(&tag)
+                            .get_mut(tag)
                             .ok_or_else(|| ApplyError::MissingSequence {
                                 selector: selector.clone(),
                                 step_index: i as u32,

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -2,7 +2,7 @@
 use byteordered::byteorder::{ByteOrder, LittleEndian};
 use dicom_core::dicom_value;
 use dicom_core::header::{DataElement, EmptyObject, HasLength, Header};
-use dicom_core::ops::{ApplyOp, AttributeAction, AttributeOp};
+use dicom_core::ops::{ApplyOp, AttributeAction, AttributeOp, AttributeSelectorStep};
 use dicom_core::value::{PrimitiveValue, Value, ValueType};
 use dicom_core::{Length, Tag, VR};
 use dicom_dictionary_std::tags;
@@ -254,7 +254,11 @@ impl FileMetaTable {
     /// See the [`dicom_encoding::ops`] module
     /// for more information.
     fn apply(&mut self, op: AttributeOp) -> ApplyResult {
-        match op.tag {
+        let AttributeSelectorStep::Tag(tag) = op.selector.first_step() else {
+            return UnsupportedAttributeSnafu.fail();
+        };
+
+        match *tag {
             tags::TRANSFER_SYNTAX_UID => Self::apply_required_string(op, &mut self.transfer_syntax),
             tags::MEDIA_STORAGE_SOP_CLASS_UID => {
                 Self::apply_required_string(op, &mut self.media_storage_sop_class_uid)
@@ -1279,20 +1283,20 @@ mod tests {
 
         // replace does not set missing attributes
         table
-            .apply(AttributeOp {
-                tag: tags::IMPLEMENTATION_VERSION_NAME,
-                action: AttributeAction::ReplaceStr("MY_DICOM_1.1".into()),
-            })
+            .apply(AttributeOp::new(
+                tags::IMPLEMENTATION_VERSION_NAME,
+                AttributeAction::ReplaceStr("MY_DICOM_1.1".into()),
+            ))
             .unwrap();
 
         assert_eq!(table.implementation_version_name, None);
 
         // but SetStr does
         table
-            .apply(AttributeOp {
-                tag: tags::IMPLEMENTATION_VERSION_NAME,
-                action: AttributeAction::SetStr("MY_DICOM_1.1".into()),
-            })
+            .apply(AttributeOp::new(
+                tags::IMPLEMENTATION_VERSION_NAME,
+                AttributeAction::SetStr("MY_DICOM_1.1".into()),
+            ))
             .unwrap();
 
         assert_eq!(
@@ -1302,10 +1306,10 @@ mod tests {
 
         // Set (primitive) also works
         table
-            .apply(AttributeOp {
-                tag: tags::SOURCE_APPLICATION_ENTITY_TITLE,
-                action: AttributeAction::Set(PrimitiveValue::Str("RICOOGLE-STORAGE".into())),
-            })
+            .apply(AttributeOp::new(
+                tags::SOURCE_APPLICATION_ENTITY_TITLE,
+                AttributeAction::Set(PrimitiveValue::Str("RICOOGLE-STORAGE".into())),
+            ))
             .unwrap();
 
         assert_eq!(
@@ -1315,10 +1319,10 @@ mod tests {
 
         // set if missing works only if value isn't set yet
         table
-            .apply(AttributeOp {
-                tag: tags::SOURCE_APPLICATION_ENTITY_TITLE,
-                action: AttributeAction::SetStrIfMissing("STORE-SCU".into()),
-            })
+            .apply(AttributeOp::new(
+                tags::SOURCE_APPLICATION_ENTITY_TITLE,
+                AttributeAction::SetStrIfMissing("STORE-SCU".into()),
+            ))
             .unwrap();
 
         assert_eq!(
@@ -1327,10 +1331,10 @@ mod tests {
         );
 
         table
-            .apply(AttributeOp {
-                tag: tags::SENDING_APPLICATION_ENTITY_TITLE,
-                action: AttributeAction::SetStrIfMissing("STORE-SCU".into()),
-            })
+            .apply(AttributeOp::new(
+                tags::SENDING_APPLICATION_ENTITY_TITLE,
+                AttributeAction::SetStrIfMissing("STORE-SCU".into()),
+            ))
             .unwrap();
 
         assert_eq!(
@@ -1340,12 +1344,10 @@ mod tests {
 
         // replacing mandatory field
         table
-            .apply(AttributeOp {
-                tag: tags::MEDIA_STORAGE_SOP_CLASS_UID,
-                action: AttributeAction::Replace(PrimitiveValue::Str(
-                    "1.2.840.10008.5.1.4.1.1.7".into(),
-                )),
-            })
+            .apply(AttributeOp::new(
+                tags::MEDIA_STORAGE_SOP_CLASS_UID,
+                AttributeAction::Replace(PrimitiveValue::Str("1.2.840.10008.5.1.4.1.1.7".into())),
+            ))
             .unwrap();
 
         assert_eq!(


### PR DESCRIPTION
This extends the attribute operations API (`dicom_core::ops`) so that operation descriptors specify a full _attribute selector_ instead of just a tag. This enables the consumer to specify any attribute at an arbitrary depth (even within nested data sets).

For example:

```rust
obj.apply(AttributeOp::new(
    (
        // navigate to Sequence of Ultrasound Regions
        tags::SEQUENCE_OF_ULTRASOUND_REGIONS,
        // enter the first item
        0,
        // select Region Spatial Format
        Tag(0x0018, 0x6012)
    ),
    AttributeAction::Remove),
)?;
```

Parsing from text is also supported:

```rust
let selector: AttributeSelector = StandardDataDictionary.parse_selector(
    "SequenceOfUltrasoundRegions[0].(0018,6012)"
).unwrap();
```

### Summary

- add `DataElement::items_mut` and `DataElements::fragments_mut`
- add `AttributeSelector` and `AttributeSelectorStep`
   - contains multiple conversions from `Tag` and tuples of interleaved tags and items, plus dynamic constructor `new`
- replace `tag` in `AttributeOp` with new `selector`
- adjust implementations of `ApplyOp` accordingly
- add a method in `DataDictionary` for parsing attribute selectors in text form
- extend documentation of `DataDictionary`
