### PR TITLE
Tweak toimage

### DIFF
--- a/toimage/README.md
+++ b/toimage/README.md
@@ -11,15 +11,15 @@ This tool is part of the [DICOM-rs](https://github.com/Enet4/dicom-rs) project.
 ## Usage
 
 ```none
-    dicom-toimage [OPTIONS] [FILES]...
+dicom-toimage [OPTIONS] <FILES>...
 
 Arguments:
-  [FILES]...  Path to the DICOM file to convert
+  <FILES>...  Paths to the DICOM files (or directories) to convert
 
 Options:
   -r, --recursive             Parse directory recursively
-  -o, --out <OUTPUT>          Path to the output image, this should include the file extension (default is to replace input extension with `.png`)
-  -d, --outdir <OUTDIR>       Path to the output directory if multiple files are given Conflicts with `output`
+  -o, --out <OUTPUT>          Path to the output image, including file extension (replaces input extension with `.png` by default)
+  -d, --outdir <OUTDIR>       Path to the output directory in bulk conversion mode, conflicts with `output`
   -e, --ext <EXT>             Extension when converting multiple files (default is to replace input extension with `.png`)
   -F, --frame <FRAME_NUMBER>  Frame number (0-indexed) [default: 0]
       --8bit                  Force output bit depth to 8 bits per sample

--- a/toimage/README.md
+++ b/toimage/README.md
@@ -25,6 +25,7 @@ Options:
       --8bit                  Force output bit depth to 8 bits per sample
       --16bit                 Force output bit depth to 16 bits per sample
       --unwrap                Output the raw pixel data instead of decoding it
+      --fail-first            Stop on the first failed conversion
   -v, --verbose               Print more information about the image and the output file
   -h, --help                  Print help
   -V, --version               Print version

--- a/toimage/src/main.rs
+++ b/toimage/src/main.rs
@@ -10,25 +10,25 @@ use dicom_pixeldata::{ConvertOptions, PixelDecoder};
 use snafu::{OptionExt, Report, ResultExt, Snafu, Whatever};
 use tracing::{error, warn, Level};
 
-/// Convert a DICOM file into an image file
+/// Convert DICOM files into image files
 #[derive(Debug, Parser)]
 #[command(version)]
 struct App {
-    /// Path to the DICOM file to convert
+    /// A directory or multiple paths to the DICOM files to convert
     #[arg(required(true))]
     files: Vec<PathBuf>,
 
-    /// Parse directory recursively
+    /// Parse the given directory recursively
     #[arg(short = 'r', long = "recursive")]
     recursive: bool,
 
-    /// Path to the output image, this should include the file extension
-    /// (default is to replace input extension with `.png`)
+    /// Path to the output image, including file extension
+    /// (replaces input extension with `.png` by default)
     #[arg(short = 'o', long = "out")]
     output: Option<PathBuf>,
 
-    /// Path to the output directory if multiple files are given
-    /// Conflicts with `output`
+    /// Path to the output directory in bulk conversion mode,
+    /// conflicts with `output`
     #[arg(short = 'd', long = "outdir", conflicts_with = "output")]
     outdir: Option<PathBuf>,
 

--- a/toimage/src/main.rs
+++ b/toimage/src/main.rs
@@ -15,6 +15,7 @@ use tracing::{error, warn, Level};
 #[command(version)]
 struct App {
     /// Path to the DICOM file to convert
+    #[arg(required(true))]
     files: Vec<PathBuf>,
 
     /// Parse directory recursively


### PR DESCRIPTION
### Summary

- Refactor output path resolution
- Update CLI documentation to better match its current capabilities
- Mark `files` argument as required, so that running the command without any inputs will print some help
- Add `--fail-first` option which stops the process when on of the conversions fails (does not include errors from the recursive DICOM file collection routine).