### PR TITLE
- add connection timeout

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -13,7 +13,6 @@ use std::{
 };
 
 use crate::{
-    address,
     pdu::{
         reader::{read_pdu, DEFAULT_MAX_PDU, MAXIMUM_PDU_SIZE},
         writer::write_pdu,

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -36,7 +36,7 @@ pub enum Error {
     MissingAbstractSyntax { backtrace: Backtrace },
 
     /// could not convert to socket address
-    ToAddresss {
+    ToAddress {
         source: std::io::Error,
         backtrace: Backtrace,
     },
@@ -571,7 +571,7 @@ impl<'a> ClientAssociationOptions<'a> {
         });
 
         let conn_result: Result<TcpStream> = if let Some(timeout) = connection_timeout {
-            let addresses = ae_address.to_socket_addrs().context(ToAddresssSnafu)?;
+            let addresses = ae_address.to_socket_addrs().context(ToAddressSnafu)?;
 
             let mut res: Result<TcpStream> = NoAddressSnafu {}.fail();
 


### PR DESCRIPTION
A TCP connection od a client connection will hang in case of an invalid address or network error.
This adds the option of a connection timeout, which is different from the already implemented read/write timeout on the TcpStream 