### PR TITLE
Update meta information group length in dicom-transcode + add FileDicomObject::update_meta

### DIFF
--- a/pixeldata/src/bin/dicom-transcode.rs
+++ b/pixeldata/src/bin/dicom-transcode.rs
@@ -160,6 +160,7 @@ fn run() -> Result<(), Whatever> {
             dicom_object::IMPLEMENTATION_CLASS_UID.to_string();
         obj.meta_mut().implementation_version_name =
             Some(dicom_object::IMPLEMENTATION_VERSION_NAME.to_string());
+        obj.meta_mut().update_information_group_length();
     }
 
     // write to file

--- a/pixeldata/src/bin/dicom-transcode.rs
+++ b/pixeldata/src/bin/dicom-transcode.rs
@@ -156,11 +156,11 @@ fn run() -> Result<(), Whatever> {
 
     // override implementation class UID and version name
     if !retain_implementation {
-        obj.meta_mut().implementation_class_uid =
-            dicom_object::IMPLEMENTATION_CLASS_UID.to_string();
-        obj.meta_mut().implementation_version_name =
-            Some(dicom_object::IMPLEMENTATION_VERSION_NAME.to_string());
-        obj.meta_mut().update_information_group_length();
+        obj.update_meta(|meta| {
+            meta.implementation_class_uid = dicom_object::IMPLEMENTATION_CLASS_UID.to_string();
+            meta.implementation_version_name =
+                Some(dicom_object::IMPLEMENTATION_VERSION_NAME.to_string());
+        });
     }
 
     // write to file


### PR DESCRIPTION
Without this, Meta Information Group Length would likely be incorrect after the updates to implementation class UID and implementation version name.

Also updates `dicom_object` with `FileDicomObject::update_meta`, so that multiple changes to the file meta group table struct are reliably followed by an update to the information group length.