### PR TITLE
Add JPEG 2000 decoding support 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +176,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbf2cd9424f5ff404aba1959c835cbc448ee8b689b870a9981c76c0fd46280e6"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "c2rust-bitfields"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb34f0c0ace43530b2df7f18bc69ee0c4082158aa451ece29602f8c841e73764"
+dependencies = [
+ "c2rust-bitfields-derive",
+]
+
+[[package]]
+name = "c2rust-bitfields-derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd1601a7b828ab874d890e5a895563ca8ad485bdd3d2a359f148c8b72537241"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -623,6 +649,7 @@ dependencies = [
  "dicom-test-files",
  "jpeg-decoder",
  "jpeg-encoder",
+ "jpeg2k",
  "lazy_static",
  "tracing",
 ]
@@ -1125,6 +1152,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cf3affe27ffd9f1992690ec7575568b222abe9cb39738f6531968aca8e64906"
 
 [[package]]
+name = "jpeg2k"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "450b1c9d2621b6fb60d724e77c41cb924dc7509eace907a23dc99b1b4a2416bc"
+dependencies = [
+ "anyhow",
+ "log",
+ "openjp2",
+ "openjpeg-sys",
+ "thiserror",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1355,29 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "openjp2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b5cbb9da46ebbda123ad91818b10cd2697f062d392693a4db078e0e495813c"
+dependencies = [
+ "bitflags 1.3.2",
+ "c2rust-bitfields",
+ "libc",
+ "log",
+ "sprintf",
+]
+
+[[package]]
+name = "openjpeg-sys"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e619b5395bceca2cc5da20027e39ee6cb91fef816ec99cebb14dec3acf020def"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "overload"
@@ -1765,6 +1828,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sprintf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c0cdea5a20a06e7c57f627094e7b1618e5665592cd88f2d45fa4014e348db58"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,6 +1932,26 @@ checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ resolver = "2"
 [profile.dev.package."jpeg-decoder"]
 opt-level = 2
 
+# optimize JPEG 2000 decoder to run tests faster
+[profile.dev.package.jpeg2k]
+opt-level = 2
+
 # optimize flate2 to run tests faster
 [profile.dev.package."flate2"]
 opt-level = 2

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -54,10 +54,21 @@ default = ["rayon", "native"]
 ndarray = ["dep:ndarray"]
 image = ["dep:image"]
 
-native = ["dicom-transfer-syntax-registry/native"]
+# Rust native image codec implementations
+native = ["dicom-transfer-syntax-registry/native", "jpeg"]
+# native JPEG codec implementation
+jpeg = ["dicom-transfer-syntax-registry/jpeg"]
+# native RLE lossless codec implementation
+rle = ["dicom-transfer-syntax-registry/rle"]
+# JPEG 2000 decoding via OpenJPEG static linking
+openjpeg-sys = ["dicom-transfer-syntax-registry/openjpeg-sys"]
+
+# replace pixel data decoding to use GDCM
 gdcm = ["gdcm-rs"]
+# use Rayon for image decoding
 rayon = ["dep:rayon", "image?/jpeg_rayon", "dicom-transfer-syntax-registry/rayon"]
 
+# enable command line tools
 cli = ["dep:clap", "dep:tracing-subscriber"]
 
 [package.metadata.docs.rs]

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -2443,11 +2443,11 @@ mod tests {
 
         #[cfg(feature = "image")]
         #[rstest]
-        // jpeg2000 encoding not supported
-        #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.91\"")]
-        #[case("pydicom/693_J2KI.dcm", 1)]
-        #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.90\"")]
-        #[case("pydicom/693_J2KR.dcm", 1)]
+        // jpeg2000 encoding
+        #[cfg_attr(any(feature = "openjp2", feature = "openjpeg-sys"), case("pydicom/emri_small_jpeg_2k_lossless.dcm", 10))]
+        #[cfg_attr(any(feature = "openjp2", feature = "openjpeg-sys"), case("pydicom/693_J2KI.dcm", 1))]
+        #[cfg_attr(any(feature = "openjp2", feature = "openjpeg-sys"), case("pydicom/693_J2KR.dcm", 1))]
+        #[cfg_attr(any(feature = "openjp2", feature = "openjpeg-sys"), case("pydicom/JPEG2000.dcm", 1))]
         //
         // jpeg-ls encoding not supported
         #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.80\"")]
@@ -2455,18 +2455,18 @@ mod tests {
         #[should_panic(expected = "UnsupportedTransferSyntax { ts: \"1.2.840.10008.1.2.4.80\"")]
         #[case("pydicom/MR_small_jpeg_ls_lossless.dcm", 1)]
         //
-        // sample precicion of 12 not supported
+        // sample precision of 12 not supported yet
         #[should_panic(expected = "Unsupported(SamplePrecision(12))")]
         #[case("pydicom/JPEG-lossy.dcm", 1)]
         //
-        // works fine
-        #[case("pydicom/color3d_jpeg_baseline.dcm", 120)]
+        // JPEG baseline (8bit)
+        #[cfg_attr(feature = "jpeg", case("pydicom/color3d_jpeg_baseline.dcm", 120))]
+        #[cfg_attr(feature = "jpeg", case("pydicom/SC_rgb_jpeg_lossy_gdcm.dcm", 1))]
+        #[cfg_attr(feature = "jpeg", case("pydicom/SC_rgb_jpeg_gdcm.dcm", 1))]
         //
-        // works fine
-        #[case("pydicom/JPEG-LL.dcm", 1)]
-        #[case("pydicom/JPGLosslessP14SV1_1s_1f_8b.dcm", 1)]
-        #[case("pydicom/SC_rgb_jpeg_gdcm.dcm", 1)]
-        #[case("pydicom/SC_rgb_jpeg_lossy_gdcm.dcm", 1)]
+        // JPEG lossless
+        #[cfg_attr(feature = "jpeg", case("pydicom/JPEG-LL.dcm", 1))]
+        #[cfg_attr(feature = "jpeg", case("pydicom/JPGLosslessP14SV1_1s_1f_8b.dcm", 1))]
 
         fn test_parse_jpeg_encoded_dicom_pixel_data(#[case] value: &str, #[case] frames: u32) {
             use std::fs;
@@ -2476,7 +2476,7 @@ mod tests {
             println!("Parsing pixel data for {}", test_file.display());
             let obj = open_file(test_file).unwrap();
             let pixel_data = obj.decode_pixel_data().unwrap();
-            assert_eq!(pixel_data.number_of_frames(), frames);
+            assert_eq!(pixel_data.number_of_frames(), frames, "number of frames mismatch");
 
             let output_dir = Path::new(
                 "../target/dicom_test_files/_out/test_parse_jpeg_encoded_dicom_pixel_data",
@@ -2484,7 +2484,7 @@ mod tests {
             fs::create_dir_all(output_dir).unwrap();
 
             for i in 0..pixel_data.number_of_frames().min(MAX_TEST_FRAMES) {
-                let image = pixel_data.to_dynamic_image(i).unwrap();
+                let image = pixel_data.to_dynamic_image(i).expect("failed to retrieve the frame requested");
                 let image_path = output_dir.join(format!(
                     "{}-{}.png",
                     Path::new(value).file_stem().unwrap().to_str().unwrap(),
@@ -2496,10 +2496,10 @@ mod tests {
 
         #[cfg(feature = "image")]
         #[rstest]
-        #[case("pydicom/color3d_jpeg_baseline.dcm", 0)]
-        #[case("pydicom/color3d_jpeg_baseline.dcm", 1)]
-        #[case("pydicom/color3d_jpeg_baseline.dcm", 78)]
-        #[case("pydicom/color3d_jpeg_baseline.dcm", 119)]
+        #[cfg_attr(feature = "jpeg", case("pydicom/color3d_jpeg_baseline.dcm", 0))]
+        #[cfg_attr(feature = "jpeg", case("pydicom/color3d_jpeg_baseline.dcm", 1))]
+        #[cfg_attr(feature = "jpeg", case("pydicom/color3d_jpeg_baseline.dcm", 78))]
+        #[cfg_attr(feature = "jpeg", case("pydicom/color3d_jpeg_baseline.dcm", 119))]
         #[case("pydicom/SC_rgb_rle_2frame.dcm", 0)]
         #[case("pydicom/SC_rgb_rle_2frame.dcm", 1)]
         #[case("pydicom/JPEG2000_UNC.dcm", 0)]

--- a/toimage/Cargo.toml
+++ b/toimage/Cargo.toml
@@ -11,14 +11,14 @@ keywords = ["cli", "dicom", "image", "image-conversion"]
 readme = "README.md"
 
 [features]
-default = ['dicom-object/inventory-registry', 'dicom-object/backtraces']
+default = ['dicom-object/inventory-registry', 'dicom-object/backtraces', 'dicom-pixeldata/native']
 
 [dependencies]
 clap = { version  = "4.0.18", features = ["derive"] }
 dicom-core = { version = "0.6.1", path = "../core" }
 dicom-dictionary-std = { version = "0.6.0", path = "../dictionary-std" }
 dicom-object = { path = "../object/", version = "0.6.1" }
-dicom-pixeldata = { path = "../pixeldata/", version = "0.2.0", features = ["image"] }
+dicom-pixeldata = { path = "../pixeldata/", version = "0.2.0", default-features = false, features = ["image", "rayon"] }
 snafu = { version = "0.7.3", features = ["rust_1_61"] }
 tracing = "0.1.34"
 tracing-subscriber = "0.3.11"

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -16,12 +16,21 @@ default = ["rayon"]
 inventory-registry = ['dicom-encoding/inventory-registry']
 
 # natively implemented image encodings
-native = ["jpeg", "rle"]
+native = ["jpeg", "openjp2", "rle"]
 # native JPEG support
 jpeg = ["jpeg-decoder", "jpeg-encoder"]
+# native JPEG 2000 support via the OpenJPEG Rust port
+openjp2 = ["dep:jpeg2k", "jpeg2k/openjp2"]
 # native RLE lossless support
 rle = []
+# enable Rayon for JPEG decoding
 rayon = ["jpeg-decoder?/rayon"]
+# build OpenJPEG with multithreading
+openjpeg-sys-threads = ["rayon", "jpeg2k?/threads"]
+
+# JPEG 2000 support via the OpenJPEG Rust port,
+# overrides `openjp2` if present
+openjpeg-sys = ["dep:jpeg2k", "jpeg2k/openjpeg-sys"]
 
 [dependencies]
 dicom-core = { path = "../core", version = "0.6.1" }
@@ -29,6 +38,11 @@ dicom-encoding = { path = "../encoding", version = "0.6.0" }
 lazy_static = "1.2.0"
 byteordered = "0.6"
 tracing = "0.1.34"
+
+[dependencies.jpeg2k]
+version = "0.6.6"
+optional = true
+default-features = false
 
 [dependencies.jpeg-decoder]
 version = "0.3.0"

--- a/transfer-syntax-registry/src/adapters/jpeg2k.rs
+++ b/transfer-syntax-registry/src/adapters/jpeg2k.rs
@@ -1,0 +1,135 @@
+//! Support for JPEG 2000 image decoding.
+
+use dicom_encoding::adapters::{decode_error, DecodeResult, PixelDataObject, PixelDataReader};
+use dicom_encoding::snafu::prelude::*;
+use jpeg2k::Image;
+use std::borrow::Cow;
+use tracing::warn;
+
+/// Pixel data adapter for transfer syntaxes based on JPEG 2000.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Jpeg2000Adapter;
+
+impl PixelDataReader for Jpeg2000Adapter {
+    /// Decode a single frame in JPEG 2000 from a DICOM object.
+    fn decode_frame(
+        &self,
+        src: &dyn PixelDataObject,
+        frame: u32,
+        dst: &mut Vec<u8>,
+    ) -> DecodeResult<()> {
+        let cols = src
+            .cols()
+            .context(decode_error::MissingAttributeSnafu { name: "Columns" })?;
+        let rows = src
+            .rows()
+            .context(decode_error::MissingAttributeSnafu { name: "Rows" })?;
+        let samples_per_pixel =
+            src.samples_per_pixel()
+                .context(decode_error::MissingAttributeSnafu {
+                    name: "SamplesPerPixel",
+                })?;
+        let bits_allocated = src
+            .bits_allocated()
+            .context(decode_error::MissingAttributeSnafu {
+                name: "BitsAllocated",
+            })?;
+
+        ensure_whatever!(
+            bits_allocated == 8 || bits_allocated == 16,
+            "BitsAllocated other than 8 or 16 is not supported"
+        );
+
+        let nr_frames = src.number_of_frames().unwrap_or(1) as usize;
+
+        ensure!(
+            nr_frames > frame as usize,
+            decode_error::FrameRangeOutOfBoundsSnafu
+        );
+
+        let bytes_per_sample = bits_allocated / 8;
+
+        // `stride` it the total number of bytes for each sample plane
+        let stride: usize = bytes_per_sample as usize * cols as usize * rows as usize;
+        dst.reserve_exact(samples_per_pixel as usize * stride);
+        let base_offset = dst.len();
+        dst.resize(base_offset + (samples_per_pixel as usize * stride), 0);
+
+        let raw = src
+            .raw_pixel_data()
+            .whatever_context("Expected to have raw pixel data available")?;
+
+        let frame_data = if raw.fragments.len() == 1 || raw.fragments.len() == nr_frames {
+            // assuming 1:1 frame-to-fragment mapping
+            Cow::Borrowed(
+                raw.fragments
+                    .get(frame as usize)
+                    .with_whatever_context(|| {
+                        format!("Missing fragment #{} for the frame requested", frame)
+                    })?,
+            )
+        } else {
+            // Some embedded JPEGs might span multiple fragments.
+            // In this case we look up the basic offset table
+            // and gather all of the frame's fragments in a single vector.
+            // Note: not the most efficient way to do this,
+            // consider optimizing later with byte chunk readers
+            let base_offset = raw.offset_table.get(frame as usize).copied();
+            let base_offset = if frame == 0 {
+                base_offset.unwrap_or(0) as usize
+            } else {
+                base_offset
+                    .with_whatever_context(|| format!("Missing offset for frame #{}", frame))?
+                    as usize
+            };
+            let next_offset = raw.offset_table.get(frame as usize + 1);
+
+            let mut offset = 0;
+            let mut fragments = Vec::new();
+            for fragment in &raw.fragments {
+                // include it
+                if offset >= base_offset {
+                    fragments.extend_from_slice(fragment);
+                }
+                offset += fragment.len() + 8;
+                if let Some(&next_offset) = next_offset {
+                    if offset >= next_offset as usize {
+                        // next fragment is for the next frame
+                        break;
+                    }
+                }
+            }
+
+            Cow::Owned(fragments)
+        };
+
+        let image = Image::from_bytes(&frame_data).whatever_context("jpeg2k decoder failure")?;
+
+        // Note: we cannot use `get_pixels`
+        // because the current implementation narrows the data
+        // down to 8 bits per sample
+        let components = image.components();
+
+        // write each component into the destination buffer
+        for (component_i, component) in components.iter().enumerate() {
+            if component_i > samples_per_pixel as usize {
+                warn!(
+                    "JPEG 2000 image has more components than expected ({} > {})",
+                    component_i, samples_per_pixel
+                );
+                break;
+            }
+
+            // write in standard layout
+            for (i, sample) in component.data().iter().enumerate() {
+                let offset = base_offset
+                    + i * samples_per_pixel as usize * bytes_per_sample as usize
+                    + component_i * bytes_per_sample as usize;
+                dst[offset..offset + bytes_per_sample as usize]
+                    .copy_from_slice(&sample.to_le_bytes()[..bytes_per_sample as usize]);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/transfer-syntax-registry/src/adapters/mod.rs
+++ b/transfer-syntax-registry/src/adapters/mod.rs
@@ -4,15 +4,27 @@
 //! can be added via Cargo features.
 //!
 //! - [`jpeg`](jpeg) provides native JPEG decoding
-//!   (baseline and lossless).
+//!   (baseline and lossless)
+//!   and encoding (baseline).
 //!   Requires the `jpeg` feature,
 //!   enabled by default.
-//! - [`rle_lossless`](rle_lossless) provides RLE lossless decoding.
+//! - [`jpeg2k`](jpeg2k) contains JPEG 2000 support,
+//!   which is currently available through [OpenJPEG].
+//!   The `openjp2` feature provides native JPEG 2000 decoding
+//!   via the [Rust port of OpenJPEG][OpenJPEG-rs].
+//!   Alternatively, enable the `openjpeg-sys` feature
+//!   to statically link to the OpenJPEG reference implementation.
+//!   `openjp2` is enabled by default.
+//! - [`rle_lossless`](rle_lossless) provides native RLE lossless decoding.
 //!   Requires the `rle` feature,
 //!   enabled by default.
-
+//! 
+//! [OpenJPEG]: https://github.com/uclouvain/openjpeg
+//! [OpenJPEG-rs]: https://crates.io/crates/openjp2
 #[cfg(feature = "jpeg")]
 pub mod jpeg;
+#[cfg(any(feature = "openjp2", feature = "openjpeg-sys"))]
+pub mod jpeg2k;
 #[cfg(feature = "rle")]
 pub mod rle_lossless;
 
@@ -22,6 +34,11 @@ pub mod uncompressed;
 /// Enable the `jpeg` feature to use this module.
 #[cfg(not(feature = "jpeg"))]
 pub mod jpeg {}
+
+/// **Note:** This module is a stub.
+/// Enable either `openjp2` or `openjpeg-sys` to use this module.
+#[cfg(not(any(feature = "openjp2", feature = "openjpeg-sys")))]
+pub mod jpeg2k {}
 
 /// **Note:** This module is a stub.
 /// Enable the `rle` feature to use this module.

--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -27,11 +27,13 @@ use dicom_encoding::transfer_syntax::{AdapterFreeTransferSyntax as Ts, Codec};
 
 use dicom_encoding::transfer_syntax::{NeverAdapter, TransferSyntax};
 
-#[cfg(feature = "rle")]
+#[cfg(any(feature = "rle", feature = "openjp2", feature = "openjpeg-sys"))]
 use dicom_encoding::NeverPixelAdapter;
 
 #[cfg(feature = "jpeg")]
 use crate::adapters::jpeg::JpegAdapter;
+#[cfg(any(feature = "openjp2", feature = "openjpeg-sys"))]
+use crate::adapters::jpeg2k::Jpeg2000Adapter;
 #[cfg(feature = "rle")]
 use crate::adapters::rle_lossless::RleLosslessAdapter;
 
@@ -191,6 +193,73 @@ pub const JPIP_REFERENCED_DEFLATE: Ts = Ts::new_ele(
     Codec::Dataset(None),
 );
 
+// --- JPEG 2000 support ---
+
+/// An alias for a transfer syntax specifier with [`Jpeg2000Adapter`]
+/// (supports decoding and encoding to JPEG baseline,
+/// support for JPEG extended and JPEG lossless may vary).
+#[cfg(any(feature = "openjp2", feature = "openjpeg-sys"))]
+type Jpeg2000Ts<R = Jpeg2000Adapter, W = NeverPixelAdapter> = TransferSyntax<NeverAdapter, R, W>;
+
+/// Create a transfer syntax with JPEG 2000 encapsulated pixel data
+#[cfg(any(feature = "openjp2", feature = "openjpeg-sys"))]
+const fn create_ts_jpeg2k(uid: &'static str, name: &'static str) -> Jpeg2000Ts {
+    TransferSyntax::new_ele(
+        uid,
+        name,
+        Codec::EncapsulatedPixelData(Some(Jpeg2000Adapter), None),
+    )
+}
+
+/// **Decoder implementation:** JPEG 2000 Image Compression (Lossless Only)
+#[cfg(any(feature = "openjp2", feature = "openjpeg-sys"))]
+pub const JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: Jpeg2000Ts = create_ts_jpeg2k(
+    "1.2.840.10008.1.2.4.90",
+    "JPEG 2000 Image Compression (Lossless Only)",
+);
+/// **Stub descriptor:** JPEG 2000 Image Compression (Lossless Only)
+#[cfg(not(any(feature = "openjp2", feature = "openjpeg-sys")))]
+pub const JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.90",
+    "JPEG 2000 Image Compression (Lossless Only)",
+);
+
+/// **Decoder implementation:** JPEG 2000 Image Compression
+#[cfg(any(feature = "openjp2", feature = "openjpeg-sys"))]
+pub const JPEG_2000_IMAGE_COMPRESSION: Jpeg2000Ts =
+    create_ts_jpeg2k("1.2.840.10008.1.2.4.91", "JPEG 2000 Image Compression");
+/// **Stub descriptor:** JPEG 2000 Image Compression
+#[cfg(not(any(feature = "openjp2", feature = "openjpeg-sys")))]
+pub const JPEG_2000_IMAGE_COMPRESSION: Ts =
+    create_ts_stub("1.2.840.10008.1.2.4.91", "JPEG 2000 Image Compression");
+
+/// **Decoder implementation:** JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)
+#[cfg(any(feature = "openjp2", feature = "openjpeg-sys"))]
+pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION_LOSSLESS_ONLY: Jpeg2000Ts =
+    create_ts_jpeg2k(
+        "1.2.840.10008.1.2.4.92",
+        "JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)",
+    );
+/// **Stub descriptor:** JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)
+#[cfg(not(any(feature = "openjp2", feature = "openjpeg-sys")))]
+pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.92",
+    "JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)",
+);
+
+/// **Decoder implementation:** JPEG 2000 Part 2 Multi-component Image Compression
+#[cfg(any(feature = "openjp2", feature = "openjpeg-sys"))]
+pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION: Jpeg2000Ts = create_ts_jpeg2k(
+    "1.2.840.10008.1.2.4.93",
+    "JPEG 2000 Part 2 Multi-component Image Compression",
+);
+/// **Stub descriptor:** JPEG 2000 Part 2 Multi-component Image Compression
+#[cfg(not(any(feature = "openjp2", feature = "openjpeg-sys")))]
+pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.93",
+    "JPEG 2000 Part 2 Multi-component Image Compression",
+);
+
 // --- partially supported transfer syntaxes, pixel data encapsulation not supported ---
 
 /// **Stub descriptor:** JPEG-LS Lossless Image Compression
@@ -202,25 +271,6 @@ pub const JPEG_LS_LOSSLESS_IMAGE_COMPRESSION: Ts = create_ts_stub(
 pub const JPEG_LS_LOSSY_IMAGE_COMPRESSION: Ts = create_ts_stub(
     "1.2.840.10008.1.2.4.81",
     "JPEG-LS Lossy (Near-Lossless) Image Compression",
-);
-
-/// **Stub descriptor:** JPEG 2000 Image Compression (Lossless Only)
-pub const JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
-    "1.2.840.10008.1.2.4.90",
-    "JPEG 2000 Image Compression (Lossless Only)",
-);
-/// **Stub descriptor:** JPEG 2000 Image Compression
-pub const JPEG_2000_IMAGE_COMPRESSION: Ts =
-    create_ts_stub("1.2.840.10008.1.2.4.91", "JPEG 2000 Image Compression");
-/// **Stub descriptor:** JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)
-pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
-    "1.2.840.10008.1.2.4.92",
-    "JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only)",
-);
-/// **Stub descriptor:** JPEG 2000 Part 2 Multi-component Image Compression
-pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION: Ts = create_ts_stub(
-    "1.2.840.10008.1.2.4.93",
-    "JPEG 2000 Part 2 Multi-component Image Compression",
 );
 
 /// **Stub descriptor:** JPIP Referenced

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -49,10 +49,14 @@
 //!
 //! | transfer syntax               | decoding support     | encoding support |
 //! |-------------------------------|----------------------|------------------|
-//! | JPEG Baseline (Process 1)     | Cargo feature `jpeg` | x |
+//! | JPEG Baseline (Process 1)     | Cargo feature `jpeg` | ✓ |
 //! | JPEG Extended (Process 2 & 4) | Cargo feature `jpeg` | x |
 //! | JPEG Lossless, Non-Hierarchical (Process 14) | Cargo feature `jpeg` | x |
 //! | JPEG Lossless, Non-Hierarchical, First-Order Prediction (Process 14 [Selection Value 1]) | Cargo feature `jpeg` | x |
+//! | JPEG 2000 (Lossless Only)     | Cargo feature `openjp2` or `openjpeg-sys` | x |
+//! | JPEG 2000                     | Cargo feature `openjp2` or `openjpeg-sys` | x |
+//! | JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only) | Cargo feature `openjp2` or `openjpeg-sys` | x |
+//! | JPEG 2000 Part 2 Multi-component Image Compression | Cargo feature `openjp2` or `openjpeg-sys` | x |
 //! | RLE Lossless                  | Cargo feature `rle` | x |
 //!
 //! Transfer syntaxes which are not supported,


### PR DESCRIPTION
This adds direct support for decoding pixel data in JPEG 2000, via jpeg2k. `jpeg2k` lets us pick between linking the reference implementation of OpenJPEG (Cargo feature `openjpeg-sys`) or a Rust port (Cargo feature `openjp2`).

A few more changes were made to the Cargo feature set so that downstream crates can be more specific about which via `dicom-pixeldata`.
For instance, doing `cargo install --path toimage` would include the Rust port of openjp2, but with the command below, you can build `dicom-toimage` statically linked with the OpenJPEG reference software.

```sh
cargo install --path toimage --no-default-features \
    --features=dicom-pixeldata/jpeg,dicom-pixeldata/rle,dicom-pixeldata/openjpeg-sys
```

### Summary

- [ts-registry] add features `openjp2` and `openjpeg-sys`
   - they map to the backend impl of JPEG 2000 via jpeg2k
- [ts-registry] add JPEG 2000 pixel data adapter with decoding support
- [pixeldata] expose more transfer-syntax-registry features, so that specific image decoding implementations can be selected
- [pixeldata] adjust jpeg decoding test cases according to support
- [toimage] relocate `dicom-pixeldata/native` to default features, so that native implementations can be disabled at will
