### PR TITLE
Bump jpeg2k dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,8 @@ jobs:
           cache: true
       # test project with default + extra features
       - run: cargo test --features image,ndarray,sop-class,rle,cli
+      # test dicom-pixeldata with openjp2
+      - run: cargo test -p dicom-pixeldata --features openjp2
       # test dicom-pixeldata with openjpeg-sys
       - run: cargo test -p dicom-pixeldata --features openjpeg-sys
       # test dicom-pixeldata with gdcm-rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,26 +153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "c2rust-bitfields"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb34f0c0ace43530b2df7f18bc69ee0c4082158aa451ece29602f8c841e73764"
-dependencies = [
- "c2rust-bitfields-derive",
-]
-
-[[package]]
-name = "c2rust-bitfields-derive"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd1601a7b828ab874d890e5a895563ca8ad485bdd3d2a359f148c8b72537241"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,7 +211,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -860,7 +840,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1137,9 +1117,9 @@ checksum = "2fefe5a4fb12fa836172dc53cc36c37af693f6197ae702f931faad8774caf926"
 
 [[package]]
 name = "jpeg2k"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450b1c9d2621b6fb60d724e77c41cb924dc7509eace907a23dc99b1b4a2416bc"
+checksum = "4c39a5eaa35680d66cd90f2e55ce7560446d625cdf270569ec02af1d0977300d"
 dependencies = [
  "anyhow",
  "log",
@@ -1293,14 +1273,13 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openjp2"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b5cbb9da46ebbda123ad91818b10cd2697f062d392693a4db078e0e495813c"
+checksum = "ce5917385197ffffdaebb67a187f2d2ab955dd7d2527bdec7ea3088874d58cce"
 dependencies = [
  "bitflags 1.3.2",
- "c2rust-bitfields",
- "libc",
  "log",
+ "smallvec",
  "sprintf",
 ]
 
@@ -1513,7 +1492,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.58",
+ "syn",
  "unicode-ident",
 ]
 
@@ -1626,7 +1605,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1700,7 +1679,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1740,7 +1719,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1778,17 +1757,6 @@ dependencies = [
  "peresil",
  "quick-error",
  "sxd-document",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -1841,7 +1809,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1899,7 +1867,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -2065,7 +2033,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2087,7 +2055,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -23,7 +23,7 @@ native_windows = ["jpeg", "rle"]
 jpeg = ["jpeg-decoder", "jpeg-encoder"]
 # JPEG 2000 support via the OpenJPEG Rust port,
 # works on Linux and a few other platforms
-openjp2 = ["dep:jpeg2k", "jpeg2k/openjp2"]
+openjp2 = ["dep:jpeg2k", "dep:openjp2", "jpeg2k/openjp2"]
 # native RLE lossless support
 rle = []
 # enable Rayon for JPEG decoding

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -31,7 +31,7 @@ rayon = ["jpeg-decoder?/rayon"]
 # enable SIMD operations for JPEG encoding
 simd = ["jpeg-encoder?/simd"]
 
-# JPEG 2000 support via the OpenJPEG Rust port,
+# JPEG 2000 support via the OpenJPEG native bindings,
 # conflicts with `openjp2`
 openjpeg-sys = ["dep:jpeg2k", "jpeg2k/openjpeg-sys"]
 
@@ -48,6 +48,11 @@ tracing = "0.1.34"
 
 [dependencies.jpeg2k]
 version = "0.6.6"
+optional = true
+default-features = false
+
+[dependencies.openjp2]
+version = "0.3.5"
 optional = true
 default-features = false
 

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -23,7 +23,7 @@ native_windows = ["jpeg", "rle"]
 jpeg = ["jpeg-decoder", "jpeg-encoder"]
 # JPEG 2000 support via the OpenJPEG Rust port,
 # works on Linux and a few other platforms
-openjp2 = ["dep:jpeg2k", "dep:openjp2", "jpeg2k/openjp2"]
+openjp2 = ["dep:jpeg2k", "jpeg2k/openjp2"]
 # native RLE lossless support
 rle = []
 # enable Rayon for JPEG decoding
@@ -47,12 +47,7 @@ byteordered = "0.6"
 tracing = "0.1.34"
 
 [dependencies.jpeg2k]
-version = "0.6.6"
-optional = true
-default-features = false
-
-[dependencies.openjp2]
-version = "0.3.6"
+version = "0.6.8"
 optional = true
 default-features = false
 

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -52,7 +52,7 @@ optional = true
 default-features = false
 
 [dependencies.openjp2]
-version = "0.3.5"
+version = "0.3.6"
 optional = true
 default-features = false
 


### PR DESCRIPTION
Bump `jpeg2k` in order to obtain the latest patches of `openjp2`, and test its usage against DICOM-rs. Resolves #501.