### PR TITLE
[parent] Re-export more Cargo features from pixeldata

### DIFF
--- a/parent/Cargo.toml
+++ b/parent/Cargo.toml
@@ -17,6 +17,8 @@ inventory-registry = ['dicom-encoding/inventory-registry', 'dicom-transfer-synta
 backtraces = ['dicom-object/backtraces']
 ul = ['dicom-ul']
 pixeldata = ['dicom-pixeldata']
+image = ["pixeldata", "dicom-pixeldata/image"]
+ndarray = ["pixeldata", "dicom-pixeldata/ndarray"]
 
 [dependencies]
 dicom-core = { path = "../core", version = "0.6.3" }

--- a/parent/README.md
+++ b/parent/README.md
@@ -44,7 +44,9 @@ for more information.
 The following root modules are behind Cargo features enabled by default:
 
 - [`ul`]: the DICOM upper layer protocol library
-- [`pixeldata`]: the pixel data abstraction library
+- [`pixeldata`]: the pixel data abstraction library.
+  The Cargo features `image`, `ndarray` are re-exported from `dicom-pixeldata`
+  and may be enabled at will through the parent crate.
 
 If you do not intend to use these modules,
 you can disable these features accordingly.


### PR DESCRIPTION
This exposes Cargo features `image` and `ndarray` from `dicom-pixeldata` to the parent crate. This will make it possible to use pixel data image and ndarray conversion capabilities through `dicom` like the example TOML below, hopefully preventing confusions similar to #465.

```toml
dicom = { version = "0.7", features = ["image", "ndarray"] }
```
