### PR TITLE
Decode single frame using GDCM

### DIFF
--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -36,11 +36,11 @@ where
         let transfer_syntax = &self.meta().transfer_syntax;
         let registry =
             TransferSyntaxRegistry
-                .get(&&transfer_syntax)
+                .get(transfer_syntax)
                 .context(UnknownTransferSyntaxSnafu {
                     ts_uid: transfer_syntax,
                 })?;
-        let ts_type = GDCMTransferSyntax::from_str(&registry.uid()).map_err(|_| {
+        let ts_type = GDCMTransferSyntax::from_str(registry.uid()).map_err(|_| {
             UnsupportedTransferSyntaxSnafu {
                 ts: transfer_syntax.clone(),
             }
@@ -67,7 +67,7 @@ where
                 };
                 if fragments.len() > 1 {
                     // Bundle fragments and decode multi-frame dicoms
-                    let dims = [cols.into(), rows.into(), number_of_frames.into()];
+                    let dims = [cols.into(), rows.into(), number_of_frames];
                     let fragments: Vec<_> = fragments.iter().map(|frag| frag.as_slice()).collect();
                     decode_multi_frame_compressed(
                         fragments.as_slice(),

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -25,13 +25,16 @@ where
 
         let photometric_interpretation =
             photometric_interpretation(self).context(GetAttributeSnafu)?;
-        let pi_type = GDCMPhotometricInterpretation::from_str(photometric_interpretation.as_str())
-            .map_err(|_| {
-                UnsupportedPhotometricInterpretationSnafu {
-                    pi: photometric_interpretation.clone(),
-                }
-                .build()
-            })?;
+        let pi_type = match photometric_interpretation {
+            PhotometricInterpretation::PaletteColor => GDCMPhotometricInterpretation::PALETTE_COLOR,
+            _ => GDCMPhotometricInterpretation::from_str(photometric_interpretation.as_str())
+                .map_err(|_| {
+                    UnsupportedPhotometricInterpretationSnafu {
+                        pi: photometric_interpretation.clone(),
+                    }
+                    .build()
+                })?,
+        };
 
         let transfer_syntax = &self.meta().transfer_syntax;
         let registry =
@@ -156,13 +159,16 @@ where
 
         let photometric_interpretation =
             photometric_interpretation(self).context(GetAttributeSnafu)?;
-        let pi_type = GDCMPhotometricInterpretation::from_str(photometric_interpretation.as_str())
-            .map_err(|_| {
-                UnsupportedPhotometricInterpretationSnafu {
-                    pi: photometric_interpretation.clone(),
-                }
-                .build()
-            })?;
+        let pi_type = match photometric_interpretation {
+            PhotometricInterpretation::PaletteColor => GDCMPhotometricInterpretation::PALETTE_COLOR,
+            _ => GDCMPhotometricInterpretation::from_str(photometric_interpretation.as_str())
+                .map_err(|_| {
+                    UnsupportedPhotometricInterpretationSnafu {
+                        pi: photometric_interpretation.clone(),
+                    }
+                    .build()
+                })?,
+        };
 
         let transfer_syntax = &self.meta().transfer_syntax;
         let registry =


### PR DESCRIPTION
Extending from the PR #421 when using GDCM to decode images it will load the whole image to memory. This PR implements the logic required to load only one image.