### PR TITLE
Implement truncating DICOM values

### DIFF
--- a/core/src/ops.rs
+++ b/core/src/ops.rs
@@ -609,6 +609,21 @@ pub enum AttributeAction {
     /// Append a 64-bit floating point number as an additional numeric value,
     /// creating the attribute if it does not exist yet.
     PushF64(f64),
+    /// Truncate a value or a sequence to the given number of items,
+    /// removing extraneous items from the end of the list.
+    /// 
+    /// On primitive values, this truncates the value
+    /// by the number of individual value items
+    /// (note that bytes in a [`PrimitiveValue::U8`]
+    /// are treated as individual items).
+    /// On data set sequences and pixel data fragment sequences,
+    /// this operation is applied to
+    /// the data set items (or fragments) in the sequence.
+    /// 
+    /// Does nothing if the attribute does not exist
+    /// or the cardinality of the element is already lower than or equal to
+    /// the given size.
+    Truncate(usize),
 }
 
 impl AttributeAction {

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -249,6 +249,27 @@ impl<I, P> Value<I, P> {
             _ => None,
         }
     }
+
+    /// Shorten this value by removing trailing elements
+    /// to fit the given limit.
+    /// 
+    /// On primitive values,
+    /// elements are counted by the number of individual value items
+    /// (note that bytes in a [`PrimitiveValue::U8`]
+    /// are treated as individual items).
+    /// On data set sequences and pixel data fragment sequences,
+    /// this operation is applied to
+    /// the data set items (or fragments) in the sequence.
+    ///
+    /// Nothing is done if the value's cardinality
+    /// is already lower than or equal to the limit.
+    pub fn truncate(&mut self, limit: usize) {
+        match self {
+            Value::Primitive(v) => v.truncate(limit),
+            Value::Sequence(v) => v.truncate(limit),
+            Value::PixelSequence(v) => v.truncate(limit),
+        }
+    }
 }
 
 impl<I, P> From<&str> for Value<I, P> {
@@ -839,6 +860,13 @@ impl<I> DataSetSequence<I> {
     pub fn length(&self) -> Length {
         HasLength::length(self)
     }
+
+    /// Shorten this sequence by removing trailing data set items
+    /// to fit the given limit.
+    #[inline]
+    pub fn truncate(&mut self, limit: usize) {
+        self.items.truncate(limit);
+    }
 }
 
 impl<I> HasLength for DataSetSequence<I> {
@@ -1011,6 +1039,15 @@ impl<P> PixelFragmentSequence<P> {
     #[inline]
     pub fn length(&self) -> Length {
         HasLength::length(self)
+    }
+
+    /// Shorten this sequence by removing trailing fragments
+    /// to fit the given limit.
+    /// 
+    /// Note that this operations does not affect the basic offset table.
+    #[inline]
+    pub fn truncate(&mut self, limit: usize) {
+        self.fragments.truncate(limit);
     }
 }
 

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -4095,6 +4095,50 @@ impl PrimitiveValue {
             .build()),
         }
     }
+
+    /// Shorten this value by removing trailing elements
+    /// to fit the given limit.
+    /// 
+    /// Elements are counted by the number of individual value items
+    /// (note that bytes in a [`PrimitiveValue::U8`]
+    /// are treated as individual items).
+    ///
+    /// Nothing is done if the value's cardinality
+    /// is already lower than or equal to the limit.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dicom_core::dicom_value;
+    /// # use dicom_core::value::PrimitiveValue;
+    /// let mut value = dicom_value!(I32, [1, 2, 5]);
+    /// value.truncate(2);
+    /// assert_eq!(value.to_multi_int::<i32>()?, vec![1, 2]);
+    ///
+    /// value.truncate(0);
+    /// assert_eq!(value.multiplicity(), 0);
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn truncate(&mut self, limit: usize) {
+        match self {
+            PrimitiveValue::Empty |
+            PrimitiveValue::Str(_) => { /* no-op */ },
+            PrimitiveValue::Strs(l) => l.truncate(limit),
+            PrimitiveValue::Tags(l) => l.truncate(limit),
+            PrimitiveValue::U8(l) => l.truncate(limit),
+            PrimitiveValue::I16(l) => l.truncate(limit),
+            PrimitiveValue::U16(l) => l.truncate(limit),
+            PrimitiveValue::I32(l) => l.truncate(limit),
+            PrimitiveValue::U32(l) => l.truncate(limit),
+            PrimitiveValue::I64(l) => l.truncate(limit),
+            PrimitiveValue::U64(l) => l.truncate(limit),
+            PrimitiveValue::F32(l) => l.truncate(limit),
+            PrimitiveValue::F64(l) => l.truncate(limit),
+            PrimitiveValue::Date(l) => l.truncate(limit),
+            PrimitiveValue::DateTime(l) => l.truncate(limit),
+            PrimitiveValue::Time(l) => l.truncate(limit),
+        }
+    }
 }
 
 /// The output of this method is equivalent to calling the method `to_str`

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -285,9 +285,13 @@ impl FileMetaTable {
             tags::PRIVATE_INFORMATION_CREATOR_UID => {
                 Self::apply_optional_string(op, &mut self.private_information_creator_uid)
             }
-            _ if matches!(op.action, AttributeAction::Remove | AttributeAction::Empty) => {
+            _ if matches!(
+                op.action,
+                AttributeAction::Remove | AttributeAction::Empty | AttributeAction::Truncate(_)
+            ) =>
+            {
                 // any other attribute is not supported
-                // (ignore Remove and Empty)
+                // (ignore Remove, Empty, Truncate)
                 Ok(())
             }
             _ => UnsupportedAttributeSnafu.fail(),
@@ -301,7 +305,7 @@ impl FileMetaTable {
     fn apply_required_string(op: AttributeOp, target_attribute: &mut String) -> ApplyResult {
         match op.action {
             AttributeAction::Remove | AttributeAction::Empty => MandatorySnafu.fail(),
-            AttributeAction::SetVr(_) => {
+            AttributeAction::SetVr(_) | AttributeAction::Truncate(_) => {
                 // ignore
                 Ok(())
             }


### PR DESCRIPTION
This PR implements operations to truncate DICOM values. On primitive values, this shortens the list of primitive elements in the DICOM value to a given limit. On data set sequences and pixel fragment sequences, this shortens the list of items in the sequence.

This includes methods and a new action for the attribute operations API.

### Summary

- [core] Add `truncate` methods to value types
- [core][object] Add `AttributeAction::Truncate`

