### PR TITLE
[Fix] BOT generation for encapsulated data

### DIFF
--- a/core/src/value/fragments.rs
+++ b/core/src/value/fragments.rs
@@ -107,6 +107,8 @@ impl From<Vec<Fragments>> for PixelFragmentSequence<InMemFragment> {
             fragments.append(&mut frame.fragments);
         }
 
+        offset_table.resize(offset_table.len() - 1, 0);
+
         PixelFragmentSequence {
             offset_table,
             fragments: C::from_vec(fragments),
@@ -117,6 +119,7 @@ impl From<Vec<Fragments>> for PixelFragmentSequence<InMemFragment> {
 #[cfg(test)]
 mod tests {
     use crate::value::fragments::Fragments;
+    use crate::value::{InMemFragment, PixelFragmentSequence};
 
     #[test]
     fn test_fragment_frame() {
@@ -174,5 +177,33 @@ mod tests {
         assert_eq!(fragment.fragments[0], vec![150, 164]);
         assert_eq!(fragment.fragments[1].len(), 2);
         assert_eq!(fragment.fragments[1], vec![200, 222]);
+    }
+
+    #[test]
+    fn test_bot_single_fragment_generation() {
+        let data = vec![Fragments::new(vec![0u8, 0u8], 2)];
+        let fragment_sequence: PixelFragmentSequence<InMemFragment> = data.into();
+        assert_eq!(fragment_sequence.offset_table.len(), 1);
+        assert_eq!(fragment_sequence.offset_table[0], 0);
+    }
+
+    #[test]
+    fn test_bot_multi_fragments_generation() {
+        let data = vec![Fragments::new(vec![0u8, 0u8, 0u8, 0u8], 2)];
+        let fragment_sequence: PixelFragmentSequence<InMemFragment> = data.into();
+        assert_eq!(fragment_sequence.offset_table.len(), 1);
+        assert_eq!(fragment_sequence.offset_table[0], 0);
+    }
+
+    #[test]
+    fn test_bot_multi_frame_generation() {
+        let data = vec![
+            Fragments::new(vec![0u8, 0u8, 0u8, 0u8], 0),
+            Fragments::new(vec![1u8, 1u8, 1u8, 1u8, 1u8, 1u8], 0),
+        ];
+        let fragment_sequence: PixelFragmentSequence<InMemFragment> = data.into();
+        assert_eq!(fragment_sequence.offset_table.len(), 2);
+        assert_eq!(fragment_sequence.offset_table[0], 0);
+        assert_eq!(fragment_sequence.offset_table[1], 12); // 8 separator bytes + 4 data bytes
     }
 }

--- a/core/src/value/fragments.rs
+++ b/core/src/value/fragments.rs
@@ -199,8 +199,8 @@ mod tests {
     #[test]
     fn test_bot_multi_frame_generation() {
         let data = vec![
-            Fragments::new(vec![0u8, 0u8, 0u8, 0u8], 0),
-            Fragments::new(vec![1u8, 1u8, 1u8, 1u8, 1u8, 1u8], 0),
+            Fragments::new(vec![0u8; 4], 0),
+            Fragments::new(vec![1u8; 6], 0),
         ];
         let fragment_sequence: PixelFragmentSequence<InMemFragment> = data.into();
         assert_eq!(fragment_sequence.offset_table.len(), 2);

--- a/core/src/value/fragments.rs
+++ b/core/src/value/fragments.rs
@@ -94,20 +94,21 @@ impl From<Vec<Fragments>> for PixelFragmentSequence<InMemFragment> {
 
         let mut fragments = Vec::new();
         let is_multiframe = value.len() > 1;
+        let last_frame = value.len() - 1;
 
-        for mut frame in value {
+        for (index, mut frame) in value.into_iter().enumerate() {
             if frame.is_multiframe() && is_multiframe {
                 panic!("More than 1 fragment per frame is invalid for multi frame pixel data");
             }
 
-            let offset = frame.len();
-            offset_table.push(current_offset + offset);
-            current_offset += offset;
+            if index < last_frame {
+                let offset = frame.len();
+                offset_table.push(current_offset + offset);
+                current_offset += offset;
+            }
 
             fragments.append(&mut frame.fragments);
         }
-
-        offset_table.resize(offset_table.len() - 1, 0);
 
         PixelFragmentSequence {
             offset_table,

--- a/core/src/value/fragments.rs
+++ b/core/src/value/fragments.rs
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn test_bot_single_fragment_generation() {
-        let data = vec![Fragments::new(vec![0u8, 0u8], 2)];
+        let data = vec![Fragments::new(vec![0u8; 2], 2)];
         let fragment_sequence: PixelFragmentSequence<InMemFragment> = data.into();
         assert_eq!(fragment_sequence.offset_table.len(), 1);
         assert_eq!(fragment_sequence.offset_table[0], 0);
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn test_bot_multi_fragments_generation() {
-        let data = vec![Fragments::new(vec![0u8, 0u8, 0u8, 0u8], 2)];
+        let data = vec![Fragments::new(vec![0u8; 4], 2)];
         let fragment_sequence: PixelFragmentSequence<InMemFragment> = data.into();
         assert_eq!(fragment_sequence.offset_table.len(), 1);
         assert_eq!(fragment_sequence.offset_table[0], 0);

--- a/pixeldata/src/encapsulation.rs
+++ b/pixeldata/src/encapsulation.rs
@@ -65,7 +65,7 @@ mod tests {
         {
             let offset_table = enc.offset_table();
             let fragments = enc.fragments();
-            assert_eq!(offset_table.len(), 3);
+            assert_eq!(offset_table.len(), 2);
             assert_eq!(fragments.len(), 2);
             assert_eq!(fragments[0].len(), 4);
             assert_eq!(fragments[1].len(), 4);
@@ -79,7 +79,7 @@ mod tests {
         if let Value::PixelSequence(enc) = encapsulate_single_frame(vec![20, 30, 40], 1) {
             let offset_table = enc.offset_table();
             let fragments = enc.fragments();
-            assert_eq!(offset_table.len(), 2);
+            assert_eq!(offset_table.len(), 1);
             assert_eq!(fragments.len(), 2);
             assert_eq!(fragments[0].len(), 2);
             assert_eq!(fragments[1].len(), 2);


### PR DESCRIPTION
The BOT of the pixel data should point to the beginning of each frame. The original implementation was adding 1 extra index which was wrong as the last entry pointed to the end of the file.