### PR TITLE
Improve storescp to handle multiple p-data values

### DIFF
--- a/storescp/src/main.rs
+++ b/storescp/src/main.rs
@@ -250,6 +250,7 @@ fn run(scu_stream: TcpStream, args: &App) -> Result<(), Whatever> {
                             "Released association with {}",
                             association.client_ae_title()
                         );
+                        break;
                     }
                     Pdu::AbortRQ { source } => {
                         warn!("Aborted connection from: {:?}", source);
@@ -268,7 +269,13 @@ fn run(scu_stream: TcpStream, args: &App) -> Result<(), Whatever> {
             }
         }
     }
-    info!("Dropping connection with {}", association.client_ae_title());
+
+    if let Ok(peer_addr) = association.inner_stream().peer_addr() {
+        info!("Dropping connection with {} ({})", association.client_ae_title(), peer_addr);
+    } else {
+        info!("Dropping connection with {}", association.client_ae_title());
+    }
+
     Ok(())
 }
 

--- a/storescp/src/main.rs
+++ b/storescp/src/main.rs
@@ -10,7 +10,7 @@ use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_object::{FileMetaTableBuilder, InMemDicomObject, StandardDataDictionary};
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use dicom_ul::{pdu::PDataValueType, Pdu};
-use snafu::{OptionExt, ResultExt, Whatever};
+use snafu::{OptionExt, Report, ResultExt, Whatever};
 use tracing::{debug, error, info, warn, Level};
 
 use crate::transfer::ABSTRACT_SYNTAXES;
@@ -260,11 +260,15 @@ fn run(scu_stream: TcpStream, args: &App) -> Result<(), Whatever> {
                 }
             }
             Err(err @ dicom_ul::association::server::Error::Receive { .. }) => {
-                debug!("{}", err);
+                if verbose {
+                    info!("{}", Report::from_error(err));
+                } else {
+                    info!("{}", err);
+                }
                 break;
             }
             Err(err) => {
-                warn!("Unexpected error: {}", snafu::Report::from_error(err));
+                warn!("Unexpected error: {}", Report::from_error(err));
                 break;
             }
         }

--- a/storescp/src/main.rs
+++ b/storescp/src/main.rs
@@ -106,133 +106,136 @@ fn run(scu_stream: TcpStream, args: &App) -> Result<(), Whatever> {
                             continue;
                         }
 
-                        if data[0].value_type == PDataValueType::Data && !data[0].is_last {
-                            instance_buffer.append(&mut data[0].data);
-                        } else if data[0].value_type == PDataValueType::Command && data[0].is_last {
-                            // commands are always in implict VR LE
-                            let ts =
-                                dicom_transfer_syntax_registry::entries::IMPLICIT_VR_LITTLE_ENDIAN
-                                    .erased();
-                            let data_value = &data[0];
-                            let v = &data_value.data;
+                        for data_value in data {
 
-                            let obj = InMemDicomObject::read_dataset_with_ts(v.as_slice(), &ts)
-                                .whatever_context("failed to read incoming DICOM command")?;
-                            let command_field = obj
-                                .element(tags::COMMAND_FIELD)
-                                .whatever_context("Missing Command Field")?
-                                .uint16()
-                                .whatever_context("Command Field is not an integer")?;
+                            if data_value.value_type == PDataValueType::Data && !data_value.is_last {
+                                instance_buffer.append(&mut data_value.data);
+                            } else if data_value.value_type == PDataValueType::Command && data_value.is_last {
+                                // commands are always in implict VR LE
+                                let ts =
+                                    dicom_transfer_syntax_registry::entries::IMPLICIT_VR_LITTLE_ENDIAN
+                                        .erased();
+                                let data_value = &data_value;
+                                let v = &data_value.data;
 
-                            if command_field == 0x0030 {
-                                // Handle C-ECHO-RQ
-                                let cecho_response = create_cecho_response(msgid);
-                                let mut cecho_data = Vec::new();
+                                let obj = InMemDicomObject::read_dataset_with_ts(v.as_slice(), &ts)
+                                    .whatever_context("failed to read incoming DICOM command")?;
+                                let command_field = obj
+                                    .element(tags::COMMAND_FIELD)
+                                    .whatever_context("Missing Command Field")?
+                                    .uint16()
+                                    .whatever_context("Command Field is not an integer")?;
 
-                                cecho_response
-                                    .write_dataset_with_ts(&mut cecho_data, &ts)
-                                    .whatever_context("could not write C-ECHO response object")?;
+                                if command_field == 0x0030 {
+                                    // Handle C-ECHO-RQ
+                                    let cecho_response = create_cecho_response(msgid);
+                                    let mut cecho_data = Vec::new();
+
+                                    cecho_response
+                                        .write_dataset_with_ts(&mut cecho_data, &ts)
+                                        .whatever_context("could not write C-ECHO response object")?;
+
+                                    let pdu_response = Pdu::PData {
+                                        data: vec![dicom_ul::pdu::PDataValue {
+                                            presentation_context_id: data_value.presentation_context_id,
+                                            value_type: PDataValueType::Command,
+                                            is_last: true,
+                                            data: cecho_data,
+                                        }],
+                                    };
+                                    association.send(&pdu_response).whatever_context(
+                                        "failed to send C-ECHO response object to SCU",
+                                    )?;
+                                } else {
+                                    msgid = obj
+                                        .element(tags::MESSAGE_ID)
+                                        .whatever_context("Missing Message ID")?
+                                        .to_int()
+                                        .whatever_context("Message ID is not an integer")?;
+                                    sop_class_uid = obj
+                                        .element(tags::AFFECTED_SOP_CLASS_UID)
+                                        .whatever_context("missing Affected SOP Class UID")?
+                                        .to_str()
+                                        .whatever_context("could not retrieve Affected SOP Class UID")?
+                                        .to_string();
+                                    sop_instance_uid = obj
+                                        .element(tags::AFFECTED_SOP_INSTANCE_UID)
+                                        .whatever_context("missing Affected SOP Instance UID")?
+                                        .to_str()
+                                        .whatever_context(
+                                            "could not retrieve Affected SOP Instance UID",
+                                        )?
+                                        .to_string();
+                                }
+                                instance_buffer.clear();
+                            } else if data_value.value_type == PDataValueType::Data && data_value.is_last {
+                                instance_buffer.append(&mut data_value.data);
+
+                                let presentation_context = association
+                                    .presentation_contexts()
+                                    .iter()
+                                    .find(|pc| pc.id == data_value.presentation_context_id)
+                                    .whatever_context("missing presentation context")?;
+                                let ts = &presentation_context.transfer_syntax;
+
+                                let obj = InMemDicomObject::read_dataset_with_ts(
+                                    instance_buffer.as_slice(),
+                                    TransferSyntaxRegistry.get(ts).unwrap(),
+                                )
+                                .whatever_context("failed to read DICOM data object")?;
+                                let file_meta = FileMetaTableBuilder::new()
+                                    .media_storage_sop_class_uid(
+                                        obj.element(tags::SOP_CLASS_UID)
+                                            .whatever_context("missing SOP Class UID")?
+                                            .to_str()
+                                            .whatever_context("could not retrieve SOP Class UID")?,
+                                    )
+                                    .media_storage_sop_instance_uid(
+                                        obj.element(tags::SOP_INSTANCE_UID)
+                                            .whatever_context("missing SOP Instance UID")?
+                                            .to_str()
+                                            .whatever_context("missing SOP Instance UID")?,
+                                    )
+                                    .transfer_syntax(ts)
+                                    .build()
+                                    .whatever_context("failed to build DICOM meta file information")?;
+                                let file_obj = obj.with_exact_meta(file_meta);
+
+                                // write the files to the current directory with their SOPInstanceUID as filenames
+                                let mut file_path = out_dir.clone();
+                                file_path
+                                    .push(sop_instance_uid.trim_end_matches('\0').to_string() + ".dcm");
+                                file_obj
+                                    .write_to_file(&file_path)
+                                    .whatever_context("could not save DICOM object to file")?;
+                                info!("Stored {}", file_path.display());
+
+                                // send C-STORE-RSP object
+                                // commands are always in implict VR LE
+                                let ts =
+                                    dicom_transfer_syntax_registry::entries::IMPLICIT_VR_LITTLE_ENDIAN
+                                        .erased();
+
+                                let obj =
+                                    create_cstore_response(msgid, &sop_class_uid, &sop_instance_uid);
+
+                                let mut obj_data = Vec::new();
+
+                                obj.write_dataset_with_ts(&mut obj_data, &ts)
+                                    .whatever_context("could not write response object")?;
 
                                 let pdu_response = Pdu::PData {
                                     data: vec![dicom_ul::pdu::PDataValue {
-                                        presentation_context_id: data[0].presentation_context_id,
+                                        presentation_context_id: data_value.presentation_context_id,
                                         value_type: PDataValueType::Command,
                                         is_last: true,
-                                        data: cecho_data,
+                                        data: obj_data,
                                     }],
                                 };
-                                association.send(&pdu_response).whatever_context(
-                                    "failed to send C-ECHO response object to SCU",
-                                )?;
-                            } else {
-                                msgid = obj
-                                    .element(tags::MESSAGE_ID)
-                                    .whatever_context("Missing Message ID")?
-                                    .to_int()
-                                    .whatever_context("Message ID is not an integer")?;
-                                sop_class_uid = obj
-                                    .element(tags::AFFECTED_SOP_CLASS_UID)
-                                    .whatever_context("missing Affected SOP Class UID")?
-                                    .to_str()
-                                    .whatever_context("could not retrieve Affected SOP Class UID")?
-                                    .to_string();
-                                sop_instance_uid = obj
-                                    .element(tags::AFFECTED_SOP_INSTANCE_UID)
-                                    .whatever_context("missing Affected SOP Instance UID")?
-                                    .to_str()
-                                    .whatever_context(
-                                        "could not retrieve Affected SOP Instance UID",
-                                    )?
-                                    .to_string();
+                                association
+                                    .send(&pdu_response)
+                                    .whatever_context("failed to send response object to SCU")?;
                             }
-                            instance_buffer.clear();
-                        } else if data[0].value_type == PDataValueType::Data && data[0].is_last {
-                            instance_buffer.append(&mut data[0].data);
-
-                            let presentation_context = association
-                                .presentation_contexts()
-                                .iter()
-                                .find(|pc| pc.id == data[0].presentation_context_id)
-                                .whatever_context("missing presentation context")?;
-                            let ts = &presentation_context.transfer_syntax;
-
-                            let obj = InMemDicomObject::read_dataset_with_ts(
-                                instance_buffer.as_slice(),
-                                TransferSyntaxRegistry.get(ts).unwrap(),
-                            )
-                            .whatever_context("failed to read DICOM data object")?;
-                            let file_meta = FileMetaTableBuilder::new()
-                                .media_storage_sop_class_uid(
-                                    obj.element(tags::SOP_CLASS_UID)
-                                        .whatever_context("missing SOP Class UID")?
-                                        .to_str()
-                                        .whatever_context("could not retrieve SOP Class UID")?,
-                                )
-                                .media_storage_sop_instance_uid(
-                                    obj.element(tags::SOP_INSTANCE_UID)
-                                        .whatever_context("missing SOP Instance UID")?
-                                        .to_str()
-                                        .whatever_context("missing SOP Instance UID")?,
-                                )
-                                .transfer_syntax(ts)
-                                .build()
-                                .whatever_context("failed to build DICOM meta file information")?;
-                            let file_obj = obj.with_exact_meta(file_meta);
-
-                            // write the files to the current directory with their SOPInstanceUID as filenames
-                            let mut file_path = out_dir.clone();
-                            file_path
-                                .push(sop_instance_uid.trim_end_matches('\0').to_string() + ".dcm");
-                            file_obj
-                                .write_to_file(&file_path)
-                                .whatever_context("could not save DICOM object to file")?;
-                            info!("Stored {}", file_path.display());
-
-                            // send C-STORE-RSP object
-                            // commands are always in implict VR LE
-                            let ts =
-                                dicom_transfer_syntax_registry::entries::IMPLICIT_VR_LITTLE_ENDIAN
-                                    .erased();
-
-                            let obj =
-                                create_cstore_response(msgid, &sop_class_uid, &sop_instance_uid);
-
-                            let mut obj_data = Vec::new();
-
-                            obj.write_dataset_with_ts(&mut obj_data, &ts)
-                                .whatever_context("could not write response object")?;
-
-                            let pdu_response = Pdu::PData {
-                                data: vec![dicom_ul::pdu::PDataValue {
-                                    presentation_context_id: data[0].presentation_context_id,
-                                    value_type: PDataValueType::Command,
-                                    is_last: true,
-                                    data: obj_data,
-                                }],
-                            };
-                            association
-                                .send(&pdu_response)
-                                .whatever_context("failed to send response object to SCU")?;
                         }
                     }
                     Pdu::ReleaseRQ => {


### PR DESCRIPTION
### Summary

- Fix p-data multi-value handling so that it can handle multiple values in a single PDU
- Add connection drop after sending release RP
- Tweak error reporting