### PR TITLE
Decode a single frame via object pixel data decoding API

### DIFF
--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -2,7 +2,7 @@
 
 use dicom_core::{DataDictionary, Tag};
 use dicom_dictionary_std::tags;
-use dicom_object::{mem::InMemElement, FileDicomObject, InMemDicomObject};
+use dicom_object::{FileDicomObject, InMemDicomObject};
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 use std::fmt;
 
@@ -140,16 +140,6 @@ pub fn high_bit<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> Result<u16> {
     retrieve_required_u16(obj, tags::HIGH_BIT, AttributeName::HighBit)
-}
-
-/// Get the PixelData element from the DICOM object
-pub fn pixel_data<D: DataDictionary + Clone>(
-    obj: &FileDicomObject<InMemDicomObject<D>>,
-) -> Result<&InMemElement<D>> {
-    let name = AttributeName::PixelData;
-    obj.element_opt(tags::PIXEL_DATA)
-        .context(RetrieveSnafu { name })?
-        .context(MissingRequiredSnafu { name })
 }
 
 /// Get the RescaleIntercept from the DICOM object or returns 0

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -2,7 +2,7 @@
 
 use dicom_core::{DataDictionary, Tag};
 use dicom_dictionary_std::tags;
-use dicom_object::{FileDicomObject, InMemDicomObject};
+use dicom_object::{mem::InMemElement, FileDicomObject, InMemDicomObject};
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 use std::fmt;
 
@@ -140,6 +140,16 @@ pub fn high_bit<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> Result<u16> {
     retrieve_required_u16(obj, tags::HIGH_BIT, AttributeName::HighBit)
+}
+
+/// Get the PixelData element from the DICOM object
+pub fn pixel_data<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<&InMemElement<D>> {
+    let name = AttributeName::PixelData;
+    obj.element_opt(tags::PIXEL_DATA)
+        .context(RetrieveSnafu { name })?
+        .context(MissingRequiredSnafu { name })
 }
 
 /// Get the RescaleIntercept from the DICOM object or returns 0

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -16,8 +16,10 @@ where
 {
     fn decode_pixel_data(&self) -> Result<DecodedPixelData> {
         use super::attribute::*;
+        use dicom_dictionary_std::tags;
 
-        let pixel_data = pixel_data(self).context(GetAttributeSnafu)?;
+        let pixel_data = self.get(tags::PIXEL_DATA).context(NoPixelDataSnafu)?;
+        
         let cols = cols(self).context(GetAttributeSnafu)?;
         let rows = rows(self).context(GetAttributeSnafu)?;
 
@@ -212,6 +214,37 @@ mod tests {
             ));
             image.save(image_path).unwrap();
         }
+    }
+
+    #[cfg(feature = "image")]
+    #[rstest]
+    #[case("pydicom/color3d_jpeg_baseline.dcm", 0)]
+    #[case("pydicom/color3d_jpeg_baseline.dcm", 1)]
+    #[case("pydicom/color3d_jpeg_baseline.dcm", 78)]
+    #[case("pydicom/color3d_jpeg_baseline.dcm", 119)]
+    #[case("pydicom/SC_rgb_rle_2frame.dcm", 0)]
+    #[case("pydicom/SC_rgb_rle_2frame.dcm", 1)]
+    #[case("pydicom/JPEG2000.dcm", 0)]
+    #[case("pydicom/JPEG2000_UNC.dcm", 0)]
+   fn test_parse_dicom_pixel_data_individual_frames(#[case] value: &str, #[case] frame: u32) {
+        let test_file = dicom_test_files::path(value).unwrap();
+        println!("Parsing pixel data for {}", test_file.display());
+        let obj = open_file(test_file).unwrap();
+        let pixel_data = obj.decode_pixel_data_frame(frame).unwrap();
+        let output_dir = Path::new(
+            "../target/dicom_test_files/_out/test_gdcm_parse_dicom_pixel_data_individual_frames",
+        );
+        std::fs::create_dir_all(output_dir).unwrap();
+
+        assert_eq!(pixel_data.number_of_frames(), 1);
+
+        let image = pixel_data.to_dynamic_image(0).unwrap();
+        let image_path = output_dir.join(format!(
+            "{}-{}.png",
+            Path::new(value).file_stem().unwrap().to_str().unwrap(),
+            frame,
+        ));
+        image.save(image_path).unwrap();
     }
 
     #[cfg(feature = "ndarray")]

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -16,9 +16,8 @@ where
 {
     fn decode_pixel_data(&self) -> Result<DecodedPixelData> {
         use super::attribute::*;
-        use dicom_dictionary_std::tags;
 
-        let pixel_data = self.get(tags::PIXEL_DATA).context(NoPixelDataSnafu)?;
+        let pixel_data = pixel_data(self).context(GetAttributeSnafu)?;
         
         let cols = cols(self).context(GetAttributeSnafu)?;
         let rows = rows(self).context(GetAttributeSnafu)?;

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -151,11 +151,6 @@ pub struct Error(InnerError);
 /// Inner error type
 #[derive(Debug, Snafu)]
 pub enum InnerError {
-    #[snafu(display("Object has no Pixel Data"))]
-    NoPixelData {
-        backtrace: Backtrace,
-    },
-
     #[snafu(display("Failed to get required DICOM attribute"))]
     GetAttribute {
         #[snafu(backtrace)]
@@ -1769,9 +1764,7 @@ where
     D: DataDictionary + Clone,
 {
     fn decode_pixel_data(&self) -> Result<DecodedPixelData> {
-        use dicom_dictionary_std::tags;
-
-        let pixel_data = self.get(tags::PIXEL_DATA).context(NoPixelDataSnafu)?;
+        let pixel_data = attribute::pixel_data(self).context(GetAttributeSnafu)?;
 
         let ImagingProperties {
             cols,
@@ -1871,9 +1864,7 @@ where
     }
 
     fn decode_pixel_data_frame(&self, frame: u32) -> Result<DecodedPixelData<'_>> {
-        use dicom_dictionary_std::tags;
-
-        let pixel_data = self.get(tags::PIXEL_DATA).context(NoPixelDataSnafu)?;
+        let pixel_data = attribute::pixel_data(self).context(GetAttributeSnafu)?;
 
         let ImagingProperties {
             cols,

--- a/toimage/src/main.rs
+++ b/toimage/src/main.rs
@@ -246,12 +246,21 @@ fn run(args: App) -> Result<(), Error> {
                 let frame_size = rows * columns * samples_per_pixel * ((bits_allocated + 7) / 8);
 
                 let frame = frame_number as usize;
-                Cow::Owned(
-                    v.to_bytes()
-                        .get((frame_size * frame)..(frame_size * (frame + 1)))
-                        .context(FrameOutOfBoundsSnafu { frame_number })?
-                        .to_vec(),
-                )
+                let mut data = v.to_bytes();
+                match &mut data {
+                    Cow::Borrowed(data) => {
+                        *data = data
+                            .get((frame_size * frame)..(frame_size * (frame + 1)))
+                            .context(FrameOutOfBoundsSnafu { frame_number })?;
+                    }
+                    Cow::Owned(data) => {
+                        *data = data
+                            .get((frame_size * frame)..(frame_size * (frame + 1)))
+                            .context(FrameOutOfBoundsSnafu { frame_number })?
+                            .to_vec();
+                    }
+                }
+                data
             }
             _ => {
                 return UnexpectedPixelDataSnafu.fail();
@@ -289,7 +298,7 @@ fn run(args: App) -> Result<(), Error> {
         }
 
         let image = pixel
-            .to_dynamic_image_with_options(frame_number, &options)
+            .to_dynamic_image_with_options(0, &options)
             .context(ConvertImageSnafu)?;
 
         image.save(&output).context(SaveImageSnafu)?;

--- a/toimage/src/main.rs
+++ b/toimage/src/main.rs
@@ -266,7 +266,9 @@ fn run(args: App) -> Result<(), Error> {
             path
         });
 
-        let pixel = obj.decode_pixel_data().context(DecodePixelDataSnafu)?;
+        let pixel = obj
+            .decode_pixel_data_frame(frame_number)
+            .context(DecodePixelDataSnafu)?;
 
         if verbose {
             println!(


### PR DESCRIPTION
Although it was possible to retrieve a single frame from a blob of decoded pixel data, the API provided by `PixelDecoder` required the user to decode all of the frames first.
This PR extends this trait for the possibility to decode only one of the frames in a DICOM object. `dicom-toimage` has also been optimized by using it.