### PR TITLE
add: User identity negotiation

### DIFF
--- a/storescu/README.md
+++ b/storescu/README.md
@@ -32,6 +32,11 @@ OPTIONS:
         --calling-ae-title <calling-ae-title>    the calling Application Entity title [default: STORE-SCU]
         --max-pdu-length <max-pdu-length>        the maximum PDU length accepted by the SCU [default: 16384]
     -m, --message-id <message-id>                the C-STORE message ID [default: 1]
+        --username <username>                    user identity username
+        --password <password>                    user identity password
+        --kerberos-service-ticket <ticket>       user identity Kerberos service ticket
+        --saml-assertion <assertion>             user identity SAML assertion
+        --jwt <jwt>                              user identity JWT
 
 ARGS:
     <addr>        socket address to Store SCP, optionally with AE title (example: "STORE-SCP@127.0.0.1:104")

--- a/storescu/src/main.rs
+++ b/storescu/src/main.rs
@@ -56,6 +56,21 @@ struct App {
     // hide option if transcoding is disabled
     #[cfg_attr(not(feature = "transcode"), arg(hide(true)))]
     never_transcode: bool,
+    /// User Identity username
+    #[arg(long = "username")]
+    username: Option<String>,
+    /// User Identity password
+    #[arg(long = "password")]
+    password: Option<String>,
+    /// User Identity Kerberos service ticket
+    #[arg(long = "kerberos-service-ticket")]
+    kerberos_service_ticket: Option<String>,
+    /// User Identity SAML assertion
+    #[arg(long = "saml-assertion")]
+    saml_assertion: Option<String>,
+    /// User Identity JWT
+    #[arg(long = "jwt")]
+    jwt: Option<String>,
 }
 
 struct DicomFile {
@@ -112,6 +127,11 @@ fn run() -> Result<(), Error> {
         max_pdu_length,
         fail_first,
         mut never_transcode,
+        username,
+        password,
+        kerberos_service_ticket,
+        saml_assertion,
+        jwt,
     } = App::parse();
 
     // never transcode if the feature is disabled
@@ -200,6 +220,26 @@ fn run() -> Result<(), Error> {
 
     if let Some(called_ae_title) = called_ae_title {
         scu_init = scu_init.called_ae_title(called_ae_title);
+    }
+
+    if let Some(username) = username {
+        scu_init = scu_init.username(username);
+    }
+
+    if let Some(password) = password {
+        scu_init = scu_init.password(password);
+    }
+
+    if let Some(kerberos_service_ticket) = kerberos_service_ticket {
+        scu_init = scu_init.kerberos_service_ticket(kerberos_service_ticket);
+    }
+
+    if let Some(saml_assertion) = saml_assertion {
+        scu_init = scu_init.saml_assertion(saml_assertion);
+    }
+
+    if let Some(jwt) = jwt {
+        scu_init = scu_init.jwt(jwt);
     }
 
     let mut scu = scu_init.establish_with(&addr).context(InitScuSnafu)?;

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -611,7 +611,7 @@ impl<'a> ClientAssociationOptions<'a> {
         if let Some(saml_assertion) = saml_assertion {
             result = Some(UserIdentity::new(
                 false,
-                UserIdentityType::SAMLAssertion,
+                UserIdentityType::SamlAssertion,
                 saml_assertion.into().as_bytes().to_vec(),
                 vec![],
             ));
@@ -620,7 +620,7 @@ impl<'a> ClientAssociationOptions<'a> {
         if let Some(jwt) = jwt {
             result = Some(UserIdentity::new(
                 false,
-                UserIdentityType::JWT,
+                UserIdentityType::Jwt,
                 jwt.into().as_bytes().to_vec(),
                 vec![],
             ));

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -17,7 +17,7 @@ use crate::{
         writer::write_pdu,
         AbortRQSource, AssociationAC, AssociationRJ, AssociationRQ, Pdu,
         PresentationContextProposed, PresentationContextResult, PresentationContextResultReason,
-        UserVariableItem,
+        UserIdentity, UserIdentityType, UserVariableItem,
     },
     AeAddr, IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
 };
@@ -167,6 +167,16 @@ pub struct ClientAssociationOptions<'a> {
     max_pdu_length: u32,
     /// whether to receive PDUs in strict mode
     strict: bool,
+    /// User identity username
+    username: Option<Cow<'a, str>>,
+    /// User identity password
+    password: Option<Cow<'a, str>>,
+    /// User identity Kerberos service ticket
+    kerberos_service_ticket: Option<Cow<'a, str>>,
+    /// User identity SAML assertion
+    saml_assertion: Option<Cow<'a, str>>,
+    /// User identity JWT
+    jwt: Option<Cow<'a, str>>,
 }
 
 impl<'a> Default for ClientAssociationOptions<'a> {
@@ -183,6 +193,11 @@ impl<'a> Default for ClientAssociationOptions<'a> {
             protocol_version: 1,
             max_pdu_length: crate::pdu::reader::DEFAULT_MAX_PDU,
             strict: true,
+            username: None,
+            password: None,
+            kerberos_service_ticket: None,
+            saml_assertion: None,
+            jwt: None,
         }
     }
 }
@@ -270,6 +285,76 @@ impl<'a> ClientAssociationOptions<'a> {
         self
     }
 
+    /// Sets the user identity username
+    pub fn username<T>(mut self, username: T) -> Self
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        let username = username.into();
+        if username.is_empty() {
+            self.username = None;
+        } else {
+            self.username = Some(username);
+        }
+        self
+    }
+
+    /// Sets the user identity password
+    pub fn password<T>(mut self, password: T) -> Self
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        let password = password.into();
+        if password.is_empty() {
+            self.password = None;
+        } else {
+            self.password = Some(password);
+        }
+        self
+    }
+
+    /// Sets the user identity Kerberos service ticket
+    pub fn kerberos_service_ticket<T>(mut self, kerberos_service_ticket: T) -> Self
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        let kerberos_service_ticket = kerberos_service_ticket.into();
+        if kerberos_service_ticket.is_empty() {
+            self.kerberos_service_ticket = None;
+        } else {
+            self.kerberos_service_ticket = Some(kerberos_service_ticket);
+        }
+        self
+    }
+
+    /// Sets the user identity SAML assertion
+    pub fn saml_assertion<T>(mut self, saml_assertion: T) -> Self
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        let saml_assertion = saml_assertion.into();
+        if saml_assertion.is_empty() {
+            self.saml_assertion = None;
+        } else {
+            self.saml_assertion = Some(saml_assertion);
+        }
+        self
+    }
+
+    /// Sets the user identity JWT
+    pub fn jwt<T>(mut self, jwt: T) -> Self
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        let jwt = jwt.into();
+        if jwt.is_empty() {
+            self.jwt = None;
+        } else {
+            self.jwt = Some(jwt);
+        }
+        self
+    }
+
     /// Initiate the TCP connection to the given address
     /// and request a new DICOM association,
     /// negotiating the presentation contexts in the process.
@@ -319,6 +404,11 @@ impl<'a> ClientAssociationOptions<'a> {
             protocol_version,
             max_pdu_length,
             strict,
+            username,
+            password,
+            kerberos_service_ticket,
+            saml_assertion,
+            jwt,
         } = self;
 
         // fail if no presentation contexts were provided: they represent intent,
@@ -355,19 +445,30 @@ impl<'a> ClientAssociationOptions<'a> {
                     .collect(),
             })
             .collect();
+
+        let mut user_variables = vec![
+            UserVariableItem::MaxLength(max_pdu_length),
+            UserVariableItem::ImplementationClassUID(IMPLEMENTATION_CLASS_UID.to_string()),
+            UserVariableItem::ImplementationVersionName(IMPLEMENTATION_VERSION_NAME.to_string()),
+        ];
+
+        if let Some(user_identity) = Self::determine_user_identity(
+            username,
+            password,
+            kerberos_service_ticket,
+            saml_assertion,
+            jwt,
+        ) {
+            user_variables.push(UserVariableItem::UserIdentityItem(user_identity));
+        }
+
         let msg = Pdu::AssociationRQ(AssociationRQ {
             protocol_version,
             calling_ae_title: calling_ae_title.to_string(),
             called_ae_title: called_ae_title.to_string(),
             application_context_name: application_context_name.to_string(),
             presentation_contexts,
-            user_variables: vec![
-                UserVariableItem::MaxLength(max_pdu_length),
-                UserVariableItem::ImplementationClassUID(IMPLEMENTATION_CLASS_UID.to_string()),
-                UserVariableItem::ImplementationVersionName(
-                    IMPLEMENTATION_VERSION_NAME.to_string(),
-                ),
-            ],
+            user_variables,
         });
 
         let mut socket = std::net::TcpStream::connect(ae_address).context(ConnectSnafu)?;
@@ -466,6 +567,66 @@ impl<'a> ClientAssociationOptions<'a> {
                 UnknownResponseSnafu { pdu }.fail()
             }
         }
+    }
+
+    fn determine_user_identity<T>(
+        username: Option<T>,
+        password: Option<T>,
+        kerberos_service_ticket: Option<T>,
+        saml_assertion: Option<T>,
+        jwt: Option<T>,
+    ) -> Option<UserIdentity>
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        let mut result: Option<UserIdentity> = None;
+
+        if let Some(username) = username {
+            if let Some(password) = password {
+                result = Some(UserIdentity::new(
+                    false,
+                    UserIdentityType::UsernamePassword,
+                    username.into().as_bytes().to_vec(),
+                    password.into().as_bytes().to_vec(),
+                ));
+            } else {
+                result = Some(UserIdentity::new(
+                    false,
+                    UserIdentityType::Username,
+                    username.into().as_bytes().to_vec(),
+                    vec![],
+                ));
+            }
+        }
+
+        if let Some(kerberos_service_ticket) = kerberos_service_ticket {
+            result = Some(UserIdentity::new(
+                false,
+                UserIdentityType::KerberosServiceTicket,
+                kerberos_service_ticket.into().as_bytes().to_vec(),
+                vec![],
+            ));
+        }
+
+        if let Some(saml_assertion) = saml_assertion {
+            result = Some(UserIdentity::new(
+                false,
+                UserIdentityType::SAMLAssertion,
+                saml_assertion.into().as_bytes().to_vec(),
+                vec![],
+            ));
+        }
+
+        if let Some(jwt) = jwt {
+            result = Some(UserIdentity::new(
+                false,
+                UserIdentityType::JWT,
+                jwt.into().as_bytes().to_vec(),
+                vec![],
+            ));
+        }
+
+        result
     }
 }
 

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -330,6 +330,79 @@ pub enum UserVariableItem {
     ImplementationClassUID(String),
     ImplementationVersionName(String),
     SopClassExtendedNegotiationSubItem(String, Vec<u8>),
+    UserIdentityItem(UserIdentity),
+}
+
+#[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
+pub struct UserIdentity {
+    positive_response_requested: bool,
+    identity_type: UserIdentityType,
+    primary_field: Vec<u8>,
+    secondary_field: Vec<u8>,
+}
+impl UserIdentity {
+    pub fn new(
+        positive_response_requested: bool,
+        identity_type: UserIdentityType,
+        primary_field: Vec<u8>,
+        secondary_field: Vec<u8>,
+    ) -> Self {
+        UserIdentity {
+            positive_response_requested,
+            identity_type,
+            primary_field,
+            secondary_field,
+        }
+    }
+
+    pub fn positive_response_requested(&self) -> bool {
+        self.positive_response_requested
+    }
+
+    pub fn identity_type(&self) -> UserIdentityType {
+        self.identity_type.clone()
+    }
+
+    pub fn primary_field(&self) -> Vec<u8> {
+        self.primary_field.clone()
+    }
+
+    pub fn secondary_field(&self) -> Vec<u8> {
+        self.secondary_field.clone()
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
+pub enum UserIdentityType {
+    Username,
+    UsernamePassword,
+    KerberosServiceTicket,
+    SAMLAssertion,
+    JWT,
+    Unsupported,
+}
+impl UserIdentityType {
+    fn from(user_identity_type: u8) -> Self {
+        match user_identity_type {
+            1 => Self::Username,
+            2 => Self::UsernamePassword,
+            3 => Self::KerberosServiceTicket,
+            4 => Self::SAMLAssertion,
+            5 => Self::JWT,
+            _ => Self::Unsupported,
+        }
+    }
+
+    fn to_u8(&self) -> u8 {
+        match self {
+            Self::Username => 1,
+            Self::UsernamePassword => 2,
+            Self::KerberosServiceTicket => 3,
+            Self::SAMLAssertion => 4,
+            Self::JWT => 5,
+            Self::Unsupported => 0,
+        }
+    }
 }
 
 /// An in-memory representation of a full Protocol Data Unit (PDU)

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -373,23 +373,23 @@ impl UserIdentity {
 }
 
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
+#[non_exhaustive]
 pub enum UserIdentityType {
     Username,
     UsernamePassword,
     KerberosServiceTicket,
-    SAMLAssertion,
-    JWT,
-    Unsupported,
+    SamlAssertion,
+    Jwt,
 }
 impl UserIdentityType {
-    fn from(user_identity_type: u8) -> Self {
+    fn from(user_identity_type: u8) -> Option<Self> {
         match user_identity_type {
-            1 => Self::Username,
-            2 => Self::UsernamePassword,
-            3 => Self::KerberosServiceTicket,
-            4 => Self::SAMLAssertion,
-            5 => Self::JWT,
-            _ => Self::Unsupported,
+            1 => Some(Self::Username),
+            2 => Some(Self::UsernamePassword),
+            3 => Some(Self::KerberosServiceTicket),
+            4 => Some(Self::SamlAssertion),
+            5 => Some(Self::Jwt),
+            _ => None,
         }
     }
 
@@ -398,9 +398,8 @@ impl UserIdentityType {
             Self::Username => 1,
             Self::UsernamePassword => 2,
             Self::KerberosServiceTicket => 3,
-            Self::SAMLAssertion => 4,
-            Self::JWT => 5,
-            Self::Unsupported => 0,
+            Self::SamlAssertion => 4,
+            Self::Jwt => 5,
         }
     }
 }

--- a/ul/tests/pdu.rs
+++ b/ul/tests/pdu.rs
@@ -37,8 +37,8 @@ fn can_read_write_associate_rq() -> Result<(), Box<dyn std::error::Error>> {
             UserVariableItem::UserIdentityItem(UserIdentity::new(
                 false,
                 UserIdentityType::UsernamePassword,
-                "MyUsername".as_bytes().to_vec(),
-                "MyPassword".as_bytes().to_vec(),
+                b"MyUsername".to_vec(),
+                b"MyPassword".to_vec(),
             )),
         ],
     };
@@ -125,7 +125,7 @@ fn can_read_write_primary_field_only_user_identity() -> Result<(), Box<dyn std::
             UserVariableItem::UserIdentityItem(UserIdentity::new(
                 false,
                 UserIdentityType::Username,
-                "MyUsername".as_bytes().to_vec(),
+                b"MyUsername".to_vec(),
                 vec![],
             )),
         ],

--- a/ul/tests/pdu.rs
+++ b/ul/tests/pdu.rs
@@ -1,7 +1,8 @@
 use dicom_ul::pdu::reader::{read_pdu, DEFAULT_MAX_PDU};
 use dicom_ul::pdu::writer::write_pdu;
 use dicom_ul::pdu::{
-    AssociationRQ, PDataValue, PDataValueType, Pdu, PresentationContextProposed, UserVariableItem,
+    AssociationRQ, PDataValue, PDataValueType, Pdu, PresentationContextProposed, UserIdentity,
+    UserIdentityType, UserVariableItem,
 };
 use matches::matches;
 use std::io::Cursor;
@@ -33,6 +34,12 @@ fn can_read_write_associate_rq() -> Result<(), Box<dyn std::error::Error>> {
                 "abstract 1".to_string(),
                 vec![1, 1, 0, 1, 1, 0, 1],
             ),
+            UserVariableItem::UserIdentityItem(UserIdentity::new(
+                false,
+                UserIdentityType::UsernamePassword,
+                "MyUsername".as_bytes().to_vec(),
+                "MyPassword".as_bytes().to_vec(),
+            )),
         ],
     };
 
@@ -66,7 +73,7 @@ fn can_read_write_associate_rq() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(presentation_contexts[1].transfer_syntaxes.len(), 2);
         assert_eq!(presentation_contexts[1].transfer_syntaxes[0], "transfer 3");
         assert_eq!(presentation_contexts[1].transfer_syntaxes[1], "transfer 4");
-        assert_eq!(user_variables.len(), 4);
+        assert_eq!(user_variables.len(), 5);
         assert!(matches!(
             &user_variables[0],
             UserVariableItem::ImplementationClassUID(u) if u == "class uid"
@@ -80,6 +87,96 @@ fn can_read_write_associate_rq() -> Result<(), Box<dyn std::error::Error>> {
             UserVariableItem::SopClassExtendedNegotiationSubItem(sop_class_uid, data)
             if sop_class_uid ==  "abstract 1" &&
             data.as_slice() == [1,1,0,1,1,0,1]
+        ));
+        assert!(matches!(&user_variables[4],
+            UserVariableItem::UserIdentityItem(user_identity)
+            if !user_identity.positive_response_requested() &&
+            user_identity.identity_type() == UserIdentityType::UsernamePassword &&
+            user_identity.primary_field() == [77,121,85,115,101,114,110,97,109,101] &&
+            user_identity.secondary_field() == [77,121,80,97,115,115,119,111,114,100]
+        ));
+    } else {
+        panic!("invalid pdu type");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn can_read_write_primary_field_only_user_identity() -> Result<(), Box<dyn std::error::Error>> {
+    let association_rq = AssociationRQ {
+        protocol_version: 2,
+        calling_ae_title: "calling ae".to_string(),
+        called_ae_title: "called ae".to_string(),
+        application_context_name: "application context name".to_string(),
+        presentation_contexts: vec![PresentationContextProposed {
+            id: 1,
+            abstract_syntax: "abstract 1".to_string(),
+            transfer_syntaxes: vec!["transfer 1".to_string()],
+        }],
+        user_variables: vec![
+            UserVariableItem::ImplementationClassUID("class uid".to_string()),
+            UserVariableItem::ImplementationVersionName("version name".to_string()),
+            UserVariableItem::MaxLength(23),
+            UserVariableItem::SopClassExtendedNegotiationSubItem(
+                "abstract 1".to_string(),
+                vec![1, 1, 0, 1, 1, 0, 1],
+            ),
+            UserVariableItem::UserIdentityItem(UserIdentity::new(
+                false,
+                UserIdentityType::Username,
+                "MyUsername".as_bytes().to_vec(),
+                vec![],
+            )),
+        ],
+    };
+
+    let mut bytes = vec![0u8; 0];
+    write_pdu(&mut bytes, &association_rq.into())?;
+
+    let result = read_pdu(&mut Cursor::new(&bytes), DEFAULT_MAX_PDU, true)?;
+
+    if let Pdu::AssociationRQ(AssociationRQ {
+        protocol_version,
+        calling_ae_title,
+        called_ae_title,
+        application_context_name,
+        presentation_contexts,
+        user_variables,
+    }) = result
+    {
+        assert_eq!(protocol_version, 2);
+        assert_eq!(calling_ae_title, "calling ae");
+        assert_eq!(called_ae_title, "called ae");
+        assert_eq!(
+            application_context_name,
+            "application context name".to_string()
+        );
+        assert_eq!(presentation_contexts.len(), 1);
+        assert_eq!(presentation_contexts[0].abstract_syntax, "abstract 1");
+        assert_eq!(presentation_contexts[0].transfer_syntaxes.len(), 1);
+        assert_eq!(presentation_contexts[0].transfer_syntaxes[0], "transfer 1");
+        assert_eq!(user_variables.len(), 5);
+        assert!(matches!(
+            &user_variables[0],
+            UserVariableItem::ImplementationClassUID(u) if u == "class uid"
+        ));
+        assert!(matches!(
+            &user_variables[1],
+            UserVariableItem::ImplementationVersionName(v) if v == "version name"
+        ));
+        assert!(matches!(user_variables[2], UserVariableItem::MaxLength(l) if l == 23));
+        assert!(matches!(&user_variables[3],
+            UserVariableItem::SopClassExtendedNegotiationSubItem(sop_class_uid, data)
+            if sop_class_uid ==  "abstract 1" &&
+            data.as_slice() == [1,1,0,1,1,0,1]
+        ));
+        assert!(matches!(&user_variables[4],
+            UserVariableItem::UserIdentityItem(user_identity)
+            if !user_identity.positive_response_requested() &&
+            user_identity.identity_type() == UserIdentityType::Username &&
+            user_identity.primary_field() == [77,121,85,115,101,114,110,97,109,101] &&
+            user_identity.secondary_field() == []
         ));
     } else {
         panic!("invalid pdu type");


### PR DESCRIPTION
Hello,

Looking for your feedback in adding some of the [user identity negotiation](https://dicom.nema.org/medical/dicom/current/output/chtml/part07/sect_D.3.3.7.html) options.

In order to keep this minimal, I added the entrypoint into retrieving this data into the existing AccessControl trait. The downside being that it breaks the interface.

Thanks