### PR TITLE
Update gdcm-rs to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
  "num-traits",
  "safe-transmute",
  "smallvec",
- "snafu 0.8.0",
+ "snafu",
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ dependencies = [
  "dicom-object",
  "dicom-transfer-syntax-registry",
  "owo-colors",
- "snafu 0.8.0",
+ "snafu",
  "terminal_size",
 ]
 
@@ -422,7 +422,7 @@ dependencies = [
  "dicom-object",
  "dicom-transfer-syntax-registry",
  "dicom-ul",
- "snafu 0.8.0",
+ "snafu",
  "tracing",
  "tracing-subscriber",
 ]
@@ -436,7 +436,7 @@ dependencies = [
  "dicom-dictionary-std",
  "encoding",
  "inventory",
- "snafu 0.8.0",
+ "snafu",
 ]
 
 [[package]]
@@ -451,7 +451,7 @@ dependencies = [
  "dicom-object",
  "dicom-transfer-syntax-registry",
  "dicom-ul",
- "snafu 0.8.0",
+ "snafu",
  "tracing",
  "tracing-subscriber",
 ]
@@ -465,7 +465,7 @@ dependencies = [
  "dicom-dictionary-std",
  "dicom-object",
  "image",
- "snafu 0.8.0",
+ "snafu",
  "tracing",
  "tracing-subscriber",
 ]
@@ -498,7 +498,7 @@ dependencies = [
  "dicom-transfer-syntax-registry",
  "itertools",
  "smallvec",
- "snafu 0.8.0",
+ "snafu",
  "tempfile",
  "tracing",
 ]
@@ -512,7 +512,7 @@ dependencies = [
  "dicom-dictionary-std",
  "dicom-encoding",
  "smallvec",
- "snafu 0.8.0",
+ "snafu",
  "tracing",
 ]
 
@@ -534,7 +534,7 @@ dependencies = [
  "num-traits",
  "rayon",
  "rstest",
- "snafu 0.8.0",
+ "snafu",
  "tracing",
  "tracing-subscriber",
 ]
@@ -546,7 +546,7 @@ dependencies = [
  "clap",
  "dicom-dictionary-std",
  "dicom-ul",
- "snafu 0.8.0",
+ "snafu",
  "tracing",
  "tracing-subscriber",
 ]
@@ -562,7 +562,7 @@ dependencies = [
  "dicom-object",
  "dicom-transfer-syntax-registry",
  "dicom-ul",
- "snafu 0.8.0",
+ "snafu",
  "tracing",
  "tracing-subscriber",
 ]
@@ -580,7 +580,7 @@ dependencies = [
  "dicom-transfer-syntax-registry",
  "dicom-ul",
  "indicatif",
- "snafu 0.8.0",
+ "snafu",
  "tracing",
  "tracing-subscriber",
  "walkdir",
@@ -606,7 +606,7 @@ dependencies = [
  "dicom-dictionary-std",
  "dicom-object",
  "dicom-pixeldata",
- "snafu 0.8.0",
+ "snafu",
  "tracing",
  "tracing-subscriber",
 ]
@@ -634,7 +634,7 @@ dependencies = [
  "dicom-encoding",
  "dicom-transfer-syntax-registry",
  "matches",
- "snafu 0.8.0",
+ "snafu",
  "tracing",
 ]
 
@@ -653,12 +653,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -918,14 +912,14 @@ dependencies = [
 
 [[package]]
 name = "gdcm-rs"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5acb16bb2d49e6414ea834250ecf97a4d248e02b2b5dc4c644e615d6e1c9f7"
+checksum = "dea719b974ad4837aabb2a5fbee4c8fb6b5fbf5d55db4212c50ffb63b8538e2e"
 dependencies = [
  "cc",
  "cmake",
  "libc",
- "snafu 0.7.5",
+ "snafu",
  "strum",
  "strum_macros",
 ]
@@ -1161,9 +1155,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1698,40 +1692,18 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "snafu"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+checksum = "5ed22871b3fe6eff9f1b48f6cbd54149ff8e9acd740dea9146092435f9c43bd3"
 dependencies = [
- "doc-comment",
- "snafu-derive 0.7.5",
-]
-
-[[package]]
-name = "snafu"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d342c51730e54029130d7dc9fd735d28c4cd360f1368c01981d4f03ff207f096"
-dependencies = [
- "snafu-derive 0.8.0",
+ "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080c44971436b1af15d6f61ddd8b543995cf63ab8e677d46b00cc06f4ef267a0"
+checksum = "4651148226ec36010993fcba6c3381552e8463e9f3e337b75af202b0688b5274"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1762,21 +1734,21 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -23,7 +23,7 @@ dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry", version
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.6.1" }
 snafu = "0.8"
 byteorder = "1.4.3"
-gdcm-rs = { version = "0.5.0", optional = true }
+gdcm-rs = { version = "0.6", optional = true }
 rayon = { version = "1.5.0", optional = true }
 ndarray = { version = "0.15.1", optional = true }
 num-traits = "0.2.12"

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -15,7 +15,7 @@
 //! [GDCM bindings]: https://crates.io/crates/gdcm-rs
 //!
 //! ```toml
-//! dicom-pixeldata = { version = "0.1", features = ["gdcm"] }
+//! dicom-pixeldata = { version = "0.2", features = ["gdcm"] }
 //! ```
 //!
 //! Once the pixel data is decoded,


### PR DESCRIPTION
### Summary

- Update gdcm-rs to 0.6
- Update doc comment in crate root
