### PR TITLE
Add transcoder API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           cache: true
       # test project with default + extra features
-      - run: cargo test --features image,ndarray,sop-class,rle
+      - run: cargo test --features image,ndarray,sop-class,rle,cli
       # test dicom-pixeldata with gdcm-rs
       - run: cargo test -p dicom-pixeldata --features gdcm
       # test dicom-pixeldata without default features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "dicom-dictionary-std",
  "dicom-encoding",
  "dicom-object",
+ "dicom-pixeldata",
  "dicom-transfer-syntax-registry",
  "dicom-ul",
  "indicatif",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,33 +199,31 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5f1946157a96594eb2d2c10eb7ad9a2b27518cb3000209dec700c35df9197d"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78116e32a042dd73c2901f0dc30790d20ff3447f3e3472fad359e8c3d282bcd6"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "once_cell",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fd1a5729c4548118d7d70ff234a44868d00489a4b6597b0b020918a0e91a1a"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -525,6 +523,7 @@ name = "dicom-pixeldata"
 version = "0.2.0"
 dependencies = [
  "byteorder",
+ "clap",
  "dicom-core",
  "dicom-dictionary-std",
  "dicom-encoding",
@@ -539,6 +538,7 @@ dependencies = [
  "rstest",
  "snafu",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -10,6 +10,11 @@ categories = ["multimedia::images"]
 keywords = ["dicom"]
 readme = "README.md"
 
+[[bin]]
+name = "dicom-transcode"
+path = "src/bin/dicom-transcode.rs"
+required-features = ["cli"]
+
 [dependencies]
 dicom-object = { path = "../object", version = "0.6.1" }
 dicom-core = { path = "../core", version = "0.6.1" }
@@ -30,6 +35,15 @@ default-features = false
 features = ["jpeg", "png", "pnm", "tiff", "webp", "bmp", "openexr"]
 optional = true
 
+[dependencies.clap]
+version = "4.4.2"
+optional = true
+features = ["cargo", "derive"]
+
+[dependencies.tracing-subscriber]
+version = "0.3.17"
+optional = true
+
 [dev-dependencies]
 rstest = "0.18.1"
 dicom-test-files = "0.2.1"
@@ -43,6 +57,8 @@ image = ["dep:image"]
 native = ["dicom-transfer-syntax-registry/native"]
 gdcm = ["gdcm-rs"]
 rayon = ["dep:rayon", "image?/jpeg_rayon", "dicom-transfer-syntax-registry/rayon"]
+
+cli = ["dep:clap", "dep:tracing-subscriber"]
 
 [package.metadata.docs.rs]
 features = ["image", "ndarray"]

--- a/pixeldata/src/bin/dicom-transcode.rs
+++ b/pixeldata/src/bin/dicom-transcode.rs
@@ -1,0 +1,169 @@
+//! A CLI tool for transcoding a DICOM file
+//! to another transfer syntax.
+use clap::Parser;
+use dicom_dictionary_std::uids;
+use dicom_encoding::{TransferSyntaxIndex, TransferSyntax};
+use dicom_encoding::adapters::EncodeOptions;
+use dicom_object::open_file;
+use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
+use snafu::{Report, Whatever, OptionExt};
+use tracing::Level;
+use std::path::PathBuf;
+use dicom_pixeldata::Transcode;
+
+/// Exit code for when an error emerged while reading the DICOM file.
+const ERROR_READ: i32 = -2;
+/// Exit code for when an error emerged while transcoding the file.
+const ERROR_TRANSCODE: i32 = -3;
+/// Exit code for when an error emerged while writing the file.
+const ERROR_WRITE: i32 = -4;
+/// Exit code for when an error emerged while writing the file.
+const ERROR_OTHER: i32 = -128;
+
+/// Transcode a DICOM file
+#[derive(Debug, Parser)]
+#[command(version)]
+struct App {
+    file: PathBuf,
+    /// The output file (default is to change the extension to .new.dcm)
+    #[clap(short = 'o', long = "output")]
+    output: Option<PathBuf>,
+
+    /// The encoding quality (from 0 to 100)
+    #[clap(long = "quality")]
+    quality: Option<u8>,
+    /// The encoding effort (from 0 to 100)
+    #[clap(long = "effort")]
+    effort: Option<u8>,
+
+    /// Target transfer syntax
+    #[clap(flatten)]
+    target_ts: TargetTransferSyntax,
+
+    /// Verbose mode
+    #[clap(short = 'v', long = "verbose")]
+    verbose: bool,
+}
+
+/// Specifier for the target transfer syntax
+#[derive(Debug, Parser)]
+
+#[group(required = true, multiple = false)]
+struct TargetTransferSyntax {
+    /// Transcode to the Transfer Syntax indicated by UID
+    #[clap(long = "ts")]
+    ts: Option<String>,
+
+    /// Transcode to Explicit VR Little Endian
+    #[clap(long = "expl-vr-le")]
+    explicit_vr_le: bool,
+
+    /// Transcode to Implicit VR Little Endian
+    #[clap(long = "impl-vr-le")]
+    implicit_vr_le: bool,
+    
+    /// Transcode to JPEG baseline (8-bit)
+    #[clap(long = "jpeg-baseline")]
+    jpeg_baseline: bool,
+}
+
+impl TargetTransferSyntax {
+    fn resolve(&self) -> Result<&'static TransferSyntax, Whatever> {
+        
+        // explicit VR little endian
+        if self.explicit_vr_le {
+            return Ok(TransferSyntaxRegistry.get(uids::EXPLICIT_VR_LITTLE_ENDIAN)
+                .expect("Explicit VR Little Endian is missing???"));
+        }
+        
+        // implicit VR little endian
+        if self.implicit_vr_le {
+            return Ok(TransferSyntaxRegistry.get(uids::IMPLICIT_VR_LITTLE_ENDIAN)
+                .expect("Implicit VR Little Endian is missing???"));
+        }
+
+        // JPEG baseline
+        if self.jpeg_baseline {
+            return TransferSyntaxRegistry.get(uids::JPEG_BASELINE8_BIT)
+                .whatever_context("Missing specifier for JPEG Baseline (8-bit)");
+        }
+
+        // by TS UID
+        let Some(ts) = &self.ts else {
+            snafu::whatever!("No target transfer syntax specified");
+        };
+
+        TransferSyntaxRegistry.get(ts)
+            .whatever_context("Unknown transfer syntax")
+    }
+}
+
+
+fn main() {
+    run().unwrap_or_else(|e| {
+        eprintln!("{}", Report::from_error(e));
+        std::process::exit(ERROR_OTHER);
+    });
+}
+
+fn run() -> Result<(), Whatever> {
+    let App {
+        file,
+        output,
+        quality,
+        effort,
+        target_ts,
+        verbose,
+    } = App::parse();
+
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_max_level(if verbose { Level::DEBUG } else { Level::INFO })
+            .finish(),
+    )
+    .unwrap_or_else(|e| {
+        eprintln!("{}", snafu::Report::from_error(e));
+    });
+
+    let output = output.unwrap_or_else(|| {
+        let mut file = file.clone();
+        file.set_extension("new.dcm");
+        file
+    });
+
+    let mut obj = open_file(file).unwrap_or_else(|e| {
+        eprintln!("{}", Report::from_error(e));
+        std::process::exit(ERROR_READ);
+    });
+
+    // lookup transfer syntax
+    let ts = target_ts.resolve()?;
+
+    let mut options = EncodeOptions::default();
+    options.quality = quality;
+    options.effort = effort;
+
+    obj.transcode_with_options(ts, options).unwrap_or_else(|e| {
+        eprintln!("{}", Report::from_error(e));
+        std::process::exit(ERROR_TRANSCODE);
+    });
+
+    // write to file
+    obj.write_to_file(output).unwrap_or_else(|e| {
+        eprintln!("{}", Report::from_error(e));
+        std::process::exit(ERROR_WRITE);
+    });
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::App;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_cli() {
+        App::command().debug_assert();
+    }
+}

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -132,6 +132,7 @@ pub use ndarray;
 
 mod attribute;
 mod lut;
+mod transcode;
 
 pub mod encapsulation;
 pub(crate) mod transform;
@@ -139,6 +140,7 @@ pub(crate) mod transform;
 // re-exports
 pub use attribute::{PhotometricInterpretation, PixelRepresentation, PlanarConfiguration};
 pub use lut::{CreateLutError, Lut};
+pub use transcode::{Error as TranscodeError, Result as TranscodeResult, Transcode};
 pub use transform::{Rescale, VoiLutFunction, WindowLevel, WindowLevelTransform};
 
 #[cfg(feature = "gdcm")]

--- a/pixeldata/src/transcode.rs
+++ b/pixeldata/src/transcode.rs
@@ -419,6 +419,7 @@ mod tests {
 
 
     /// can transcode native multi-frame pixel data
+    #[cfg(feature = "native")]
     #[test]
     fn test_transcode_2frames_to_jpeg() {
         let test_file = dicom_test_files::path("pydicom/SC_rgb_2frame.dcm").unwrap();

--- a/pixeldata/src/transcode.rs
+++ b/pixeldata/src/transcode.rs
@@ -277,8 +277,11 @@ mod tests {
     use dicom_dictionary_std::uids;
     use dicom_object::open_file;
     use dicom_test_files;
-    use dicom_transfer_syntax_registry::entries::{JPEG_BASELINE, JPEG_EXTENDED};
+    use dicom_transfer_syntax_registry::entries::JPEG_EXTENDED;
+    #[cfg(feature = "native")]
+    use dicom_transfer_syntax_registry::entries::JPEG_BASELINE;
 
+    #[cfg(feature = "native")]
     #[test]
     fn test_transcode_from_jpeg_lossless_to_native_rgb() {
         let test_file = dicom_test_files::path("pydicom/SC_rgb_jpeg_gdcm.dcm").unwrap();
@@ -308,6 +311,7 @@ mod tests {
         assert_eq!(pixels.len(), rows * cols * spp);
     }
 
+    #[cfg(feature = "native")]
     #[test]
     fn test_transcode_from_native_to_jpeg_rgb() {
         let test_file = dicom_test_files::path("pydicom/SC_rgb.dcm").unwrap();
@@ -380,6 +384,7 @@ mod tests {
 
     }
 
+    #[cfg(feature = "native")]
     #[test]
     // Note: Test ignored until 12-bit JPEG decoding is supported
     #[ignore]
@@ -432,11 +437,13 @@ mod tests {
             let test_file = dicom_test_files::path("pydicom/JPEG-lossy.dcm").unwrap();
             let mut obj = open_file(test_file).unwrap();
 
+            assert_eq!(obj.meta().transfer_syntax(), uids::JPEG_EXTENDED12_BIT);
+
             // transcode to the same TS
             obj.transcode(&JPEG_EXTENDED.erased())
                 .expect("Should have transcoded successfully");
 
-            assert_eq!(obj.meta().transfer_syntax(), JPEG_EXTENDED.uid());
+            assert_eq!(obj.meta().transfer_syntax(), uids::JPEG_EXTENDED12_BIT);
             // pixel data is still encapsulated
             let fragments = obj.get(tags::PIXEL_DATA).unwrap().fragments().unwrap();
             assert_eq!(fragments.len(), 1);

--- a/pixeldata/src/transcode.rs
+++ b/pixeldata/src/transcode.rs
@@ -9,10 +9,10 @@ use snafu::{ensure, OptionExt, ResultExt, Snafu};
 
 use crate::PixelDecoder;
 
+/// An error occurred during the object transcoding process.
 #[derive(Debug, Snafu)]
 pub struct Error(InnerError);
 
-/// An error occurred during the object transcoding process.
 #[derive(Debug, Snafu)]
 pub(crate) enum InnerError {
     /// Unrecognized transfer syntax of receiving object ({ts})

--- a/pixeldata/src/transcode.rs
+++ b/pixeldata/src/transcode.rs
@@ -1,0 +1,194 @@
+use dicom_core::{
+    smallvec::smallvec, DataDictionary, DataElement, DicomValue, Length, PrimitiveValue, VR,
+};
+use dicom_dictionary_std::tags;
+use dicom_encoding::{adapters::EncodeOptions, Codec, TransferSyntax, TransferSyntaxIndex};
+use dicom_object::{mem::InMemFragment, FileDicomObject, InMemDicomObject};
+use dicom_transfer_syntax_registry::{entries::EXPLICIT_VR_LITTLE_ENDIAN, TransferSyntaxRegistry};
+use snafu::{ensure, OptionExt, ResultExt, Snafu};
+
+use crate::PixelDecoder;
+
+#[derive(Debug, Snafu)]
+pub struct Error(InnerError);
+
+/// An error occurred during the object transcoding process.
+#[derive(Debug, Snafu)]
+pub(crate) enum InnerError {
+    /// Unrecognized transfer syntax of receiving object ({ts})
+    UnknownSrcTransferSyntax { ts: String },
+
+    /// Unsupported target transfer syntax
+    UnsupportedTransferSyntax,
+
+    /// Could not decode pixel data of receiving object  
+    DecodePixelData { source: crate::Error },
+
+    /// Could not encode pixel data to target encoding
+    EncodePixelData {
+        source: dicom_encoding::adapters::EncodeError,
+    },
+
+    /// Unsupported bits per sample ({bits_allocated})
+    UnsupportedBitsAllocated { bits_allocated: u16 },
+
+    /// Encoding multi-frame objects is not implemented
+    MultiFrameEncodingNotImplemented,
+}
+
+/// Alias for the result of transcoding a DICOM object.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Interface for transcoding a DICOM object's pixel data
+/// to comply with a different transfer syntax.
+pub trait Transcode {
+    /// Convert the receiving object's transfer syntax
+    /// to the one specified in `ts`,
+    /// replacing one or more attributes to fit the intended transfer syntax,
+    /// including the meta group specifying the transfer syntax.
+    ///
+    /// If the receiving object's pixel data is encapsulated,
+    /// the object is first decoded into native pixel data.
+    /// In case of an encoding error,
+    /// the object may be left with this intermediate state.
+    fn transcode(&mut self, ts: &TransferSyntax) -> Result<()>;
+}
+
+impl<D> Transcode for FileDicomObject<InMemDicomObject<D>>
+where
+    D: Clone + DataDictionary,
+{
+    fn transcode(&mut self, ts: &TransferSyntax) -> Result<()> {
+        let current_ts_uid = &self.meta().transfer_syntax;
+        // do nothing if the transfer syntax already matches
+        if current_ts_uid == ts.uid() {
+            return Ok(());
+        }
+
+        // inspect current object TS
+        let current_ts = TransferSyntaxRegistry
+            .get(current_ts_uid)
+            .with_context(|| UnknownSrcTransferSyntaxSnafu {
+                ts: current_ts_uid.to_string(),
+            })?;
+
+        if ts.is_codec_free() {
+            if current_ts.is_codec_free() {
+                // no pixel data conversion is necessary:
+                // change transfer syntax and return
+                self.meta_mut().set_transfer_syntax(ts);
+                Ok(())
+            } else {
+                // decode pixel data
+                let decoded_pixeldata = self.decode_pixel_data().context(DecodePixelDataSnafu)?;
+
+                // apply change to pixel data attribute
+                match decoded_pixeldata.bits_allocated {
+                    8 => {
+                        // 8-bit samples
+                        let pixels = decoded_pixeldata.data().to_vec();
+                        self.put(DataElement::new_with_len(
+                            tags::PIXEL_DATA,
+                            VR::OW,
+                            Length::defined(pixels.len() as u32),
+                            PrimitiveValue::from(pixels),
+                        ));
+                    }
+                    16 => {
+                        // 16-bit samples
+                        let pixels = decoded_pixeldata.data_ow();
+                        self.put(DataElement::new_with_len(
+                            tags::PIXEL_DATA,
+                            VR::OW,
+                            Length::defined(pixels.len() as u32 * 2),
+                            PrimitiveValue::U16(pixels.into()),
+                        ));
+                    }
+                    _ => {
+                        return UnsupportedBitsAllocatedSnafu {
+                            bits_allocated: decoded_pixeldata.bits_allocated,
+                        }
+                        .fail()?
+                    }
+                };
+
+                // change transfer syntax and return
+                self.meta_mut().set_transfer_syntax(ts);
+                Ok(())
+            }
+        } else {
+            // must decode then encode
+            let adapter = match ts.codec() {
+                Codec::PixelData(adapter) => adapter,
+                Codec::EncapsulatedPixelData => return UnsupportedTransferSyntaxSnafu.fail()?,
+                Codec::None | Codec::Unsupported | Codec::Dataset(_) => {
+                    unreachable!("Unexpected codec from transfer syntax")
+                }
+            };
+
+            // decode pixel data
+            let decoded_pixeldata = self.decode_pixel_data().context(DecodePixelDataSnafu)?;
+            let bits_allocated = decoded_pixeldata.bits_allocated();
+            let number_of_frames = decoded_pixeldata.number_of_frames();
+
+            // note: there currently not a clear way
+            // to encode multiple fragments,
+            // so we stop if the image has more than one frame
+            ensure!(number_of_frames == 1, MultiFrameEncodingNotImplementedSnafu);
+
+            // apply change to pixel data attribute
+            match bits_allocated {
+                8 => {
+                    // 8-bit samples
+                    let pixels = decoded_pixeldata.data().to_vec();
+                    self.put(DataElement::new_with_len(
+                        tags::PIXEL_DATA,
+                        VR::OW,
+                        Length::defined(pixels.len() as u32),
+                        PrimitiveValue::from(pixels),
+                    ));
+                }
+                16 => {
+                    // 16-bit samples
+                    let pixels = decoded_pixeldata.data_ow();
+                    self.put(DataElement::new_with_len(
+                        tags::PIXEL_DATA,
+                        VR::OW,
+                        Length::defined(pixels.len() as u32 * 2),
+                        PrimitiveValue::U16(pixels.into()),
+                    ));
+                }
+                _ => return UnsupportedBitsAllocatedSnafu { bits_allocated }.fail()?,
+            };
+
+            // change transfer syntax to Explicit VR little endian
+            self.meta_mut()
+                .set_transfer_syntax(&EXPLICIT_VR_LITTLE_ENDIAN);
+
+            // use RWPixel adapter API
+            let mut pixeldata = Vec::new();
+            let options = EncodeOptions::new();
+            adapter
+                .encode(&*self, options, &mut pixeldata)
+                .context(EncodePixelDataSnafu)?;
+
+            // put everything in a single fragment
+            let pixel_seq = DicomValue::<InMemDicomObject<D>, InMemFragment>::PixelSequence {
+                offset_table: smallvec![],
+                fragments: smallvec![pixeldata],
+            };
+
+            self.put(DataElement::new_with_len(
+                tags::PIXEL_DATA,
+                VR::OB,
+                Length::UNDEFINED,
+                pixel_seq,
+            ));
+
+            // change transfer syntax
+            self.meta_mut().set_transfer_syntax(ts);
+
+            Ok(())
+        }
+    }
+}

--- a/pixeldata/src/transcode.rs
+++ b/pixeldata/src/transcode.rs
@@ -1,11 +1,20 @@
+//! DICOM Transcoder API
+//! 
+//! This module collects the pixel data decoding and encoding capabilities
+//! of `dicom_encoding` and `dicom_pixeldata`
+//! to offer a convenient API for converting DICOM objects
+//! to different transfer syntaxes.
+//! 
+//! See the [`Transcode`] trait for more information.
 use dicom_core::{
-    smallvec::smallvec, DataDictionary, DataElement, DicomValue, Length, PrimitiveValue, Tag, VR,
+    value::PixelFragmentSequence, DataDictionary, DataElement,
+    Length, PrimitiveValue, VR, ops::ApplyOp,
 };
 use dicom_dictionary_std::tags;
 use dicom_encoding::{adapters::EncodeOptions, Codec, TransferSyntax, TransferSyntaxIndex};
-use dicom_object::{mem::InMemFragment, FileDicomObject, InMemDicomObject};
+use dicom_object::{FileDicomObject, InMemDicomObject};
 use dicom_transfer_syntax_registry::{entries::EXPLICIT_VR_LITTLE_ENDIAN, TransferSyntaxRegistry};
-use snafu::{ensure, OptionExt, ResultExt, Snafu};
+use snafu::{OptionExt, ResultExt, Snafu};
 
 use crate::PixelDecoder;
 
@@ -21,11 +30,14 @@ pub(crate) enum InnerError {
     /// Unsupported target transfer syntax
     UnsupportedTransferSyntax,
 
+    /// Unsupported transcoding capability
+    UnsupportedTranscoding,
+
     /// Could not decode pixel data of receiving object  
     DecodePixelData { source: crate::Error },
 
     /// Could not read receiving object
-    ReadObject { source: dicom_object::Error },
+    ReadObject { source: dicom_object::ReadError },
 
     /// Could not encode pixel data to target encoding
     EncodePixelData {
@@ -44,24 +56,64 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Interface for transcoding a DICOM object's pixel data
 /// to comply with a different transfer syntax.
+/// Can be implemented by in-memory DICOM object representations
+/// as well as partial or lazy DICOM object readers,
+/// so that transcoding can be performed without loading the entire object.
+/// 
+/// # Example
+/// 
+/// A typical [file DICOM object in memory](FileDicomObject)
+/// can be transcoded inline using [`transcode`](Transcode::transcode).
+/// 
+/// ```no_run
+/// # use dicom_object::open_file;
+/// use dicom_pixeldata::Transcode as _;
+/// 
+/// let mut obj = dicom_object::open_file("image.dcm").unwrap();
+/// // convert to JPEG
+/// obj.transcode(&dicom_transfer_syntax_registry::entries::JPEG_BASELINE.erased())?;
+/// 
+/// // save transcoded version to file
+/// obj.write_to_file("image_jpg.dcm")?;
+/// 
+/// Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 pub trait Transcode {
     /// Convert the receiving object's transfer syntax
-    /// to the one specified in `ts`,
-    /// replacing one or more attributes to fit the intended transfer syntax,
+    /// to the one specified in `ts` according to the given encoding options.
+    /// 
+    /// This method may replace one or more attributes accordingly,
+    /// including the meta group specifying the transfer syntax.
+    /// The encoding options only apply if the pixel data needs to be re-encoded.
+    ///
+    /// If the receiving object's pixel data is encapsulated,
+    /// the object might be first decoded into native pixel data.
+    /// In case of an encoding error,
+    /// the object may be left in an intermediate state,
+    /// which should not be assumed to be consistent.
+    fn transcode_with_options(&mut self, ts: &TransferSyntax, options: EncodeOptions) -> Result<()>;
+
+    /// Convert the receiving object's transfer syntax
+    /// to the one specified in `ts`.
+    /// 
+    /// This method may replace one or more attributes accordingly,
     /// including the meta group specifying the transfer syntax.
     ///
     /// If the receiving object's pixel data is encapsulated,
-    /// the object is first decoded into native pixel data.
+    /// the object might be first decoded into native pixel data.
     /// In case of an encoding error,
-    /// the object may be left with this intermediate state.
-    fn transcode(&mut self, ts: &TransferSyntax) -> Result<()>;
+    /// the object may be left in an intermediate state,
+    /// which should not be assumed to be consistent.
+    fn transcode(&mut self, ts: &TransferSyntax) -> Result<()> {
+        self.transcode_with_options(ts, EncodeOptions::default())
+    }
 }
 
 impl<D> Transcode for FileDicomObject<InMemDicomObject<D>>
 where
     D: Clone + DataDictionary,
 {
-    fn transcode(&mut self, ts: &TransferSyntax) -> Result<()> {
+    fn transcode_with_options(&mut self, ts: &TransferSyntax, options: EncodeOptions) -> Result<()> {
         let current_ts_uid = &self.meta().transfer_syntax;
         // do nothing if the transfer syntax already matches
         if current_ts_uid == ts.uid() {
@@ -75,13 +127,14 @@ where
                 ts: current_ts_uid.to_string(),
             })?;
 
-        if ts.is_codec_free() {
-            if current_ts.is_codec_free() {
+        match (current_ts.is_codec_free(), ts.is_codec_free()) {
+            (true, true) => {
                 // no pixel data conversion is necessary:
                 // change transfer syntax and return
                 self.meta_mut().set_transfer_syntax(ts);
                 Ok(())
-            } else {
+            },
+            (false, true) => {
                 // decode pixel data
                 let decoded_pixeldata = self.decode_pixel_data().context(DecodePixelDataSnafu)?;
 
@@ -113,107 +166,108 @@ where
                         }
                         .fail()?
                     }
+                }
+
+                // update transfer syntax
+                self.meta_mut()
+                    .set_transfer_syntax(&ts);
+
+                Ok(())
+            },
+            (_, false) => {
+                // must decode then encode
+                let writer = match ts.codec() {
+                    Codec::EncapsulatedPixelData(_, Some(writer)) => writer,
+                    Codec::EncapsulatedPixelData(..) => {
+                        return UnsupportedTransferSyntaxSnafu.fail()?
+                    }
+                    Codec::Dataset(None) => return UnsupportedTransferSyntaxSnafu.fail()?,
+                    Codec::Dataset(Some(_)) => return UnsupportedTranscodingSnafu.fail()?,
+                    Codec::None => {
+                        // already tested in `is_codec_free`
+                        unreachable!("Unexpected codec from transfer syntax")
+                    }
                 };
 
-                // change transfer syntax and return
-                self.meta_mut().set_transfer_syntax(ts);
-                Ok(())
-            }
-        } else {
-            // must decode then encode
-            let adapter = match ts.codec() {
-                Codec::PixelData(adapter) => adapter,
-                Codec::EncapsulatedPixelData => return UnsupportedTransferSyntaxSnafu.fail()?,
-                Codec::None | Codec::Unsupported | Codec::Dataset(_) => {
-                    unreachable!("Unexpected codec from transfer syntax")
-                }
-            };
+                // decode pixel data
+                let decoded_pixeldata = self.decode_pixel_data().context(DecodePixelDataSnafu)?;
+                let bits_allocated = decoded_pixeldata.bits_allocated();
 
-            // decode pixel data
-            let decoded_pixeldata = self.decode_pixel_data().context(DecodePixelDataSnafu)?;
-            let bits_allocated = decoded_pixeldata.bits_allocated();
-            let number_of_frames = decoded_pixeldata.number_of_frames();
+                // apply change to pixel data attribute
+                match bits_allocated {
+                    8 => {
+                        // 8-bit samples
+                        let pixels = decoded_pixeldata.data().to_vec();
+                        self.put(DataElement::new_with_len(
+                            tags::PIXEL_DATA,
+                            VR::OW,
+                            Length::defined(pixels.len() as u32),
+                            PrimitiveValue::from(pixels),
+                        ));
+                    }
+                    16 => {
+                        // 16-bit samples
+                        let pixels = decoded_pixeldata.data_ow();
+                        self.put(DataElement::new_with_len(
+                            tags::PIXEL_DATA,
+                            VR::OW,
+                            Length::defined(pixels.len() as u32 * 2),
+                            PrimitiveValue::U16(pixels.into()),
+                        ));
+                    }
+                    _ => return UnsupportedBitsAllocatedSnafu { bits_allocated }.fail()?,
+                };
 
-            // note: there currently not a clear way
-            // to encode multiple fragments,
-            // so we stop if the image has more than one frame
-            ensure!(number_of_frames == 1, MultiFrameEncodingNotImplementedSnafu);
+                // change transfer syntax to Explicit VR little endian
+                self.meta_mut()
+                    .set_transfer_syntax(&EXPLICIT_VR_LITTLE_ENDIAN.erased());
 
-            // apply change to pixel data attribute
-            match bits_allocated {
-                8 => {
-                    // 8-bit samples
-                    let pixels = decoded_pixeldata.data().to_vec();
-                    self.put(DataElement::new_with_len(
-                        tags::PIXEL_DATA,
-                        VR::OW,
-                        Length::defined(pixels.len() as u32),
-                        PrimitiveValue::from(pixels),
-                    ));
-                }
-                16 => {
-                    // 16-bit samples
-                    let pixels = decoded_pixeldata.data_ow();
-                    self.put(DataElement::new_with_len(
-                        tags::PIXEL_DATA,
-                        VR::OW,
-                        Length::defined(pixels.len() as u32 * 2),
-                        PrimitiveValue::U16(pixels.into()),
-                    ));
-                }
-                _ => return UnsupportedBitsAllocatedSnafu { bits_allocated }.fail()?,
-            };
+                // use RWPixel adapter API
+                let mut offset_table = Vec::new();
+                let mut fragments = Vec::new();
 
-            // change transfer syntax to Explicit VR little endian
-            self.meta_mut()
-                .set_transfer_syntax(&EXPLICIT_VR_LITTLE_ENDIAN);
+                let ops = writer
+                    .encode(&*self, options, &mut fragments, &mut offset_table)
+                    .context(EncodePixelDataSnafu)?;
 
-            // use RWPixel adapter API
-            let mut pixeldata = Vec::new();
-            let options = EncodeOptions::new();
-            adapter
-                .encode(&*self, options, &mut pixeldata)
-                .context(EncodePixelDataSnafu)?;
+                let num_frames = offset_table.len();
+                let total_pixeldata_len: u64 = fragments.iter().map(|f| f.len() as u64).sum();
 
-            let total_pixeldata_len = pixeldata.len() as u64;
+                self.put(DataElement::new_with_len(
+                    tags::PIXEL_DATA,
+                    VR::OB,
+                    Length::UNDEFINED,
+                    PixelFragmentSequence::new(offset_table, fragments),
+                ));
 
-            // put everything in a single fragment
-            let pixel_seq = DicomValue::<InMemDicomObject<D>, InMemFragment>::PixelSequence {
-                offset_table: smallvec![],
-                fragments: smallvec![pixeldata],
-            };
-
-            self.put(DataElement::new_with_len(
-                tags::PIXEL_DATA,
-                VR::OB,
-                Length::UNDEFINED,
-                pixel_seq,
-            ));
-
-            self.put(DataElement::new(
-                tags::NUMBER_OF_FRAMES,
-                VR::IS,
-                PrimitiveValue::from("1"),
-            ));
-
-            // replace Encapsulated Pixel Data Value Total Length
-            // if it is present
-            if self
-                .element_opt(Tag(0x7FE0, 0x0003))
-                .context(ReadObjectSnafu)?
-                .is_some()
-            {
                 self.put(DataElement::new(
-                    Tag(0x7FE0, 0x0003),
+                    tags::NUMBER_OF_FRAMES,
+                    VR::IS,
+                    num_frames.to_string(),
+                ));
+
+                // provide Encapsulated Pixel Data Value Total Length
+                self.put(DataElement::new(
+                    tags::ENCAPSULATED_PIXEL_DATA_VALUE_TOTAL_LENGTH,
                     VR::UV,
                     PrimitiveValue::from(total_pixeldata_len),
                 ));
+
+                // try to apply operations
+                for (n, op) in ops.into_iter().enumerate() {
+                    match self.apply(op) {
+                        Ok(_) => (),
+                        Err(e) => {
+                            tracing::warn!("Could not apply transcoding step #{}: {}", n, e)
+                        }
+                    }
+                }
+
+                // change transfer syntax
+                self.meta_mut().set_transfer_syntax(ts);
+
+                Ok(())
             }
-
-            // change transfer syntax
-            self.meta_mut().set_transfer_syntax(ts);
-
-            Ok(())
         }
     }
 }
@@ -221,23 +275,25 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dicom_dictionary_std::uids;
     use dicom_object::open_file;
     use dicom_test_files;
+    use dicom_transfer_syntax_registry::entries::{JPEG_BASELINE, JPEG_EXTENDED};
 
     #[test]
-    fn test_transcode_from_jpeg_to_native_rgb() {
+    fn test_transcode_from_jpeg_lossless_to_native_rgb() {
         let test_file = dicom_test_files::path("pydicom/SC_rgb_jpeg_gdcm.dcm").unwrap();
         let mut obj = open_file(test_file).unwrap();
 
         // pre-condition check: pixel data conversion is needed here
-        assert_ne!(&obj.meta().transfer_syntax, EXPLICIT_VR_LITTLE_ENDIAN.uid());
+        assert_eq!(&obj.meta().transfer_syntax, uids::JPEG_LOSSLESS_SV1);
 
         // transcode to explicit VR little endian
         obj.transcode(&EXPLICIT_VR_LITTLE_ENDIAN.erased())
             .expect("Should have transcoded successfully");
 
         // check transfer syntax
-        assert_eq!(&obj.meta().transfer_syntax, EXPLICIT_VR_LITTLE_ENDIAN.uid());
+        assert_eq!(obj.meta().transfer_syntax(), EXPLICIT_VR_LITTLE_ENDIAN.uid());
 
         // check that the pixel data is in its native form
         // and has the expected size
@@ -254,14 +310,86 @@ mod tests {
     }
 
     #[test]
-    // Test ignored until 12-bit JPEG decoding is supported
+    fn test_transcode_from_native_to_jpeg_rgb() {
+        let test_file = dicom_test_files::path("pydicom/SC_rgb.dcm").unwrap();
+        let mut obj = open_file(&test_file).unwrap();
+
+        // pre-condition check: pixel data is native
+        assert_eq!(obj.meta().transfer_syntax(), uids::EXPLICIT_VR_LITTLE_ENDIAN);
+
+        // transcode to JPEG baseline
+        obj.transcode(&JPEG_BASELINE.erased())
+            .expect("Should have transcoded successfully");
+
+        // check transfer syntax
+        assert_eq!(obj.meta().transfer_syntax(), JPEG_BASELINE.uid());
+
+        // check that the pixel data is encapsulated
+        // and has the expected number of fragments
+        let pixel_data = obj.get(tags::PIXEL_DATA).unwrap();
+        let fragments = pixel_data
+            .fragments()
+            .expect("Pixel Data should be in encapsulated fragments");
+
+        // one frame, one fragment (as required by JPEG baseline)
+        assert_eq!(fragments.len(), 1);
+
+        // check that the fragment data is in valid JPEG (magic code)
+        let fragment = &fragments[0];
+        assert!(fragment.len() > 4);
+        assert_eq!(&fragment[0..2], &[0xFF, 0xD8]);
+
+        let size_1 = fragment.len();
+
+        // re-encode with different options
+
+        let mut obj = open_file(test_file).unwrap();
+
+        // pre-condition check: pixel data is native
+        assert_eq!(obj.meta().transfer_syntax(), uids::EXPLICIT_VR_LITTLE_ENDIAN);
+
+        // transcode to JPEG baseline
+        let mut options = EncodeOptions::new();
+        // low quality
+        options.quality = Some(50);
+        obj.transcode_with_options(&JPEG_BASELINE.erased(), options)
+            .expect("Should have transcoded successfully");
+
+        // check transfer syntax
+        assert_eq!(obj.meta().transfer_syntax(), JPEG_BASELINE.uid());
+
+        // check that the pixel data is encapsulated
+        // and has the expected number of fragments
+        let pixel_data = obj.get(tags::PIXEL_DATA).unwrap();
+        let fragments = pixel_data
+            .fragments()
+            .expect("Pixel Data should be in encapsulated fragments");
+
+        // one frame, one fragment (as required by JPEG baseline)
+        assert_eq!(fragments.len(), 1);
+
+        // check that the fragment data is in valid JPEG (magic code)
+        let fragment = &fragments[0];
+        assert!(fragment.len() > 4);
+        assert_eq!(&fragment[0..2], &[0xFF, 0xD8]);
+
+        let size_2 = fragment.len();
+
+        // the size of the second fragment should be smaller
+        // due to lower quality
+        assert!(size_2 < size_1, "expected smaller size for lower quality, but {} => {}", size_2, size_1);
+
+    }
+
+    #[test]
+    // Note: Test ignored until 12-bit JPEG decoding is supported
     #[ignore]
     fn test_transcode_from_jpeg_to_native_16bit() {
         let test_file = dicom_test_files::path("pydicom/JPEG-lossy.dcm").unwrap();
         let mut obj = open_file(test_file).unwrap();
 
         // pre-condition check: pixel data conversion is needed here
-        assert_ne!(&obj.meta().transfer_syntax, EXPLICIT_VR_LITTLE_ENDIAN.uid());
+        assert_eq!(&obj.meta().transfer_syntax, uids::JPEG_EXTENDED12_BIT);
 
         // transcode to explicit VR little endian
         obj.transcode(&EXPLICIT_VR_LITTLE_ENDIAN.erased())
@@ -283,5 +411,36 @@ mod tests {
         let bps = 2;
 
         assert_eq!(pixels.len(), rows * cols * spp * bps);
+    }
+
+    /// if the transfer syntax is the same, no transcoding should be performed
+    #[test]
+    fn test_no_transcoding_needed() {
+        {
+            let test_file = dicom_test_files::path("pydicom/SC_rgb.dcm").unwrap();
+            let mut obj = open_file(test_file).unwrap();
+
+            // transcode to the same TS
+            obj.transcode(&EXPLICIT_VR_LITTLE_ENDIAN.erased())
+                .expect("Should have transcoded successfully");
+
+            assert_eq!(obj.meta().transfer_syntax(), EXPLICIT_VR_LITTLE_ENDIAN.uid());
+            // pixel data is still native
+            let pixel_data = obj.get(tags::PIXEL_DATA).unwrap().to_bytes().unwrap();
+            assert_eq!(pixel_data.len(), 100 * 100 * 3);
+        }
+        {
+            let test_file = dicom_test_files::path("pydicom/JPEG-lossy.dcm").unwrap();
+            let mut obj = open_file(test_file).unwrap();
+
+            // transcode to the same TS
+            obj.transcode(&JPEG_EXTENDED.erased())
+                .expect("Should have transcoded successfully");
+
+            assert_eq!(obj.meta().transfer_syntax(), JPEG_EXTENDED.uid());
+            // pixel data is still encapsulated
+            let fragments = obj.get(tags::PIXEL_DATA).unwrap().fragments().unwrap();
+            assert_eq!(fragments.len(), 1);
+        }
     }
 }

--- a/pixeldata/src/transcode.rs
+++ b/pixeldata/src/transcode.rs
@@ -75,8 +75,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// 
 /// // save transcoded version to file
 /// obj.write_to_file("image_jpg.dcm")?;
-/// 
-/// Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub trait Transcode {
     /// Convert the receiving object's transfer syntax

--- a/storescu/Cargo.toml
+++ b/storescu/Cargo.toml
@@ -10,14 +10,20 @@ categories = ["command-line-utilities"]
 keywords = ["dicom"]
 readme = "README.md"
 
+[features]
+default = ["transcode"]
+# support DICOM transcoding
+transcode = ["dep:dicom-pixeldata"]
+
 [dependencies]
 clap = { version  = "4.0.18", features = ["derive"] }
 dicom-core = { path = '../core', version = "0.6.1" }
-dicom-ul = { path = '../ul', version = "0.5.0" }
-dicom-object = { path = '../object', version = "0.6.1" }
-dicom-encoding = { path = "../encoding/", version = "0.6.0" }
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.6.0" }
+dicom-encoding = { path = "../encoding/", version = "0.6.0" }
+dicom-object = { path = '../object', version = "0.6.1" }
+dicom-pixeldata = { version = "0.2.0", path = "../pixeldata", optional = true }
 dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.6.0" }
+dicom-ul = { path = '../ul', version = "0.5.0" }
 walkdir = "2.3.2"
 indicatif = "0.17.0"
 tracing = "0.1.34"


### PR DESCRIPTION
This is revision 1 of the new transcoding API and CLI, a convenient trait for converting an object to another transfer syntax.

### Summary

- add `dicom_pixeldata::transcode` module, contains `Transcode` trait and transcoder error type
- add some module-level test coverage for transcode
- Adjust transcoder module according to changes in v0.6
- ~~[encoding] Fix default impl of `PixelDataWriter::encode` so that it doesn't throw an error on missing _Number of Frames_~~ (already done in #414)
- [ts-registry] Fix JPEG adapter's handling of native pixel data
- [ts-registry] Implement narrowing of high depth pixel data to 8 bits
   - Results are a bit better, although they may be off the expected value range. Better check first whether transcoding to JPEG baseline really suits your use case.
- Add binary package `dicom-transcode`, a CLI tool for transcoding DICOM files.
