### PR TITLE
Infer Media Storage SOP Class UID and Media Storage SOP Instance UID from the SOP Class UID and SOP Instance UID when missing

### DIFF
--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -225,6 +225,11 @@ pub enum ReadError {
         #[snafu(backtrace)]
         source: crate::meta::Error,
     },
+    ParseSopAttributes {
+        #[snafu(source(from(dicom_core::value::ConvertValueError, Box::from)))]
+        source: Box<dicom_core::value::ConvertValueError>,
+        backtrace: Backtrace,
+    },
     #[snafu(display("Could not create data set parser"))]
     CreateParser {
         #[snafu(backtrace)]

--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -225,7 +225,8 @@ pub enum ReadError {
         #[snafu(backtrace)]
         source: crate::meta::Error,
     },
-    ParseSopAttributes {
+    #[snafu(display("Could not parse sop attribute"))]
+    ParseSopAttribute {
         #[snafu(source(from(dicom_core::value::ConvertValueError, Box::from)))]
         source: Box<dicom_core::value::ConvertValueError>,
         backtrace: Backtrace,

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -58,7 +58,7 @@ use crate::{
     CreatePrinterSnafu, DicomObject, ElementNotFoundSnafu, FileDicomObject, InvalidGroupSnafu,
     MissingElementValueSnafu, MissingLeafElementSnafu, NoSpaceSnafu, NoSuchAttributeNameSnafu,
     NoSuchDataElementAliasSnafu, NoSuchDataElementTagSnafu, NotASequenceSnafu, OpenFileSnafu,
-    ParseMetaDataSetSnafu, ParseSopAttributesSnafu, PrematureEndSnafu, PrepareMetaTableSnafu,
+    ParseMetaDataSetSnafu, ParseSopAttributeSnafu, PrematureEndSnafu, PrepareMetaTableSnafu,
     PrintDataSetSnafu, PrivateCreatorNotFoundSnafu, PrivateElementError, ReadError, ReadFileSnafu,
     ReadPreambleBytesSnafu, ReadTokenSnafu, ReadUnsupportedTransferSyntaxSnafu,
     UnexpectedTokenSnafu, WithMetaError, WriteError,
@@ -384,7 +384,7 @@ where
                     meta.media_storage_sop_class_uid = elem
                         .value()
                         .to_str()
-                        .context(ParseSopAttributesSnafu)?
+                        .context(ParseSopAttributeSnafu)?
                         .to_string();
                 }
             }
@@ -395,7 +395,7 @@ where
                     meta.media_storage_sop_instance_uid = elem
                         .value()
                         .to_str()
-                        .context(ParseSopAttributesSnafu)?
+                        .context(ParseSopAttributeSnafu)?
                         .to_string();
                 }
             }

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -972,16 +972,17 @@ impl FileMetaTableBuilder {
             // Missing information version, will assume (00H, 01H). See #28
             [0, 1],
         );
-        let media_storage_sop_class_uid =
-            self.media_storage_sop_class_uid
-                .context(MissingElementSnafu {
-                    alias: "MediaStorageSOPClassUID",
-                })?;
+        let media_storage_sop_class_uid = self.media_storage_sop_class_uid.unwrap_or_else(|| {
+            tracing::warn!("MediaStorageSOPClassUID is missing. Defaulting to empty string.");
+            String::default()
+        });
         let media_storage_sop_instance_uid =
-            self.media_storage_sop_instance_uid
-                .context(MissingElementSnafu {
-                    alias: "MediaStorageSOPInstanceUID",
-                })?;
+            self.media_storage_sop_instance_uid.unwrap_or_else(|| {
+                tracing::warn!(
+                    "MediaStorageSOPInstanceUID is missing. Defaulting to empty string."
+                );
+                String::default()
+            });
         let transfer_syntax = self.transfer_syntax.context(MissingElementSnafu {
             alias: "TransferSyntax",
         })?;


### PR DESCRIPTION
Resolves #538 

- Default Media Storage SOP Class UID and Media Storage SOP Instance UID to empty string when not available in the DICOM meta information table.
- In `open_file_with_all_options` attempt to infer the Media Storage SOP Class UID and Media Storage SOP Instance UID from the SOP Class UID and SOP Instance UID tag values if the Media Storage SOP Class UID and Media Storage SOP Instance UID are set to an empty string