### PR TITLE
[ts-registry] simplify JPEG single frame decoding

### DIFF
--- a/transfer-syntax-registry/src/adapters/jpeg.rs
+++ b/transfer-syntax-registry/src/adapters/jpeg.rs
@@ -211,60 +211,17 @@ impl PixelDataReader for JpegAdapter {
             Cow::Owned(fragments)
         };
 
-        let fragme_data_len = frame_data.len() as u64;
         let mut cursor = Cursor::new(&*frame_data);
-        let mut dst_offset = base_offset;
+        let dst_offset = base_offset;
 
-        loop {
-            let mut decoder = Decoder::new(&mut cursor);
-            let decoded = decoder
-                .decode()
-                .map_err(|e| Box::new(e) as Box<_>)
-                .whatever_context("JPEG decoder failure")?;
+        let mut decoder = Decoder::new(&mut cursor);
+        let decoded = decoder
+            .decode()
+            .map_err(|e| Box::new(e) as Box<_>)
+            .whatever_context("JPEG decoder failure")?;
 
-            let decoded_len = decoded.len();
-            dst[dst_offset..(dst_offset + decoded_len)].copy_from_slice(&decoded);
-            dst_offset += decoded_len;
-
-            if next_even(cursor.position()) >= next_even(fragme_data_len) {
-                break;
-            }
-
-            // stop if there aren't enough bytes to continue
-            if cursor.position() + 2 >= fragme_data_len {
-                break;
-            }
-
-            // DICOM fragments should always have an even length,
-            // filling this spacing with padding if it is odd.
-            // Some implementations might add this padding,
-            // whereas other might not.
-            // So we look for the start of the SOI marker
-            // to identify whether the padding is there
-            if cursor.position() % 2 > 0 {
-                let Some(next_byte_1) = cursor
-                    .get_ref()
-                    .get(cursor.position() as usize + 1)
-                    .copied()
-                else {
-                    // no more frames to read
-                    break;
-                };
-                let Some(next_byte_2) = cursor
-                    .get_ref()
-                    .get(cursor.position() as usize + 2)
-                    .copied()
-                else {
-                    // no more frames to read
-                    break;
-                };
-
-                if [next_byte_1, next_byte_2] == [0xFF, 0xD8] {
-                    // skip padding and continue
-                    cursor.set_position(cursor.position() + 1);
-                }
-            }
-        }
+        let decoded_len = decoded.len();
+        dst[dst_offset..(dst_offset + decoded_len)].copy_from_slice(&decoded);
 
         Ok(())
     }


### PR DESCRIPTION
Resolves #537.

### Summary

- when decoding a single frame with the JPEG adapter, call the decoder only once 
- increase resilience of JPEG decoder by looking for the next SOI marker after each frame decode
- add test case with more trailing bytes

