### PR TITLE
Adjust features for easier building on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
           RUSTFLAGS: -W warnings
 
   check_windows:
-    name: Check (Windows)
+    name: Build (Windows)
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
         with:
           toolchain: stable
           cache: true
-      - run: cargo check
+      - run: cargo build --no-default-features --features=image,ndarray,sop-class,rle,cli,default_windows,backtraces,inventory-registry
 
   check_macos:
     name: Check (macOS)

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -50,12 +50,17 @@ dicom-test-files = "0.2.1"
 
 [features]
 default = ["rayon", "native"]
+# preferred default features for Windows
+# (if on Windows, disable default features then add this one)
+default_windows = ["rayon", "native_windows"]
 
 ndarray = ["dep:ndarray"]
 image = ["dep:image"]
 
 # Rust native image codec implementations
-native = ["dicom-transfer-syntax-registry/native", "jpeg"]
+native = ["dicom-transfer-syntax-registry/native", "jpeg", "rle"]
+# Rust native image codec implementations that work on Windows
+native_windows = ["dicom-transfer-syntax-registry/native_windows", "jpeg", "rle"]
 # native JPEG codec implementation
 jpeg = ["dicom-transfer-syntax-registry/jpeg"]
 # native RLE lossless codec implementation

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -17,6 +17,8 @@ inventory-registry = ['dicom-encoding/inventory-registry']
 
 # natively implemented image encodings
 native = ["jpeg", "openjp2", "rle"]
+# native implementations that work on Windows
+native_windows = ["jpeg", "rle"]
 # native JPEG support
 jpeg = ["jpeg-decoder", "jpeg-encoder"]
 # native JPEG 2000 support via the OpenJPEG Rust port

--- a/transfer-syntax-registry/src/adapters/jpeg2k.rs
+++ b/transfer-syntax-registry/src/adapters/jpeg2k.rs
@@ -6,6 +6,10 @@ use jpeg2k::Image;
 use std::borrow::Cow;
 use tracing::warn;
 
+// Check jpeg2k backend conflicts
+#[cfg(all(feature = "openjp2", feature = "openjpeg-sys"))]
+compile_error!("feature \"openjp2\" and feature \"openjpeg-sys\" cannot be enabled at the same time");
+
 /// Pixel data adapter for transfer syntaxes based on JPEG 2000.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Jpeg2000Adapter;

--- a/transfer-syntax-registry/src/adapters/mod.rs
+++ b/transfer-syntax-registry/src/adapters/mod.rs
@@ -11,14 +11,16 @@
 //! - [`jpeg2k`](jpeg2k) contains JPEG 2000 support,
 //!   which is currently available through [OpenJPEG].
 //!   The `openjp2` feature provides native JPEG 2000 decoding
-//!   via the [Rust port of OpenJPEG][OpenJPEG-rs].
+//!   via the [Rust port of OpenJPEG][OpenJPEG-rs],
+//!   which works on Linux and Mac OS, but not on Windows.
 //!   Alternatively, enable the `openjpeg-sys` feature
 //!   to statically link to the OpenJPEG reference implementation.
-//!   `openjp2` is enabled by default.
+//!   `openjp2` is enabled by the feature `native`.
+//!   To build on Windows, enable `native_windows` instead.
 //! - [`rle_lossless`](rle_lossless) provides native RLE lossless decoding.
 //!   Requires the `rle` feature,
 //!   enabled by default.
-//! 
+//!
 //! [OpenJPEG]: https://github.com/uclouvain/openjpeg
 //! [OpenJPEG-rs]: https://crates.io/crates/openjp2
 #[cfg(feature = "jpeg")]


### PR DESCRIPTION
This attempts to mitigate the build error when targeting Windows without Cargo feature changes (#432). Removing feature `openjp2` from the `native` feature list is a breaking change, but we can offer alternative feature listings for Windows.

So instead of this:

```none
cargo build --no-default-features --features=cli,rle,jpeg,rayon
```

One can instead do this:

```none
cargo build --no-default-features --features=cli,default_windows
```

Or this, for the reference implementation of OpenJPEG:

```none
cargo build --no-default-features --features=cli,default_windows,openjpeg-sys,openjpeg-sys-threads
```

### Summary

- Add `native_windows` Cargo feature to `dicom-transfer-syntax-registry` and `dicom-pixeldata`
- Add `default_windows` Cargo feature to `dicom-pixeldata`
- Clarify documentation on JPEG 2000 adapter
- Add compile-time check for conflicting `jpeg2k` backend feature selection
- Change CI to build project on Windows instead of just checking

