### PR TITLE
[core] Handle leap second from chrono time types correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,11 +209,10 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
- "android-tzdata",
  "num-traits",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["dicom"]
 readme = "README.md"
 
 [dependencies]
-chrono = { version = "0.4.26", default-features = false, features = ["std"] }
+chrono = { version = "0.4.31", default-features = false, features = ["std"] }
 itertools = "0.11"
 num-traits = "0.2.12"
 safe-transmute = "0.11.0"


### PR DESCRIPTION
[chrono 0.4.31](https://github.com/chronotope/chrono/releases/tag/v0.4.31) has stricter constraints in time constructor functions, so the cases where a leap second is not allowed are already covered here.

This in turn revealed that `dicom-core` is not accepting valid times with a leap second from chrono because they are represented differently: whereas our DICOM date time types represent leap seconds as having 60 seconds, like in the encoding of DICOM VRs DT and TM, chrono represents them instead as sub-second fractions larger than 1 second. This requires the seconds and microseconds from these types to be adapted to fit in `DicomTime` and `DicomDateTime`.

Resolves the CI error detected in #427.

### Summary

- update `chrono` to `^0.4.31`
- clarify documentation of `DicomTime::from_hms_micro`
- fix `TryFrom` impls for `DicomTime` and `DicomDateTime`  so that leap years in chrono types are correctly accounted for
