### PR TITLE
[core] add prelude module

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod dictionary;
 pub mod header;
 pub mod ops;
 pub mod value;
+pub mod prelude;
 
 pub use dictionary::DataDictionary;
 pub use header::{DataElement, DataElementHeader, Length, Tag, VR};

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -1,0 +1,12 @@
+//! Prelude module.
+//!
+//! You may import all symbols within for convenient usage of this library.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use dicom_core::prelude::*;
+//! ```
+
+pub use crate::{dicom_value, DataElement, DicomValue, Tag, VR};
+pub use crate::{header::HasLength as _, DataDictionary as _};

--- a/core/tests/using_prelude.rs
+++ b/core/tests/using_prelude.rs
@@ -1,0 +1,20 @@
+use dicom_core::prelude::*;
+
+#[test]
+fn can_use_prelude() {
+    // can refer to `DataElement`, `Tag`, `VR`, and `dicom_value!`
+    let elem: DataElement<dicom_core::header::EmptyObject, dicom_core::value::InMemFragment> =
+        DataElement::new(
+            Tag(0x0010, 0x0010),
+            VR::PN,
+            dicom_value!(Str, "Simões^João"),
+        );
+    let length = elem.length().0;
+    assert_eq!(length as usize, "Simões^João".len());
+
+    // can call `by_tag`
+    assert_eq!(
+        dicom_core::dictionary::stub::StubDataDictionary.by_tag(Tag(0x0010, 0x0010)),
+        None,
+    );
+}


### PR DESCRIPTION
A conservative `prelude` model for now, includes what one is most likely to depend on without high chances of collisions or other breaking changes.
