### PR TITLE
Add DecodedPixelData::to_owned and Clone for DecodedPixelData 

### DIFF
--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1503,7 +1503,7 @@ impl DecodedPixelData<'_> {
     /// ```no_run
     /// # use dicom_object::open_file;
     /// # use dicom_pixeldata::{DecodedPixelData, PixelDecoder};
-    # type Error = Box<dyn std::error::Error>;
+    /// # type Error = Box<dyn std::error::Error>;
     /// fn get_pixeldata_only(path: &str) -> Result<DecodedPixelData<'static>, Error> {
     ///     let obj = open_file(path)?;
     ///     let pixeldata = obj.decode_pixel_data()?;

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1503,7 +1503,8 @@ impl DecodedPixelData<'_> {
     /// ```no_run
     /// # use dicom_object::open_file;
     /// # use dicom_pixeldata::{DecodedPixelData, PixelDecoder};
-    /// fn get_pixeldata_only(path: &str) -> Result<DecodedPixelData<'static>, Box<dyn std::error::Error>> {
+    # type Error = Box<dyn std::error::Error>;
+    /// fn get_pixeldata_only(path: &str) -> Result<DecodedPixelData<'static>, Error> {
     ///     let obj = open_file(path)?;
     ///     let pixeldata = obj.decode_pixel_data()?;
     ///     // can freely return from function

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1489,6 +1489,46 @@ impl DecodedPixelData<'_> {
             .context(InvalidShapeSnafu)
             .map_err(Error::from)
     }
+
+    /// Make the decoded pixel data
+    /// independent from the original DICOM object,
+    /// by making copies of any necessary data.
+    /// 
+    /// This is useful when you only need the imaging data,
+    /// or when you want a composition of the object and decoded pixel data
+    /// within the same value type.
+    ///
+    /// # Example
+    /// 
+    /// ```no_run
+    /// # use dicom_object::open_file;
+    /// # use dicom_pixeldata::{DecodedPixelData, PixelDecoder};
+    /// fn get_pixeldata_only(path: &str) -> Result<DecodedPixelData<'static>, Box<dyn std::error::Error>> {
+    ///     let obj = open_file(path)?;
+    ///     let pixeldata = obj.decode_pixel_data()?;
+    ///     // can freely return from function
+    ///     Ok(pixeldata.to_owned())
+    /// }
+    /// ```
+    pub fn to_owned(&self) -> DecodedPixelData<'static> {
+        DecodedPixelData {
+            data: Cow::Owned(self.data.to_vec()),
+            bits_allocated: self.bits_allocated,
+            bits_stored: self.bits_stored,
+            high_bit: self.high_bit,
+            pixel_representation: self.pixel_representation,
+            photometric_interpretation: self.photometric_interpretation.clone(),
+            planar_configuration: self.planar_configuration,
+            number_of_frames: self.number_of_frames,
+            rows: self.rows,
+            cols: self.cols,
+            samples_per_pixel: self.samples_per_pixel,
+            rescale_intercept: self.rescale_intercept,
+            rescale_slope: self.rescale_slope,
+            voi_lut_function: self.voi_lut_function,
+            window: self.window,
+        }
+    }
 }
 
 fn bytes_to_vec_u16(data: &[u8]) -> Vec<u16> {

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1490,8 +1490,8 @@ impl DecodedPixelData<'_> {
             .map_err(Error::from)
     }
 
-    /// Make the decoded pixel data
-    /// independent from the original DICOM object,
+    /// Obtain a version of the decoded pixel data
+    /// that is independent from the original DICOM object,
     /// by making copies of any necessary data.
     /// 
     /// This is useful when you only need the imaging data,

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -375,7 +375,7 @@ pub enum BitDepthOption {
 /// can be specified through one of the various `to_*` methods,
 /// such as [`to_dynamic_image`](Self::to_dynamic_image)
 /// and [`to_vec`](Self::to_vec).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DecodedPixelData<'a> {
     /// the raw bytes of pixel data
     data: Cow<'a, [u8]>,


### PR DESCRIPTION
This makes decoded pixel data easier to work with, as it enables the easy decoupling from the original DICOM object.

### Summary

- [pixeldata] Add `DecodedPixelData::to_owned`
- [pixeldata] derive `Clone` for `DecodedPixelData`
