### PR TITLE
Datetimefix

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,5 +17,5 @@ safe-transmute = "0.11.0"
 smallvec = "1.6.1"
 snafu = "0.7.3"
 
-[lib]
-doctest = false
+#[lib]
+#doctest = false

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,3 @@ num-traits = "0.2.12"
 safe-transmute = "0.11.0"
 smallvec = "1.6.1"
 snafu = "0.7.3"
-
-[lib]
-doctest = false

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,3 +16,6 @@ num-traits = "0.2.12"
 safe-transmute = "0.11.0"
 smallvec = "1.6.1"
 snafu = "0.7.3"
+
+[lib]
+doctest = false

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -503,11 +503,8 @@ where
     ///
     /// Returns an error if the value is not primitive.
     ///
-    pub fn to_datetime(
-        &self,
-        default_offset: FixedOffset,
-    ) -> Result<DicomDateTime, ConvertValueError> {
-        self.value().to_datetime(default_offset)
+    pub fn to_datetime(&self) -> Result<DicomDateTime, ConvertValueError> {
+        self.value().to_datetime()
     }
 
     /// Retrieve and convert the primitive value into a sequence of date-times.
@@ -517,11 +514,8 @@ where
     ///
     /// Returns an error if the value is not primitive.
     ///
-    pub fn to_multi_datetime(
-        &self,
-        default_offset: FixedOffset,
-    ) -> Result<Vec<DicomDateTime>, ConvertValueError> {
-        self.value().to_multi_datetime(default_offset)
+    pub fn to_multi_datetime(&self) -> Result<Vec<DicomDateTime>, ConvertValueError> {
+        self.value().to_multi_datetime()
     }
 
     /// Retrieve the items stored in a sequence value.

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -6,7 +6,6 @@ use crate::value::{
     CastValueError, ConvertValueError, DataSetSequence, DicomDate, DicomDateTime, DicomTime,
     InMemFragment, PrimitiveValue, Value, C,
 };
-use chrono::FixedOffset;
 use num_traits::NumCast;
 use snafu::{ensure, Backtrace, Snafu};
 use std::borrow::Cow;

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -10,3 +10,4 @@
 
 pub use crate::{dicom_value, DataElement, DicomValue, Tag, VR};
 pub use crate::{header::HasLength as _, DataDictionary as _};
+pub use crate::value::{AsRange as _, DicomDate, DicomTime, DicomDateTime};

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -14,7 +14,7 @@ pub mod range;
 pub mod serialize;
 
 pub use self::deserialize::Error as DeserializeError;
-pub use self::partial::{DicomDate, DicomDateTime, DicomTime, Precision};
+pub use self::partial::{DicomDate, DicomDateTime, DicomTime};
 pub use self::person_name::PersonName;
 pub use self::range::{AsRange, DateRange, DateTimeRange, TimeRange, PreciseDateTimeResult};
 

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -252,7 +252,7 @@ impl<I, P> Value<I, P> {
 
     /// Shorten this value by removing trailing elements
     /// to fit the given limit.
-    /// 
+    ///
     /// On primitive values,
     /// elements are counted by the number of individual value items
     /// (note that bytes in a [`PrimitiveValue::U8`]
@@ -578,12 +578,9 @@ where
     /// If the value is a primitive, it will be converted into
     /// a `DateTime` as described in [`PrimitiveValue::to_datetime`].
     ///
-    pub fn to_datetime(
-        &self,
-        default_offset: FixedOffset,
-    ) -> Result<DicomDateTime, ConvertValueError> {
+    pub fn to_datetime(&self) -> Result<DicomDateTime, ConvertValueError> {
         match self {
-            Value::Primitive(v) => v.to_datetime(default_offset),
+            Value::Primitive(v) => v.to_datetime(),
             _ => Err(ConvertValueError {
                 requested: "DicomDateTime",
                 original: self.value_type(),
@@ -597,12 +594,9 @@ where
     /// If the value is a primitive, it will be converted into
     /// a vector of `DicomDateTime` as described in [`PrimitiveValue::to_multi_datetime`].
     ///
-    pub fn to_multi_datetime(
-        &self,
-        default_offset: FixedOffset,
-    ) -> Result<Vec<DicomDateTime>, ConvertValueError> {
+    pub fn to_multi_datetime(&self) -> Result<Vec<DicomDateTime>, ConvertValueError> {
         match self {
-            Value::Primitive(v) => v.to_multi_datetime(default_offset),
+            Value::Primitive(v) => v.to_multi_datetime(),
             _ => Err(ConvertValueError {
                 requested: "DicomDateTime",
                 original: self.value_type(),
@@ -648,12 +642,9 @@ where
     /// If the value is a primitive, it will be converted into
     /// a `DateTimeRange` as described in [`PrimitiveValue::to_datetime_range`].
     ///
-    pub fn to_datetime_range(
-        &self,
-        offset: FixedOffset,
-    ) -> Result<DateTimeRange, ConvertValueError> {
+    pub fn to_datetime_range(&self) -> Result<DateTimeRange, ConvertValueError> {
         match self {
-            Value::Primitive(v) => v.to_datetime_range(offset),
+            Value::Primitive(v) => v.to_datetime_range(),
             _ => Err(ConvertValueError {
                 requested: "DateTimeRange",
                 original: self.value_type(),
@@ -1043,7 +1034,7 @@ impl<P> PixelFragmentSequence<P> {
 
     /// Shorten this sequence by removing trailing fragments
     /// to fit the given limit.
-    /// 
+    ///
     /// Note that this operations does not affect the basic offset table.
     #[inline]
     pub fn truncate(&mut self, limit: usize) {

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -23,9 +23,6 @@ pub use self::primitive::{
     ValueType,
 };
 
-/// re-exported from chrono
-use chrono::FixedOffset;
-
 /// An aggregation of one or more elements in a value.
 pub type C<T> = SmallVec<[T; 2]>;
 

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -14,7 +14,7 @@ pub mod range;
 pub mod serialize;
 
 pub use self::deserialize::Error as DeserializeError;
-pub use self::partial::{DicomDate, DicomDateTime, DicomTime};
+pub use self::partial::{DicomDate, DicomDateTime, DicomTime, Precision};
 pub use self::person_name::PersonName;
 pub use self::range::{AsRange, DateRange, DateTimeRange, TimeRange, PreciseDateTimeResult};
 

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -16,7 +16,7 @@ pub mod serialize;
 pub use self::deserialize::Error as DeserializeError;
 pub use self::partial::{DicomDate, DicomDateTime, DicomTime};
 pub use self::person_name::PersonName;
-pub use self::range::{AsRange, DateRange, DateTimeRange, TimeRange};
+pub use self::range::{AsRange, DateRange, DateTimeRange, TimeRange, PreciseDateTimeResult};
 
 pub use self::primitive::{
     CastValueError, ConvertValueError, InvalidValueReadError, ModifyValueError, PrimitiveValue,

--- a/core/src/value/partial.rs
+++ b/core/src/value/partial.rs
@@ -176,39 +176,42 @@ enum DicomTimeImpl {
 /// Represents a Dicom DateTime value with a partial precision,
 /// where some date or time components may be missing.
 ///
-/// `DicomDateTime` is always internally represented by a [DicomDate]
-/// and optionally by a [DicomTime] and a timezone [FixedOffset].
+/// `DicomDateTime` is always internally represented by a [DicomDate].
+/// The [DicomTime] and a timezone [FixedOffset] values are optional.
 ///
-/// It implements [AsRange] trait and optionally holds a [FixedOffset] value, from which corresponding
-/// [datetime][DateTime] values can be retrieved.
+/// It implements [AsRange] trait, which serves to access usable precise values from `DicomDateTime` values
+/// with missing components in the form of [PreciseDateTimeResult].
 /// # Example
 /// ```
 /// # use std::error::Error;
 /// # use std::convert::TryFrom;
 /// use chrono::{DateTime, FixedOffset, TimeZone, NaiveDateTime, NaiveDate, NaiveTime};
-/// use dicom_core::value::{DicomDate, DicomTime, DicomDateTime, AsRange};
+/// use dicom_core::value::{DicomDate, DicomTime, DicomDateTime, AsRange, PreciseDateTimeResult};
 /// # fn main() -> Result<(), Box<dyn Error>> {
 ///
 /// let offset = FixedOffset::east_opt(3600).unwrap();
 ///
-/// // the least precise date-time value possible is a 'YYYY'
-/// let dt = DicomDateTime::from_date(
+/// // lets create the least precise date-time value possible 'YYYY' and make it time-zone aware
+/// let dt = DicomDateTime::from_date_with_time_zone(
 ///     DicomDate::from_y(2020)?,
 ///     offset
 /// );
+/// // the earliest possible value is output as a [PreciseDateTimeResult]
 /// assert_eq!(
-///     Some(dt.earliest()?),
+///     dt.earliest()?,
+///     PreciseDateTimeResult::WithTimeZone(
 ///     offset.from_local_datetime(&NaiveDateTime::new(
 ///         NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
 ///         NaiveTime::from_hms_opt(0, 0, 0).unwrap()
-///     )).single()
+///     )).single().unwrap())
 /// );
 /// assert_eq!(
-///     Some(dt.latest()?),
+///     dt.latest()?,
+///     PreciseDateTimeResult::WithTimeZone(
 ///     offset.from_local_datetime(&NaiveDateTime::new(
 ///         NaiveDate::from_ymd_opt(2020, 12, 31).unwrap(),
 ///         NaiveTime::from_hms_micro_opt(23, 59, 59, 999_999).unwrap()
-///     )).single()
+///     )).single().unwrap())
 /// );
 ///
 /// let chrono_datetime = offset.from_local_datetime(&NaiveDateTime::new(

--- a/core/src/value/partial.rs
+++ b/core/src/value/partial.rs
@@ -1245,7 +1245,7 @@ mod tests {
             )
             .latest()
             .unwrap(),
-            PreciseDateTimeResult::WithTimeZone(
+            PreciseDateTimeResult::TimeZone(
             FixedOffset::east_opt(0)
                 .unwrap()
                 .from_local_datetime(&NaiveDateTime::new(
@@ -1266,7 +1266,7 @@ mod tests {
             .unwrap()
             .earliest()
             .unwrap(),
-            PreciseDateTimeResult::WithTimeZone(
+            PreciseDateTimeResult::TimeZone(
             FixedOffset::east_opt(0)
                 .unwrap()
                 .from_local_datetime(&NaiveDateTime::new(
@@ -1286,7 +1286,7 @@ mod tests {
             .unwrap()
             .latest()
             .unwrap(),
-            PreciseDateTimeResult::WithTimeZone(
+            PreciseDateTimeResult::TimeZone(
             FixedOffset::east_opt(0)
                 .unwrap()
                 .from_local_datetime(&NaiveDateTime::new(

--- a/core/src/value/partial.rs
+++ b/core/src/value/partial.rs
@@ -5,6 +5,7 @@ use snafu::{Backtrace, ResultExt, Snafu};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::ops::RangeInclusive;
+use crate::value::AsRange;
 
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
@@ -91,7 +92,7 @@ pub enum DateComponent {
 /// # use std::error::Error;
 /// # use std::convert::TryFrom;
 /// use chrono::NaiveDate;
-/// use dicom_core::value::{DicomDate, AsRange};
+/// use dicom_core::value::{DicomDate, AsRange, Precision};
 /// # fn main() -> Result<(), Box<dyn Error>> {
 ///
 /// let date = DicomDate::from_y(1492)?;
@@ -786,7 +787,7 @@ impl fmt::Debug for DicomDateTime {
 }
 
 
-/// This trait is implemented by partial precision date, time and date-time structures.
+/*/// This trait is implemented by partial precision date, time and date-time structures.
 /// This is useful to easily determine if the date / time value is precise without calling more expensive
 /// methods first.
 /// [Precision::precision()] method will retrieve the last fully precise component of it's stored date / time value.
@@ -847,7 +848,7 @@ impl fmt::Debug for DicomDateTime {
 pub trait Precision {
     /// will retrieve the last fully precise component of a date / time structure
     fn precision(&self) -> DateComponent;
-    /// returns true if value has all possible components
+    /// returns true if value has all possible date / time components
     fn is_precise(&self) -> bool;
 }
 
@@ -897,7 +898,7 @@ impl Precision for DicomDateTime {
             None => false
         }
     }
-}
+}*/
 
 impl DicomDate {
     /**

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -5051,7 +5051,6 @@ mod tests {
 
     #[test]
     fn primitive_value_to_datetime_range() {
-        let offset = FixedOffset::west_opt(3600).unwrap();
 
         assert_eq!(
             dicom_value!(Str, "202002-20210228153012.123")
@@ -5069,25 +5068,24 @@ mod tests {
             )
             .unwrap()
         );
-        // East UTC offset gets parsed
+        // East UTC offset gets parsed but will result in an ambiguous dt-range variant
         assert_eq!(
             PrimitiveValue::from(&b"2020-2030+0800"[..])
                 .to_datetime_range()
                 .unwrap(),
-            DateTimeRange::from_start_to_end_with_time_zone(
-                FixedOffset::east_opt(0) // this offset is missing, so generated
-                    .unwrap()
-                    .with_ymd_and_hms(2020, 1, 1, 0, 0, 0)
-                    .unwrap(),
-                FixedOffset::east_opt(8 * 3600)
+            DateTimeRange::AmbiguousStart { 
+                ambiguous_start: NaiveDateTime::new(
+                    NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+                    NaiveTime::from_hms_opt(0, 0, 0).unwrap()
+                ),
+                end: FixedOffset::east_opt(8 * 3600)
                     .unwrap()
                     .from_local_datetime(&NaiveDateTime::new(
                         NaiveDate::from_ymd_opt(2030, 12, 31).unwrap(),
                         NaiveTime::from_hms_micro_opt(23, 59, 59, 999_999).unwrap()
                     ))
                     .unwrap()
-            )
-            .unwrap()
+                }
         );
     }
 

--- a/core/src/value/range.rs
+++ b/core/src/value/range.rs
@@ -92,6 +92,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// This trait is implemented by date / time structures with partial precision.
 /// If the date / time structure is not precise, it is up to the user to call one of these
 /// methods to retrieve a suitable  [`chrono`] value.
+/// 
 ///
 /// # Examples
 ///
@@ -150,16 +151,6 @@ pub trait AsRange: Precision {
     /// Returns a tuple of the earliest and latest possible value from a partial precision structure.
     fn range(&self) -> Result<Self::Range>;
 
-    /// Returns `true` if partial precision structure has the maximum possible accuracy and is
-    /// a valid date / time.
-    /// For fraction of a second, the full 6 digits are required for the value to be precise.
-    /// 
-    fn is_precise(&self) -> bool {
-        let e = self.earliest();
-        let l = self.latest();
-
-        e.is_ok() && l.is_ok() && e.ok() == l.ok()
-    }
 }
 
 impl AsRange for DicomDate {
@@ -764,13 +755,13 @@ impl DateTimeRange {
         }
     }
 
-    pub fn has_time_zone(&self) -> bool {
+    /*pub fn has_time_zone(&self) -> bool {
         self.time_zone().is_some()
     }
 
     pub fn time_zone(&self) -> Option<&FixedOffset> {
-        self.time_zone()
-    }
+        self.time_zone.as_ref()
+    }*/
 }
 
 /**

--- a/core/src/value/serialize.rs
+++ b/core/src/value/serialize.rs
@@ -76,26 +76,23 @@ mod test {
     #[test]
     fn test_encode_datetime() {
         let mut data = vec![];
-        let offset = FixedOffset::east_opt(0).unwrap();
         let bytes = encode_datetime(
             &mut data,
             DicomDateTime::from_date_and_time(
                 DicomDate::from_ymd(1985, 12, 31).unwrap(),
-                DicomTime::from_hms_micro(23, 59, 48, 123_456).unwrap(),
-                offset,
+                DicomTime::from_hms_micro(23, 59, 48, 123_456).unwrap()
             )
             .unwrap(),
         )
         .unwrap();
-        // even zero offset gets encoded into string value
-        assert_eq!(from_utf8(&data).unwrap(), "19851231235948.123456+0000");
-        assert_eq!(bytes, 26);
+        assert_eq!(from_utf8(&data).unwrap(), "19851231235948.123456");
+        assert_eq!(bytes, 21);
 
         let mut data = vec![];
         let offset = FixedOffset::east_opt(3600).unwrap();
         let bytes = encode_datetime(
             &mut data,
-            DicomDateTime::from_date_and_time(
+            DicomDateTime::from_date_and_time_with_time_zone(
                 DicomDate::from_ymd(2018, 12, 24).unwrap(),
                 DicomTime::from_h(4).unwrap(),
                 offset,

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -812,7 +812,7 @@ fn value_summary(
             }
         }
         (Strs(values), VR::DT) => {
-            match value.to_multi_datetime(dicom_core::chrono::FixedOffset::east_opt(0).unwrap()) {
+            match value.to_multi_datetime() {
                 Ok(values) => {
                     // print as reformatted date
                     DumpValue::DateTime(format_value_list(values, max_characters, false))

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -889,7 +889,7 @@ where
                 AttributeSelectorStep::Nested { tag, item } => {
                     let e = obj
                         .entries
-                        .get(tag)
+                        .get(&tag)
                         .with_context(|| crate::MissingSequenceSnafu {
                             selector: selector.clone(),
                             step_index: i as u32,
@@ -1937,7 +1937,7 @@ mod tests {
         obj.put(instance_number);
 
         // add a date time
-        let dt = DicomDateTime::from_date_and_time(
+        let dt = DicomDateTime::from_date_and_time_with_time_zone(
             DicomDate::from_ymd(2022, 11, 22).unwrap(),
             DicomTime::from_hms(18, 09, 35).unwrap(),
             FixedOffset::east_opt(3600).unwrap(),

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -2,7 +2,6 @@
 //! which also supports text decoding.
 
 use crate::util::n_times;
-use chrono::FixedOffset;
 use dicom_core::header::{DataElementHeader, HasLength, Length, SequenceItemHeader, Tag, VR};
 use dicom_core::value::deserialize::{
     parse_date_partial, parse_datetime_partial, parse_time_partial,

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -230,7 +230,6 @@ pub struct StatefulDecoder<D, S, BD = BasicDecoder, TC = SpecificCharacterSet> {
     decoder: D,
     basic: BD,
     text: TC,
-    dt_utc_offset: FixedOffset,
     buffer: Vec<u8>,
     /// the assumed position of the reader source
     position: u64,
@@ -291,7 +290,6 @@ where
             basic: LittleEndianBasicDecoder,
             decoder: ExplicitVRLittleEndianDecoder::default(),
             text: DefaultCharacterSetCodec,
-            dt_utc_offset: FixedOffset::east_opt(0).unwrap(),
             buffer: Vec::with_capacity(PARSER_BUFFER_CAPACITY),
             position: 0,
         }
@@ -322,7 +320,6 @@ where
             basic,
             decoder,
             text,
-            dt_utc_offset: FixedOffset::east_opt(0).unwrap(),
             buffer: Vec::with_capacity(PARSER_BUFFER_CAPACITY),
             position,
         }
@@ -588,7 +585,7 @@ where
         let vec: Result<_> = buf
             .split(|b| *b == b'\\')
             .map(|part| {
-                parse_datetime_partial(part, self.dt_utc_offset).context(DeserializeValueSnafu {
+                parse_datetime_partial(part).context(DeserializeValueSnafu {
                     position: self.position,
                 })
             })


### PR DESCRIPTION
Please see this DicomDateTime rewrite that now can handle time zone aware and naive values.
External FixedOffset values no longer required.
some methods deprecated
some methods documented to be not optimal use of API
Breaking changes
This should fix #452 

Thank you !
