### PR TITLE
Fix pixel sample rearrangement in RLE lossless

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,10 @@ name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -572,13 +576,14 @@ dependencies = [
 
 [[package]]
 name = "dicom-test-files"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7cfbf6830242fbfbc024e368323d8a9cc40ca75f5d6dbde526090f0daea946c"
+checksum = "e49b5fdbe62d77c5a5606b0fc246591e3e29aea78fa4373c736f10e8d6569ba5"
 dependencies = [
  "sha2",
  "tempfile",
  "ureq",
+ "zstd",
 ]
 
 [[package]]
@@ -1107,6 +1112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1352,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "png"
@@ -2276,6 +2296,35 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zstd"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -20,5 +20,5 @@ serde_json = { version = "1.0.96", features = ["preserve_order"] }
 tracing = "0.1.34"
 
 [dev-dependencies]
-dicom-test-files = "0.2.1"
+dicom-test-files = "0.3"
 pretty_assertions = "1.3.0"

--- a/object/Cargo.toml
+++ b/object/Cargo.toml
@@ -27,4 +27,4 @@ tracing = "0.1.34"
 
 [dev-dependencies]
 tempfile = "3.2.0"
-dicom-test-files = "0.2.1"
+dicom-test-files = "0.3"

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -46,7 +46,7 @@ optional = true
 
 [dev-dependencies]
 rstest = "0.18.1"
-dicom-test-files = "0.2.1"
+dicom-test-files = "0.3"
 
 [features]
 default = ["rayon", "native"]

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -63,4 +63,4 @@ optional = true
 features = ["native"]
 
 [dev-dependencies]
-dicom-test-files = "0.2.1"
+dicom-test-files = "0.3"

--- a/transfer-syntax-registry/src/adapters/rle_lossless.rs
+++ b/transfer-syntax-registry/src/adapters/rle_lossless.rs
@@ -99,7 +99,12 @@ impl PixelDataReader for RleLosslessAdapter {
                     // MSB G channel: 5, 11, 17, ...
                     // LSB G channel: 4, 10, 16, ...
                     let frame_start = i * frame_size;
-                    let start = frame_start + sample_number * bytes_per_sample + byte_offset;
+                    let start = frame_start +  if samples_per_pixel == 3 {
+                        sample_number * bytes_per_sample + byte_offset
+                    } else {
+                        sample_number * bytes_per_sample + samples_per_pixel - byte_offset
+                    };
+
                     let end = (i + 1) * frame_size;
                     for (decoded_index, dst_index) in (start..end)
                         .step_by(bytes_per_sample * samples_per_pixel)
@@ -196,7 +201,12 @@ impl PixelDataReader for RleLosslessAdapter {
                     .unwrap();
 
                 // Interleave pixels as described in the example above.
-                let start = sample_number * bytes_per_sample + byte_offset;
+                let start = if samples_per_pixel == 3 {
+                    sample_number * bytes_per_sample + byte_offset
+                } else {
+                    sample_number * bytes_per_sample + samples_per_pixel - byte_offset
+                };
+
                 let end = frame_size;
                 for (decoded_index, dst_index) in (start..end)
                     .step_by(bytes_per_sample * samples_per_pixel)

--- a/transfer-syntax-registry/src/adapters/rle_lossless.rs
+++ b/transfer-syntax-registry/src/adapters/rle_lossless.rs
@@ -20,7 +20,7 @@ pub struct RleLosslessAdapter;
 impl PixelDataReader for RleLosslessAdapter {
     /// Decode the DICOM image from RLE Lossless completely.
     ///
-    /// See <http://dicom.nema.org/medical/Dicom/2018d/output/chtml/part05/chapter_G.html>
+    /// See <https://dicom.nema.org/medical/dicom/2023e/output/chtml/part05/chapter_G.html>
     fn decode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> DecodeResult<()> {
         let cols = src
             .cols()
@@ -115,7 +115,7 @@ impl PixelDataReader for RleLosslessAdapter {
 
     /// Decode a singe frame of the DICOM image from RLE Lossless.
     ///
-    /// See <http://dicom.nema.org/medical/Dicom/2018d/output/chtml/part05/chapter_G.html>
+    /// See <https://dicom.nema.org/medical/dicom/2023e/output/chtml/part05/chapter_G.html>
     fn decode_frame(
         &self,
         src: &dyn PixelDataObject,

--- a/transfer-syntax-registry/tests/rle.rs
+++ b/transfer-syntax-registry/tests/rle.rs
@@ -1,0 +1,166 @@
+//! Test suite for RLE lossless pixel data reading and writing
+#![cfg(feature = "rle")]
+
+mod adapters;
+
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    path::Path,
+};
+
+use adapters::TestDataObject;
+use dicom_core::value::PixelFragmentSequence;
+use dicom_encoding::{adapters::PixelDataReader, Codec};
+use dicom_transfer_syntax_registry::entries::RLE_LOSSLESS;
+
+fn read_data_piece(test_file: impl AsRef<Path>, offset: u64, length: usize) -> Vec<u8> {
+    let mut file = File::open(test_file).unwrap();
+    let mut buf = vec![0; length];
+    file.seek(SeekFrom::Start(offset)).unwrap();
+    file.read_exact(&mut buf).unwrap();
+    buf
+}
+
+fn check_u16_rgb_pixel(pixels: &[u8], columns: u16, x: u16, y: u16, expected_pixel: [u16; 3]) {
+    let i = (y as usize * columns as usize * 3 + x as usize * 3) * 2;
+    let got = [
+        u16::from_le_bytes([pixels[i], pixels[i + 1]]),
+        u16::from_le_bytes([pixels[i + 2], pixels[i + 3]]),
+        u16::from_le_bytes([pixels[i + 4], pixels[i + 5]]),
+    ];
+    assert_eq!(
+        got, expected_pixel,
+        "pixel sample mismatch at ({}, {}): {:?} vs {:?}",
+        x, y, got, expected_pixel
+    );
+}
+
+fn check_i16_monochrome_pixel(pixels: &[u8], columns: u16, x: u16, y: u16, expected: i16) {
+    let i = (y as usize * columns as usize + x as usize) * 2;
+    let got = i16::from_le_bytes([pixels[i], pixels[i + 1]]);
+    assert_eq!(
+        got, expected,
+        "pixel sample mismatch at ({}, {}): {:?} vs {:?}",
+        x, y, got, expected
+    );
+}
+
+#[test]
+fn read_rle_1() {
+    let test_file = dicom_test_files::path("WG04/RLE/CT1_RLE").unwrap();
+
+    // manually fetch the pixel data fragment from the file:
+
+    // PixelData offset: 0x18f6
+    // first fragment item offset: 0x1902
+    // first fragment size: 4
+    // second fragment item offset: 0x190e
+    // second fragment size: 248330
+
+    // single fragment found in file data offset 0x1916, 248330 bytes
+    let buf = read_data_piece(test_file, 0x1916, 248330);
+
+    // create test object
+    let obj = TestDataObject {
+        // RLE lossless
+        ts_uid: "1.2.840.10008.1.2.5".to_string(),
+        rows: 512,
+        columns: 512,
+        bits_allocated: 16,
+        bits_stored: 16,
+        samples_per_pixel: 1,
+        number_of_frames: 1,
+        flat_pixel_data: None,
+        pixel_data_sequence: Some(PixelFragmentSequence::new(vec![], vec![buf])),
+    };
+
+    // instantiate RLE lossless adapter
+
+    let Codec::EncapsulatedPixelData(Some(adapter), _) = RLE_LOSSLESS.codec() else {
+        panic!("RLE lossless pixel data reader not found")
+    };
+
+    let mut dest = vec![];
+
+    // decode the whole image (1 frame)
+
+    adapter
+        .decode(&obj, &mut dest)
+        .expect("RLE frame decoding failed");
+
+    // inspect the result
+    assert_eq!(dest.len(), 512 * 512 * 2);
+
+    // check a few known pixels
+    check_i16_monochrome_pixel(&dest, 512, 16, 16, -2_000);
+
+    check_i16_monochrome_pixel(&dest, 512, 255, 255, 980);
+
+    check_i16_monochrome_pixel(&dest, 512, 342, 336, 188);
+
+    // decode a single frame
+    let mut dest2 = vec![];
+    adapter
+        .decode_frame(&obj, 0, &mut dest2)
+        .expect("RLE frame decoding failed");
+
+    // the outcome should be the same
+    assert_eq!(dest, dest2);
+}
+
+#[test]
+fn read_rle_2() {
+    let test_file = dicom_test_files::path("pydicom/SC_rgb_rle_16bit.dcm").unwrap();
+
+    // manually fetch the pixel data fragment from the file:
+    // PixelData offset: 0x51a
+    // first fragment item offset: 0x526
+    // first fragment size: 0
+    // second fragment item offset: 0x52e
+    // second fragment size: 1264
+
+    // single fragment found in file data offset 0x536, 1264 bytes
+    let buf = read_data_piece(test_file, 0x536, 1_264);
+
+    // create test object
+    let obj = TestDataObject {
+        // RLE lossless
+        ts_uid: "1.2.840.10008.1.2.5".to_string(),
+        rows: 100,
+        columns: 100,
+        bits_allocated: 16,
+        bits_stored: 16,
+        samples_per_pixel: 3,
+        number_of_frames: 1,
+        flat_pixel_data: None,
+        pixel_data_sequence: Some(PixelFragmentSequence::new(vec![], vec![buf])),
+    };
+
+    // instantiate RLE lossless adapter
+
+    let Codec::EncapsulatedPixelData(Some(adapter), _) = RLE_LOSSLESS.codec() else {
+        panic!("RLE lossless pixel data reader not found")
+    };
+
+    let mut dest = vec![];
+
+    // decode the whole image (1 frame)
+
+    adapter
+        .decode(&obj, &mut dest)
+        .expect("RLE frame decoding failed");
+
+    // inspect the result
+    assert_eq!(dest.len(), 100 * 100 * 2 * 3);
+
+    // check a few known pixels
+    check_u16_rgb_pixel(&dest, 100, 0, 0, [0xFFFF, 0, 0]);
+
+    check_u16_rgb_pixel(&dest, 100, 99, 19, [0xFFFF, 32_896, 32_896]);
+
+    check_u16_rgb_pixel(&dest, 100, 54, 65, [0, 0, 0]);
+
+    check_u16_rgb_pixel(&dest, 100, 10, 95, [0xFFFF, 0xFFFF, 0xFFFF]);
+
+}


### PR DESCRIPTION
Fixes #457.

### Summary

- Update `dicom-test-files` to v0.3.0
- Add RLE lossless decoding tests
- [ts-registry] update references to DICOM standard in `rle_lossless`
- [ts-registry] Fix pixel sample arrangement bug in RLE lossless
