### PR TITLE
[dump] Extend no_text_limit option to more VRs

### DIFF
--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -748,6 +748,7 @@ fn value_summary(
             true,
             VR::CS
             | VR::AE
+            | VR::AS
             | VR::DA
             | VR::DS
             | VR::DT
@@ -755,10 +756,13 @@ fn value_summary(
             | VR::LO
             | VR::LT
             | VR::PN
+            | VR::SH
+            | VR::ST
             | VR::TM
             | VR::UC
             | VR::UI
-            | VR::UR,
+            | VR::UR
+            | VR::UT,
         ) => None,
         (false, _, _) => Some(max_characters),
     };


### PR DESCRIPTION
This makes it so that the `no_text_limit` option also dumps the entirety of data elements with the value representations Age String (AS), Short String (SH), Short Text (ST), and Unlimited Text (UT). There was no apparent reason for why this wasn't the case, they were probably just overlooked among the various VRs.