### PR TITLE
[findscu] Support combining query file with query options

### DIFF
--- a/findscu/README.md
+++ b/findscu/README.md
@@ -14,7 +14,28 @@ Note that this tool is not necessarily a drop-in replacement
 for `findscu` tools in other DICOM software toolkits.
 Run `dicom-findscu --help`  for more details.
 
-There are two exclusive ways to specify a DICOM query:
+Basic usage includes searching for a study or patient by a certain attribute.
+The following query/retrieve information models are supported at the moment:
+
+- **`-S`**: Study Root Query/Retrieve Information Model – FIND (default)
+- **`-P`**: Patient Root Query/Retrieve Information Model - FIND
+- **`-W`**: Modality Worklist Information Model – FIND
+
+There are two _non-exclusive_ ways to specify a DICOM query:
+
+### Passing a DICOM query object file
+
+You may optionally start by providing a DICOM query object as a file.
+There are currently no tools in DICOM-rs
+to assist in the process of creating these objects,
+but one can convert DCMTK DICOM data dumps
+into compatible DICOM query objects,
+or write these tools yourself.
+
+```sh
+# query is defined in file
+dicom-findscu PACS@pacs.example.com:1045 --study query.dcm
+```
 
 ### Using the multi-value `-q` option
 
@@ -25,8 +46,8 @@ Each value is a text of the form `«field_path»=«field_value»`, where:
   against the value of the specified DICOM attribute.
   It can be empty, which in that case the `=` may also be left out.
 
-Basic usage includes searching for a study or patient by a certain attribute.
-Only patient level and study level queries are supported.
+If a path to a DICOM query file is passed,
+these options will extend or override the query object from the file.
 
 #### Selector syntax
 
@@ -37,7 +58,8 @@ or a tag keyword name such as `PatientName`.
 To specify a sequence, use multiple of these separated by a dot
 (e.g. `ScheduledProcedureStepSequence.0040,0020`).
 When writing nested attributes,
-you currently need to declare the sequence first in a separate query option, and only then define the attribute inside it.
+you currently need to declare the sequence in a separate query option,
+and _only then_ define the attribute inside it, in this order.
 See the examples below for clarity.
 
 #### Examples
@@ -57,20 +79,4 @@ dicom-findscu PACS@pacs.example.com:1045 -S -q "StudyInstanceUID=*"
 dicom-findscu INFO@pacs.example.com:1045 --mwl \
     -q ScheduledProcedureStepSequence \
     -q ScheduledProcedureStepSequence.ScheduledProcedureStepStatus=ARRIVED
-```
-
-### Passing a query object file
-
-As an alternative to term queries,
-you can also provide a DICOM query object
-as a file.
-There are currently no tools in DICOM-rs
-to assist in the process of creating these objects,
-but one can convert DCMTK DICOM data dumps
-into compatible DICOM query objects,
-or write these tools yourself.
-
-```sh
-# query is defined in file
-dicom-findscu PACS@pacs.example.com:1045 --study query.dcm
 ```

--- a/findscu/src/query.rs
+++ b/findscu/src/query.rs
@@ -42,11 +42,11 @@ impl FromStr for TermQuery {
     }
 }
 
-pub fn parse_queries<T>(qs: &[T]) -> Result<InMemDicomObject, Whatever>
+pub fn parse_queries<T>(base: InMemDicomObject, qs: &[T]) -> Result<InMemDicomObject, Whatever>
 where
     T: AsRef<str>,
 {
-    let mut obj = InMemDicomObject::new_empty();
+    let mut obj = base;
 
     for q in qs {
         let term_query: TermQuery = q.as_ref().parse()?;


### PR DESCRIPTION
This allows `dicom-findscu` users to pass both a query file to serve as a base or template, as well as query options to extend it.

### Summary

- change parse_queries to take a base object
- tweak build_query so that both forms of query specification may take place, but still error if neither one is provided
- update readme accordingly
