### PR TITLE
BUG: Use only odd presentation context IDs

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -511,7 +511,7 @@ impl<'a> ClientAssociationOptions<'a> {
             .into_iter()
             .enumerate()
             .map(|(i, presentation_context)| PresentationContextProposed {
-                id: (2*i + 1) as u8,
+                id: (2 * i + 1) as u8,
                 abstract_syntax: presentation_context.0.to_string(),
                 transfer_syntaxes: presentation_context
                     .1

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -511,7 +511,7 @@ impl<'a> ClientAssociationOptions<'a> {
             .into_iter()
             .enumerate()
             .map(|(i, presentation_context)| PresentationContextProposed {
-                id: (i + 1) as u8,
+                id: (2*i + 1) as u8,
                 abstract_syntax: presentation_context.0.to_string(),
                 transfer_syntaxes: presentation_context
                     .1

--- a/ul/tests/association_echo.rs
+++ b/ul/tests/association_echo.rs
@@ -42,7 +42,7 @@ fn spawn_scp() -> Result<(JoinHandle<Result<()>>, SocketAddr)> {
                     transfer_syntax: IMPLICIT_VR_LE.to_string(),
                 },
                 PresentationContextResult {
-                    id: 2,
+                    id: 3,
                     reason: PresentationContextResultReason::AbstractSyntaxNotSupported,
                     transfer_syntax: IMPLICIT_VR_LE.to_string(),
                 }

--- a/ul/tests/association_store.rs
+++ b/ul/tests/association_store.rs
@@ -46,7 +46,7 @@ fn spawn_scp() -> Result<(JoinHandle<Result<()>>, SocketAddr)> {
                     transfer_syntax: IMPLICIT_VR_LE.to_string(),
                 },
                 PresentationContextResult {
-                    id: 2,
+                    id: 3,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: JPEG_BASELINE.to_string(),
                 }
@@ -85,7 +85,7 @@ fn scu_scp_association_test() {
                 // guaranteed to be MR image storage
                 assert_eq!(pc.transfer_syntax, IMPLICIT_VR_LE);
             }
-            2 => {
+            3 => {
                 // guaranteed to be MG image storage
                 assert_eq!(pc.transfer_syntax, JPEG_BASELINE);
             }

--- a/ul/tests/association_store_uncompressed.rs
+++ b/ul/tests/association_store_uncompressed.rs
@@ -54,7 +54,7 @@ fn spawn_scp() -> Result<(JoinHandle<Result<()>>, SocketAddr)> {
                 // should always pick Explicit VR LE
                 // because JPEG baseline was not explicitly enabled in SCP
                 PresentationContextResult {
-                    id: 2,
+                    id: 3,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: EXPLICIT_VR_LE.to_string(),
                 }
@@ -98,7 +98,7 @@ fn scu_scp_association_uncompressed() {
                 assert_eq!(pc.transfer_syntax, IMPLICIT_VR_LE);
             }
             // guaranteed to be MG image storage
-            2 => {
+            3 => {
                 // server picked this one because it did not accept JPEG baseline
                 assert_eq!(pc.transfer_syntax, EXPLICIT_VR_LE);
             }


### PR DESCRIPTION
Not really sure why, but I had an SCP I was talking to and trying to pass multiple presentation context IDs and it was failing.  I tried with a different implementation (pydicom) and it worked, looking at a packet capture the only difference was that they passed a couple of other transfer syntaxes (explicit VR big endian, and deflated), and that they only used odd numbers for presentation context ids.

I couldn't find anything in the standard to support that, but I tried changing it and it worked...

Code to reproduce:
```rust
pub fn establish_ae(
) -> (ClientAssociation, &'static TransferSyntax, u8){
    let options = ClientAssociationOptions::new()
        .with_abstract_syntax(uids::PATIENT_ROOT_QUERY_RETRIEVE_INFORMATION_MODEL_FIND)
        .with_abstract_syntax(uids::PATIENT_ROOT_QUERY_RETRIEVE_INFORMATION_MODEL_MOVE)
        .called_ae_title("MYAE".to_string())
        .calling_ae_title("FWRECEIVER".to_string())
        .read_timeout(Duration::from_secs(120))
        .write_timeout(Duration::from_secs(120));

    let scu = options
        .establish_with("10.0.1.1:104").unwrap();
    let pc_selected = if let Some(pc_selected) = scu.presentation_contexts().first() {
        pc_selected
    } else {
        let _ = scu.abort();
        std::process::exit(-2);
    };
    let pc_selected_id = pc_selected.id;
    let ts = if let Some(ts) = TransferSyntaxRegistry.get(&pc_selected.transfer_syntax) {
        ts
    } else {
        let _ = scu.abort();
        std::process::exit(-2);
    };
    return (scu, ts, pc_selected_id)
}
fn main(){
    let (assoc, ts, pc) = establish_ae();
    println!("{:?}", assoc);
}
```

Before the change, output:
```
thread 'main' panicked at src/bin/association.rs:21:45:
called `Result::unwrap()` on an `Err` value: Rejected { association_rj: AssociationRJ { result: Permanent, source: ServiceProviderASCE(NoReasonGiven) }, backtrace: Backtrace(()) }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

after:
```
ClientAssociation { presentation_contexts: [PresentationContextResult { id: 1, reason: Acceptance, transfer_syntax: "1.2.840.10008.1.2.1" }, PresentationContextResult { id: 3, reason: Acceptance, transfer_syntax: "1.2.840.10008.1.2.1" }], requestor_max_pdu_length: 16384, acceptor_max_pdu_length: 65536, socket: TcpStream { addr: 10.128.0.54:42656, peer: 10.37.235.21:104, fd: 3 }, buffer: [], strict: true }
```