### PR TITLE
Fix RLE lossless decoding

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           cache: true
-      # test project with default + useful features
-      - run: cargo test --features image,ndarray,sop-class
+      # test project with default + extra features
+      - run: cargo test --features image,ndarray,sop-class,rle
       # test dicom-pixeldata with gdcm-rs
       - run: cargo test -p dicom-pixeldata --features gdcm
       # test dicom-pixeldata without default features

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1968,28 +1968,32 @@ mod tests {
             let values = decoded.to_vec_with_options::<u8>(&options).unwrap();
 
             let columns = decoded.columns() as usize;
-            // Validated using Numpy
-            // This doesn't reshape the array based on the PlanarConfiguration
-            // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
-            assert_eq!(values.len(), 30000);
+            // validated through manual inspection of ground-truth
+            assert_eq!(values.len(), 30_000);
             // 0,0,r
             assert_eq!(values[0], 255);
             // 0,0,g
-            assert_eq!(values[1], 255);
+            assert_eq!(values[1], 0);
             // 0,0,b
-            assert_eq!(values[2], 255);
+            assert_eq!(values[2], 0);
             // 50,50,r
             assert_eq!(values[50 * columns * 3 + 50 * 3], 128);
             // 50,50,g
             assert_eq!(values[50 * columns * 3 + 50 * 3 + 1], 128);
             // 50,50,b
-            assert_eq!(values[50 * columns * 3 + 50 * 3 + 2], 128);
-            // 75,75,b
-            assert_eq!(values[75 * columns * 3 + 75 * 3], 0);
+            assert_eq!(values[50 * columns * 3 + 50 * 3 + 2], 255);
+            // 75,75,r
+            assert_eq!(values[75 * columns * 3 + 75 * 3], 64);
             // 75,75,g
-            assert_eq!(values[75 * columns * 3 + 75 * 3 + 1], 0);
+            assert_eq!(values[75 * columns * 3 + 75 * 3 + 1], 64);
             // 75,75,b
-            assert_eq!(values[75 * columns * 3 + 75 * 3 + 2], 0);
+            assert_eq!(values[75 * columns * 3 + 75 * 3 + 2], 64);
+            // 16,49,r
+            assert_eq!(values[49 * columns * 3 + 16 * 3], 0);
+            // 16,49,g
+            assert_eq!(values[49 * columns * 3 + 16 * 3 + 1], 0);
+            // 16,49,b
+            assert_eq!(values[49 * columns * 3 + 16 * 3 + 2], 255);
         }
 
         #[cfg(feature = "ndarray")]
@@ -2005,20 +2009,25 @@ mod tests {
                 .unwrap()
                 .to_ndarray_with_options::<u8>(&options)
                 .unwrap();
-            // Validated using Numpy
-            // This doesn't reshape the array based on the PlanarConfiguration
-            // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
+            // validated through manual inspection of ground-truth
             assert_eq!(ndarray.shape(), &[1, 100, 100, 3]);
-            assert_eq!(ndarray.len(), 30000);
+            assert_eq!(ndarray.len(), 30_000);
+            // 0, 0
             assert_eq!(ndarray[[0, 0, 0, 0]], 255);
-            assert_eq!(ndarray[[0, 0, 0, 1]], 255);
-            assert_eq!(ndarray[[0, 0, 0, 2]], 255);
+            assert_eq!(ndarray[[0, 0, 0, 1]], 0);
+            assert_eq!(ndarray[[0, 0, 0, 2]], 0);
+            // 50, 50
             assert_eq!(ndarray[[0, 50, 50, 0]], 128);
             assert_eq!(ndarray[[0, 50, 50, 1]], 128);
-            assert_eq!(ndarray[[0, 50, 50, 2]], 128);
-            assert_eq!(ndarray[[0, 75, 75, 0]], 0);
-            assert_eq!(ndarray[[0, 75, 75, 1]], 0);
-            assert_eq!(ndarray[[0, 75, 75, 2]], 0);
+            assert_eq!(ndarray[[0, 50, 50, 2]], 255);
+            // 75, 75
+            assert_eq!(ndarray[[0, 75, 75, 0]], 64);
+            assert_eq!(ndarray[[0, 75, 75, 1]], 64);
+            assert_eq!(ndarray[[0, 75, 75, 2]], 64);
+            // 16, 49
+            assert_eq!(ndarray[[0, 49, 16, 0]], 0);
+            assert_eq!(ndarray[[0, 49, 16, 1]], 0);
+            assert_eq!(ndarray[[0, 49, 16, 2]], 255);
         }
 
         #[cfg(feature = "ndarray")]
@@ -2033,21 +2042,42 @@ mod tests {
                 .unwrap()
                 .to_ndarray_with_options::<u8>(&options)
                 .unwrap();
-            // Validated using Numpy
-            // This doesn't reshape the array based on the PlanarConfiguration
-            // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
+            // validated through manual inspection of ground-truth
             assert_eq!(ndarray.shape(), &[2, 100, 100, 3]);
-            assert_eq!(ndarray.len(), 60000);
+            assert_eq!(ndarray.len(), 60_000);
+            // 0, 0
+            assert_eq!(ndarray[[0, 0, 0, 0]], 255);
+            assert_eq!(ndarray[[0, 0, 0, 1]], 0);
+            assert_eq!(ndarray[[0, 0, 0, 2]], 0);
+            // 50, 50
+            assert_eq!(ndarray[[0, 50, 50, 0]], 128);
+            assert_eq!(ndarray[[0, 50, 50, 1]], 128);
+            assert_eq!(ndarray[[0, 50, 50, 2]], 255);
+            // 75, 75
+            assert_eq!(ndarray[[0, 75, 75, 0]], 64);
+            assert_eq!(ndarray[[0, 75, 75, 1]], 64);
+            assert_eq!(ndarray[[0, 75, 75, 2]], 64);
+            // 16, 49
+            assert_eq!(ndarray[[0, 49, 16, 0]], 0);
+            assert_eq!(ndarray[[0, 49, 16, 1]], 0);
+            assert_eq!(ndarray[[0, 49, 16, 2]], 255);
             // The second frame is the inverse of the first frame
+            // 0, 0
             assert_eq!(ndarray[[1, 0, 0, 0]], 0);
-            assert_eq!(ndarray[[1, 0, 0, 1]], 0);
-            assert_eq!(ndarray[[1, 0, 0, 2]], 0);
+            assert_eq!(ndarray[[1, 0, 0, 1]], 255);
+            assert_eq!(ndarray[[1, 0, 0, 2]], 255);
+            // 50, 50
             assert_eq!(ndarray[[1, 50, 50, 0]], 127);
             assert_eq!(ndarray[[1, 50, 50, 1]], 127);
-            assert_eq!(ndarray[[1, 50, 50, 2]], 127);
-            assert_eq!(ndarray[[1, 75, 75, 0]], 255);
-            assert_eq!(ndarray[[1, 75, 75, 1]], 255);
-            assert_eq!(ndarray[[1, 75, 75, 2]], 255);
+            assert_eq!(ndarray[[1, 50, 50, 2]], 0);
+            // 75, 75
+            assert_eq!(ndarray[[1, 75, 75, 0]], 191);
+            assert_eq!(ndarray[[1, 75, 75, 1]], 191);
+            assert_eq!(ndarray[[1, 75, 75, 2]], 191);
+            // 16, 49
+            assert_eq!(ndarray[[1, 49, 16, 0]], 255);
+            assert_eq!(ndarray[[1, 49, 16, 1]], 255);
+            assert_eq!(ndarray[[1, 49, 16, 2]], 0);
         }
 
         #[cfg(feature = "ndarray")]
@@ -2062,20 +2092,24 @@ mod tests {
                 .unwrap()
                 .to_ndarray_with_options::<u16>(&options)
                 .unwrap();
-            // Validated using Numpy
-            // This doesn't reshape the array based on the PlanarConfiguration
-            // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
             assert_eq!(ndarray.shape(), &[1, 100, 100, 3]);
-            assert_eq!(ndarray.len(), 30000);
+            assert_eq!(ndarray.len(), 30_000);
+            // 0,0
             assert_eq!(ndarray[[0, 0, 0, 0]], 65535);
-            assert_eq!(ndarray[[0, 0, 0, 1]], 65535);
-            assert_eq!(ndarray[[0, 0, 0, 2]], 65535);
+            assert_eq!(ndarray[[0, 0, 0, 1]], 0);
+            assert_eq!(ndarray[[0, 0, 0, 2]], 0);
+            // 50,50
             assert_eq!(ndarray[[0, 50, 50, 0]], 32896);
             assert_eq!(ndarray[[0, 50, 50, 1]], 32896);
-            assert_eq!(ndarray[[0, 50, 50, 2]], 32896);
-            assert_eq!(ndarray[[0, 75, 75, 0]], 0);
-            assert_eq!(ndarray[[0, 75, 75, 1]], 0);
-            assert_eq!(ndarray[[0, 75, 75, 2]], 0);
+            assert_eq!(ndarray[[0, 50, 50, 2]], 65535);
+            // 75,75
+            assert_eq!(ndarray[[0, 75, 75, 0]], 16448);
+            assert_eq!(ndarray[[0, 75, 75, 1]], 16448);
+            assert_eq!(ndarray[[0, 75, 75, 2]], 16448);
+            // 16, 49
+            assert_eq!(ndarray[[0, 49, 16, 0]], 0);
+            assert_eq!(ndarray[[0, 49, 16, 1]], 0);
+            assert_eq!(ndarray[[0, 49, 16, 2]], 65535);
         }
 
         #[cfg(feature = "ndarray")]
@@ -2093,17 +2127,41 @@ mod tests {
             // This doesn't reshape the array based on the PlanarConfiguration
             // So for this scan the pixel layout is [Rlsb..Rmsb, Glsb..Gmsb, Blsb..msb]
             assert_eq!(ndarray.shape(), &[2, 100, 100, 3]);
-            assert_eq!(ndarray.len(), 60000);
+            assert_eq!(ndarray.len(), 60_000);
+            // 0,0
+            assert_eq!(ndarray[[0, 0, 0, 0]], 65535);
+            assert_eq!(ndarray[[0, 0, 0, 1]], 0);
+            assert_eq!(ndarray[[0, 0, 0, 2]], 0);
+            // 50,50
+            assert_eq!(ndarray[[0, 50, 50, 0]], 32896);
+            assert_eq!(ndarray[[0, 50, 50, 1]], 32896);
+            assert_eq!(ndarray[[0, 50, 50, 2]], 65535);
+            // 75,75
+            assert_eq!(ndarray[[0, 75, 75, 0]], 16448);
+            assert_eq!(ndarray[[0, 75, 75, 1]], 16448);
+            assert_eq!(ndarray[[0, 75, 75, 2]], 16448);
+            // 16, 49
+            assert_eq!(ndarray[[0, 49, 16, 0]], 0);
+            assert_eq!(ndarray[[0, 49, 16, 1]], 0);
+            assert_eq!(ndarray[[0, 49, 16, 2]], 65535);
             // The second frame is the inverse of the first frame
+            // 0,0
             assert_eq!(ndarray[[1, 0, 0, 0]], 0);
-            assert_eq!(ndarray[[1, 0, 0, 1]], 0);
-            assert_eq!(ndarray[[1, 0, 0, 2]], 0);
+            assert_eq!(ndarray[[1, 0, 0, 1]], 65535);
+            assert_eq!(ndarray[[1, 0, 0, 2]], 65535);
+            // 50,50
             assert_eq!(ndarray[[1, 50, 50, 0]], 32639);
             assert_eq!(ndarray[[1, 50, 50, 1]], 32639);
-            assert_eq!(ndarray[[1, 50, 50, 2]], 32639);
-            assert_eq!(ndarray[[1, 75, 75, 0]], 65535);
-            assert_eq!(ndarray[[1, 75, 75, 1]], 65535);
-            assert_eq!(ndarray[[1, 75, 75, 2]], 65535);
+            assert_eq!(ndarray[[1, 50, 50, 2]], 0);
+            // 75,75
+            assert_eq!(ndarray[[1, 75, 75, 0]], 49087);
+            assert_eq!(ndarray[[1, 75, 75, 1]], 49087);
+            assert_eq!(ndarray[[1, 75, 75, 2]], 49087);
+            // 16, 49
+            assert_eq!(ndarray[[1, 49, 16, 0]], 65535);
+            assert_eq!(ndarray[[1, 49, 16, 1]], 65535);
+            assert_eq!(ndarray[[1, 49, 16, 2]], 0);
+
         }
 
         #[cfg(feature = "image")]


### PR DESCRIPTION
### Summary

- Adjust RLE lossless decoding adapter so that its output is aligned with pixel data reader expectations when samples per pixel 1
- update tests accordingly
- update CI to include more extra features in `cargo test`
