### PR TITLE
Trim \0 characters from photometric interpretation

### DIFF
--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -491,8 +491,7 @@ pub fn photometric_interpretation<D: DataDictionary + Clone>(
         .context(MissingRequiredSnafu { name })?
         .string()
         .context(CastValueSnafu { name })?
-        .trim()
-        .trim_matches(char::from(0))
+        .trim_matches(|c: char| c.is_whitespace() || c == '\0')
         .into())
 }
 

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -492,6 +492,7 @@ pub fn photometric_interpretation<D: DataDictionary + Clone>(
         .string()
         .context(CastValueSnafu { name })?
         .trim()
+        .trim_matches(char::from(0))
         .into())
 }
 


### PR DESCRIPTION
trim() does not remove \0 characters, it needs to be done using trim_matches.