### PR TITLE
Move dicom-test-files in dicom-json to dev dependencies

### DIFF
--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -14,10 +14,10 @@ base64 = "0.21.2"
 dicom-core = { version = "0.6.2", path = "../core" }
 dicom-dictionary-std = { version = "0.6.1", path = "../dictionary-std" }
 dicom-object = { version = "0.6.2", path = "../object" }
-dicom-test-files = "0.2.1"
 num-traits = "0.2.15"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = { version = "1.0.96", features = ["preserve_order"] }
 
 [dev-dependencies]
+dicom-test-files = "0.2.1"
 pretty_assertions = "1.3.0"


### PR DESCRIPTION
`dicom-test-files` was mistakenly added as a main dependency of `dicom-json`, thus bloating users unnecessarily.
