### PR TITLE
Change monochrome reinterpretation requirements from pixel data readers

### DIFF
--- a/encoding/src/adapters.rs
+++ b/encoding/src/adapters.rs
@@ -236,11 +236,13 @@ pub trait PixelDataReader {
     /// The output is a sequence of native pixel values
     /// which follow the image properties of the given object
     /// _save for the photometric interpretation and planar configuration_.
-    /// The output of an image with 1 sample per pixel
-    /// is expected to be interpreted as `MONOCHROME2`,
-    /// and for 3-channel images,
+    /// If the image has 3 samples per pixel,
     /// the output must be in RGB with each pixel contiguous in memory
     /// (planar configuration of 0).
+    /// However, if the image is monochrome,
+    /// the output should retain the photometric interpretation of the source object
+    /// (so that images in _MONOCHROME1_ continue to be in _MONOCHROME1_
+    /// and images in _MONOCHROME2_ continue to be in _MONOCHROME2_).
     fn decode(&self, src: &dyn PixelDataObject, dst: &mut Vec<u8>) -> DecodeResult<()> {
         let frames = src
             .number_of_frames()
@@ -257,6 +259,8 @@ pub trait PixelDataReader {
     /// as a byte stream in little endian,
     /// appending these bytes to the given vector `dst`.
     ///
+    /// The frame index is 0-based.
+    ///
     /// It is a necessary precondition that the object's pixel data
     /// is encoded in accordance to the transfer syntax(es)
     /// supported by this adapter.
@@ -265,11 +269,13 @@ pub trait PixelDataReader {
     /// The output is a sequence of native pixel values of a frame
     /// which follow the image properties of the given object
     /// _save for the photometric interpretation and planar configuration_.
-    /// The output of an image with 1 sample per pixel
-    /// is expected to be interpreted as `MONOCHROME2`,
-    /// and for 3-channel images,
+    /// If the image has 3 samples per pixel,
     /// the output must be in RGB with each pixel contiguous in memory
     /// (planar configuration of 0).
+    /// However, if the image is monochrome,
+    /// the output should retain the photometric interpretation of the source object
+    /// (so that images in _MONOCHROME1_ continue to be in _MONOCHROME1_
+    /// and images in _MONOCHROME2_ continue to be in _MONOCHROME2_).
     fn decode_frame(
         &self,
         src: &dyn PixelDataObject,

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -1971,9 +1971,8 @@ where
                 .context(DecodePixelDataSnafu)?;
 
             // pixels are already interpreted,
-            // set new photometric interpretation
+            // set new photometric interpretation if necessary
             let new_pi = match samples_per_pixel {
-                1 => PhotometricInterpretation::Monochrome2,
                 3 => PhotometricInterpretation::Rgb,
                 _ => photometric_interpretation,
             };
@@ -2075,9 +2074,8 @@ where
                 .context(DecodePixelDataSnafu)?;
 
             // pixels are already interpreted,
-            // set new photometric interpretation
+            // set new photometric interpretation if necessary
             let new_pi = match samples_per_pixel {
-                1 => PhotometricInterpretation::Monochrome2,
                 3 => PhotometricInterpretation::Rgb,
                 _ => photometric_interpretation,
             };
@@ -2701,5 +2699,19 @@ mod tests {
             ));
             image.save(image_path).unwrap();
         }
+    }
+
+    /// Loading a MONOCHROME1 image with encapsulated pixel data
+    /// should not change the photometric interpretation
+    #[cfg(feature = "jpeg")]
+    #[test]
+    fn test_monochrome1_decode_retains_pmi() {
+        let path = dicom_test_files::path("WG04/JPLL/RG1_JPLL").unwrap();
+        let obj = dicom_object::open_file(&path).unwrap();
+        let pixel_data = obj.decode_pixel_data().unwrap();
+        assert_eq!(
+            pixel_data.photometric_interpretation(),
+            &PhotometricInterpretation::Monochrome1
+        );
     }
 }

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -2703,7 +2703,8 @@ mod tests {
 
     /// Loading a MONOCHROME1 image with encapsulated pixel data
     /// should not change the photometric interpretation
-    #[cfg(feature = "jpeg")]
+    /// (this rule does not apply to decoding via GDCM)
+    #[cfg(all(feature = "jpeg", not(feature = "gdcm")))]
     #[test]
     fn test_monochrome1_decode_retains_pmi() {
         let path = dicom_test_files::path("WG04/JPLL/RG1_JPLL").unwrap();


### PR DESCRIPTION
This fixes a mismatch between the pixel data readers' monochrome output and the way that said output was being used, thus fixing cases where the photometric interpretation was being erroneously changed from MONOCHROME1 to MONOCHROME2 for encapsulated pixel data.

### Summary

- [encoding] (change) change expectations of PixelDataReader to match implementations
   - When decoding monochrome images, `decode` and `decode_frame` should retain the photometric interpretation of the source object (monochrome1 or monochrome2)
This is the most intuitive approach with less effort for decoders. It does not apply to GDCM integration though, which will convert monochrome1 images to monochrome2.
- [pixeldata] fix photometric interpretation reset after pixel data decoding
   - decoding a monochrome image no longer implies a change to the photometric interpretation
