### PR TITLE
Make openjp2 opt-in

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,8 @@ jobs:
           cache: true
       # test project with default + extra features
       - run: cargo test --features image,ndarray,sop-class,rle,cli
+      # test dicom-pixeldata with openjpeg-sys
+      - run: cargo test -p dicom-pixeldata --features openjpeg-sys
       # test dicom-pixeldata with gdcm-rs
       - run: cargo test -p dicom-pixeldata --features gdcm
       # test dicom-pixeldata without default features
@@ -44,7 +46,7 @@ jobs:
         with:
           toolchain: stable
           cache: true
-      - run: cargo build --no-default-features --features=image,ndarray,sop-class,rle,cli,default_windows,backtraces,inventory-registry
+      - run: cargo build
 
   check_macos:
     name: Check (macOS)

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -50,23 +50,20 @@ dicom-test-files = "0.2.1"
 
 [features]
 default = ["rayon", "native"]
-# preferred default features for Windows
-# (if on Windows, disable default features then add this one)
-default_windows = ["rayon", "native_windows"]
 
 ndarray = ["dep:ndarray"]
 image = ["dep:image"]
 
 # Rust native image codec implementations
 native = ["dicom-transfer-syntax-registry/native", "jpeg", "rle"]
-# Rust native image codec implementations that work on Windows
-native_windows = ["dicom-transfer-syntax-registry/native_windows", "jpeg", "rle"]
 # native JPEG codec implementation
 jpeg = ["dicom-transfer-syntax-registry/jpeg"]
 # native RLE lossless codec implementation
 rle = ["dicom-transfer-syntax-registry/rle"]
 # JPEG 2000 decoding via OpenJPEG static linking
 openjpeg-sys = ["dicom-transfer-syntax-registry/openjpeg-sys"]
+# JPEG 2000 decoding via Rust port of OpenJPEG
+openjp2 = ["dicom-transfer-syntax-registry/openjp2"]
 
 # replace pixel data decoding to use GDCM
 gdcm = ["gdcm-rs"]

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -16,12 +16,13 @@ default = ["rayon", "simd"]
 inventory-registry = ['dicom-encoding/inventory-registry']
 
 # natively implemented image encodings
-native = ["jpeg", "openjp2", "rle"]
+native = ["jpeg", "rle"]
 # native implementations that work on Windows
 native_windows = ["jpeg", "rle"]
 # native JPEG support
 jpeg = ["jpeg-decoder", "jpeg-encoder"]
-# native JPEG 2000 support via the OpenJPEG Rust port
+# JPEG 2000 support via the OpenJPEG Rust port,
+# works on Linux and a few other platforms
 openjp2 = ["dep:jpeg2k", "jpeg2k/openjp2"]
 # native RLE lossless support
 rle = []

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -62,9 +62,9 @@
 //! | JPEG 2000 Part 2 Multi-component Image Compression | Cargo feature `openjp2` or `openjpeg-sys` | x |
 //! | RLE Lossless                  | Cargo feature `rle` | x |
 //!
-//! Cargo features behind `native` (`jpeg`, `rle`, `openjp2`)
-//! provide implementations that are written in pure Rust,
-//! and so they are easier to build and may be available in all platforms supported by Rust.
+//! Cargo features behind `native` (`jpeg`, `rle`)
+//! provide implementations that are written in pure Rust
+//! and are likely available in all supported platforms.
 //! However, a native implementation might not always be available,
 //! or alternative implementations may be preferred:
 //! 
@@ -73,6 +73,9 @@
 //!   It may offer better performance than the pure Rust implementation,
 //!   but cannot be used in WebAssembly.
 //!   Include `openjpeg-sys-threads` to build OpenJPEG with multithreading.
+//! - `openjp2` provides a binding to a computer-translated Rust port of OpenJPEG.
+//!   Due to the nature of this crate,
+//!   it does not work on all supported platforms.
 //! 
 //! Transfer syntaxes which are not supported,
 //! either due to being unable to read the data set


### PR DESCRIPTION
`openjpeg-sys` provides a good implementation, but requires linking with non-Rust code. `openjp2` is written in Rust, but only works in some platforms due to the nature of the code port. Neither of which is ready to be a default implementation.

This PR resolves #446 by requiring consumers to pick a JPEG 2000 implementation.

### Summary

- remove `openjp2` as a default Cargo feature
- remove Windows-specific Cargo features, since the default now works fine
- tweak CI workflow accordingly