### PR TITLE
[toimage] Fix error reporting without --fail-first

### DIFF
--- a/toimage/src/main.rs
+++ b/toimage/src/main.rs
@@ -240,6 +240,7 @@ fn run(args: App) -> Result<(), Error> {
                         if fail_first {
                             return Err(e);
                         } else {
+                            error!("{}", Report::from_error(e));
                             continue;
                         }
                     }


### PR DESCRIPTION
This fixes a minor regression from #532.

- add error reporting in suitable places when `fail_first` is not enabled, otherwise errors would never be reported
- let errors flow normally in the case of converting a single DICOM file
- replace a match on bool to an if-else
