### PR TITLE
Update jpeg-encoder to v0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "jpeg-encoder"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf3affe27ffd9f1992690ec7575568b222abe9cb39738f6531968aca8e64906"
+checksum = "2fefe5a4fb12fa836172dc53cc36c37af693f6197ae702f931faad8774caf926"
 
 [[package]]
 name = "jpeg2k"

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -28,12 +28,13 @@ rayon = ["jpeg-decoder?/rayon"]
 # enable SIMD operations for JPEG encoding
 simd = ["jpeg-encoder?/simd"]
 
-# build OpenJPEG with multithreading
-openjpeg-sys-threads = ["rayon", "jpeg2k?/threads"]
-
 # JPEG 2000 support via the OpenJPEG Rust port,
-# overrides `openjp2` if present
+# conflicts with `openjp2`
 openjpeg-sys = ["dep:jpeg2k", "jpeg2k/openjpeg-sys"]
+
+# build OpenJPEG with multithreading,
+# implies "rayon"
+openjpeg-sys-threads = ["rayon", "jpeg2k?/threads"]
 
 [dependencies]
 dicom-core = { path = "../core", version = "0.6.1" }

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["dicom"]
 readme = "README.md"
 
 [features]
-default = ["rayon"]
+default = ["rayon", "simd"]
 
 # inventory for compile time plugin-based transfer syntax registration
 inventory-registry = ['dicom-encoding/inventory-registry']
@@ -25,6 +25,9 @@ openjp2 = ["dep:jpeg2k", "jpeg2k/openjp2"]
 rle = []
 # enable Rayon for JPEG decoding
 rayon = ["jpeg-decoder?/rayon"]
+# enable SIMD operations for JPEG encoding
+simd = ["jpeg-encoder?/simd"]
+
 # build OpenJPEG with multithreading
 openjpeg-sys-threads = ["rayon", "jpeg2k?/threads"]
 

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -49,7 +49,7 @@ version = "0.3.0"
 optional = true
 
 [dependencies.jpeg-encoder]
-version = "0.5.1"
+version = "0.6"
 optional = true
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
### Summary

- [transfer-syntax-registry] Update jpeg-encoder to v0.6
- [transfer-syntax-registry] Expose Cargo feature jpeg-encoder/simd
- [transfer-syntax-registry] fix comments on openjpeg-sys Cargo features
