### PR TITLE
Extend type parameter list in `FileMetaTable.set_transfer_syntax`

### DIFF
--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -227,15 +227,10 @@ impl FileMetaTable {
     /// Set the file meta table's transfer syntax
     /// according to the given transfer syntax descriptor.
     ///
-    /// Extra padding to even length is trimmed.
-    ///
-    /// Note that the field `information_group_length` is _not_ updated
-    /// to consider the length of the new transfer syntax.
-    /// Should you wish to keep the field up to date,
-    /// call [`update_information_group_length`][1] afterwards.
-    ///
-    /// [1]: FileMetaTable::update_information_group_length
-    pub fn set_transfer_syntax<D, P>(&mut self, ts: &TransferSyntax<D, P>) {
+    /// This replaces the table's transfer syntax UID
+    /// to the given transfer syntax, without padding to even length.
+    /// The information group length field is automatically recalculated.
+    pub fn set_transfer_syntax<D, R, W>(&mut self, ts: &TransferSyntax<D, R, W>) {
         self.transfer_syntax = ts
             .uid()
             .trim_end_matches(|c: char| c.is_whitespace() || c == '\0')
@@ -1197,9 +1192,8 @@ mod tests {
             156 + dicom_len(IMPLEMENTATION_CLASS_UID) + dicom_len(IMPLEMENTATION_VERSION_NAME)
         );
 
-        // Note (#409): erased is required due to a missing type parameter in the setter
         table.set_transfer_syntax(
-            &dicom_transfer_syntax_registry::entries::IMPLICIT_VR_LITTLE_ENDIAN.erased(),
+            &dicom_transfer_syntax_registry::entries::IMPLICIT_VR_LITTLE_ENDIAN,
         );
         assert_eq!(
             table.information_group_length,

--- a/pixeldata/src/transcode.rs
+++ b/pixeldata/src/transcode.rs
@@ -212,7 +212,7 @@ where
 
                 // change transfer syntax to Explicit VR little endian
                 self.meta_mut()
-                    .set_transfer_syntax(&EXPLICIT_VR_LITTLE_ENDIAN.erased());
+                    .set_transfer_syntax(&EXPLICIT_VR_LITTLE_ENDIAN);
 
                 // use RWPixel adapter API
                 let mut offset_table = Vec::new();


### PR DESCRIPTION
Resolves #409.

### Summary

- [object] (breaking change) extend type parameters in `FileMetaTable.set_transfer_syntax` to the list `D, R, W`
- [pixeldata] Update call to `set_transfer_syntax in transcode module
