### PR TITLE
Add HTJ2K transfer syntaxes

### DIFF
--- a/transfer-syntax-registry/src/entries.rs
+++ b/transfer-syntax-registry/src/entries.rs
@@ -197,6 +197,13 @@ pub const JPIP_REFERENCED_DEFLATE: Ts = Ts::new_ele(
     Codec::Dataset(None),
 );
 
+/// **Stub descriptor:** JPIP Referenced Deflate
+pub const JPIP_HTJ2K_REFERENCED_DEFLATE: Ts = Ts::new_ele(
+    "1.2.840.10008.1.2.4.205",
+    "JPIP HTJ2K Referenced Deflate",
+    Codec::Dataset(None),
+);
+
 // --- JPEG 2000 support ---
 
 /// An alias for a transfer syntax specifier with [`Jpeg2000Adapter`]
@@ -263,6 +270,48 @@ pub const JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION: Ts = create_ts_stub
     "1.2.840.10008.1.2.4.93",
     "JPEG 2000 Part 2 Multi-component Image Compression",
 );
+
+// --- HTJ2K ---
+
+/// **Decoder implementation:** High-Throughput JPEG 2000 Image Compression (Lossless Only)
+#[cfg(any(feature = "openjp2", feature = "openjpeg-sys"))]
+pub const HIGH_THROUGHPUT_JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: Jpeg2000Ts = create_ts_jpeg2k(
+    "1.2.840.10008.1.2.4.201",
+    "High-Throughput JPEG 2000 Image Compression (Lossless Only)",
+);
+/// **Stub descriptor:** High-Throughput JPEG 2000 Image Compression (Lossless Only)
+#[cfg(not(any(feature = "openjp2", feature = "openjpeg-sys")))]
+pub const HIGH_THROUGHPUT_JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.201",
+    "High-Throughput JPEG 2000 Image Compression (Lossless Only)",
+);
+
+/// **Decoder implementation:** High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)
+#[cfg(any(feature = "openjp2", feature = "openjpeg-sys"))]
+pub const HIGH_THROUGHPUT_JPEG_2000_WITH_RPCL_OPTIONS_IMAGE_COMPRESSION_LOSSLESS_ONLY: Jpeg2000Ts = create_ts_jpeg2k(
+    "1.2.840.10008.1.2.4.202",
+    "High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)",
+);
+/// **Stub descriptor:** High-Throughput JPEG 2000 Image Compression (Lossless Only)
+#[cfg(not(any(feature = "openjp2", feature = "openjpeg-sys")))]
+pub const HIGH_THROUGHPUT_JPEG_2000_WITH_RPCL_OPTIONS_IMAGE_COMPRESSION_LOSSLESS_ONLY: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.202",
+    "High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)",
+);
+
+/// **Decoder implementation:** High-Throughput JPEG 2000 Image Compression
+#[cfg(any(feature = "openjp2", feature = "openjpeg-sys"))]
+pub const HIGH_THROUGHPUT_JPEG_2000_IMAGE_COMPRESSION: Jpeg2000Ts = create_ts_jpeg2k(
+    "1.2.840.10008.1.2.4.203",
+    "High-Throughput JPEG 2000 Image Compression",
+);
+/// **Stub descriptor:** High-Throughput JPEG 2000 Image Compression
+#[cfg(not(any(feature = "openjp2", feature = "openjpeg-sys")))]
+pub const HIGH_THROUGHPUT_JPEG_2000_IMAGE_COMPRESSION: Ts = create_ts_stub(
+    "1.2.840.10008.1.2.4.203",
+    "High-Throughput JPEG 2000 Image Compression",
+);
+
 
 // --- JPEG-LS ---
 
@@ -354,6 +403,9 @@ pub const JPEG_LS_LOSSY_IMAGE_COMPRESSION: Ts = create_ts_stub(
 
 /// **Stub descriptor:** JPIP Referenced
 pub const JPIP_REFERENCED: Ts = create_ts_stub("1.2.840.10008.1.2.4.94", "JPIP Referenced");
+
+/// **Stub descriptor:** JPIP HT2JK Referenced
+pub const JPIP_HTJ2K_REFERENCED: Ts = create_ts_stub("1.2.840.10008.1.2.4.204", "JPIP HTJ2K Referenced");
 
 /// **Stub descriptor:** MPEG2 Main Profile / Main Level
 pub const MPEG2_MAIN_PROFILE_MAIN_LEVEL: Ts =

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -62,6 +62,9 @@
 //! | JPEG 2000                     | Cargo feature `openjp2` or `openjpeg-sys` | x |
 //! | JPEG 2000 Part 2 Multi-component Image Compression (Lossless Only) | Cargo feature `openjp2` or `openjpeg-sys` | x |
 //! | JPEG 2000 Part 2 Multi-component Image Compression | Cargo feature `openjp2` or `openjpeg-sys` | x |
+//! | High-Throughput JPEG 2000 (Lossless Only) | Cargo feature `openjp2` or `openjpeg-sys` | x |
+//! | High-Throughput JPEG 2000 with RPCL Options (Lossless Only) | Cargo feature `openjp2` or `openjpeg-sys` | x |
+//! | High-Throughput JPEG 2000     | Cargo feature `openjp2` or `openjpeg-sys` | x |
 //! | JPEG XL Lossless              | Cargo feature `jpegxl` | ✓ |
 //! | JPEG XL Recompression         | Cargo feature `jpegxl` | x |
 //! | JPEG XL                       | Cargo feature `jpegxl` | ✓ |
@@ -97,7 +100,8 @@
 //! These stubs may also be replaced by separate libraries
 //! if using the inventory-based registry.
 //!
-//! [inventory]: https://docs.rs/inventory/0.3.12/inventory
+//! [inventory]: https://docs.rs/inventory/0.3.15/inventory
+
 use dicom_encoding::transfer_syntax::{
     AdapterFreeTransferSyntax as Ts, Codec, TransferSyntaxIndex,
 };
@@ -233,7 +237,7 @@ lazy_static! {
         };
 
         use self::entries::*;
-        let built_in_ts: [TransferSyntax; 40] = [
+        let built_in_ts: [TransferSyntax; 45] = [
             IMPLICIT_VR_LITTLE_ENDIAN.erased(),
             EXPLICIT_VR_LITTLE_ENDIAN.erased(),
             EXPLICIT_VR_BIG_ENDIAN.erased(),
@@ -242,6 +246,8 @@ lazy_static! {
 
             DEFLATED_EXPLICIT_VR_LITTLE_ENDIAN.erased(),
             JPIP_REFERENCED_DEFLATE.erased(),
+            JPIP_HTJ2K_REFERENCED_DEFLATE.erased(),
+
             JPEG_BASELINE.erased(),
             JPEG_EXTENDED.erased(),
             JPEG_LOSSLESS_NON_HIERARCHICAL.erased(),
@@ -252,10 +258,14 @@ lazy_static! {
             JPEG_2000_IMAGE_COMPRESSION.erased(),
             JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION_LOSSLESS_ONLY.erased(),
             JPEG_2000_PART2_MULTI_COMPONENT_IMAGE_COMPRESSION.erased(),
+            HIGH_THROUGHPUT_JPEG_2000_IMAGE_COMPRESSION_LOSSLESS_ONLY.erased(),
+            HIGH_THROUGHPUT_JPEG_2000_WITH_RPCL_OPTIONS_IMAGE_COMPRESSION_LOSSLESS_ONLY.erased(),
+            HIGH_THROUGHPUT_JPEG_2000_IMAGE_COMPRESSION.erased(),
             JPEG_XL_LOSSLESS.erased(),
             JPEG_XL_RECOMPRESSION.erased(),
             JPEG_XL.erased(),
             JPIP_REFERENCED.erased(),
+            JPIP_HTJ2K_REFERENCED.erased(),
             MPEG2_MAIN_PROFILE_MAIN_LEVEL.erased(),
             FRAGMENTABLE_MPEG2_MAIN_PROFILE_MAIN_LEVEL.erased(),
             MPEG2_MAIN_PROFILE_HIGH_LEVEL.erased(),


### PR DESCRIPTION
Bind pixel data decoder impl to existing JPEG200 implementations, which already support HTJ2K.
