### PR TITLE
[fromimage] Add --encapsulate option 

### DIFF
--- a/fromimage/README.md
+++ b/fromimage/README.md
@@ -11,21 +11,51 @@ This tool is part of the [DICOM-rs](https://github.com/Enet4/dicom-rs) project.
 ## Usage
 
 ```none
-dicom-fromimage 0.1.0
-Convert and replace a DICOM file's image with another image
+Usage: dicom-fromimage [OPTIONS] <DCM_FILE> <IMG_FILE>
 
-USAGE:
-    dicom-fromimage.exe [FLAGS] [OPTIONS] <dcm-file> <img-file>
+Arguments:
+  <DCM_FILE>  Path to the base DICOM file to read
+  <IMG_FILE>  Path to the image file to replace the DICOM file
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-    -v, --verbose    Print more information about the image and the output file
-
-OPTIONS:
-    -o, --out <output>    Path to the output image (default is to replace input extension with `.new.dcm`)
-
-ARGS:
-    <dcm-file>    Path to the base DICOM file to read
-    <img-file>    Path to the image file to replace the DICOM file
+Options:
+  -o, --out <OUTPUT>
+          Path to the output image (default is to replace input extension with `.new.dcm`)
+      --transfer-syntax <TRANSFER_SYNTAX>
+          Override the transfer syntax UID
+      --encapsulate
+          Encapsulate the image file raw data in a fragment sequence instead of writing native pixel data
+      --retain-implementation
+          Retain the implementation class UID and version name from base DICOM
+  -v, --verbose
+          Print more information about the image and the output file
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```
+
+### Example
+
+Given a template DICOM file `base.dcm`,
+replace the image data with the image in `image.png`:
+
+```none
+dicom-fromimage base.dcm image.png -o image.dcm
+```
+
+This will read the image file in the second argument
+and save it as native pixel data in Explicit VR Little Endian to `image.dcm`.
+
+You can also encapsulate the image file into a pixel data fragment,
+without converting to native pixel data.
+This allows you to create a DICOM file in JPEG baseline:
+
+```none
+dicom-fromimage base.dcm image.jpg --transfer-syntax 1.2.840.10008.1.2.4.50 --encapsulate -o image.dcm
+```
+
+**Note:** `--transfer-syntax` is just a UID override,
+it will not automatically transcode the pixel data
+to conform to the given transfer syntax. 
+To transcode files between transfer syntaxes,
+see [`dicom-transcode`](https://github.com/Enet4/dicom-rs/tree/master/pixeldata).

--- a/fromimage/src/main.rs
+++ b/fromimage/src/main.rs
@@ -39,7 +39,7 @@ struct App {
     #[arg(short = 'o', long = "out")]
     output: Option<PathBuf>,
     /// Override the transfer syntax UID (pixel data is not converted)
-    #[arg(long = "transfer-syntax")]
+    #[arg(long = "transfer-syntax", alias = "ts")]
     transfer_syntax: Option<String>,
     /// Encapsulate the image file raw data in a fragment sequence
     /// instead of writing native pixel data

--- a/pixeldata/README.md
+++ b/pixeldata/README.md
@@ -9,3 +9,30 @@ and is responsible for decoding pixel data elements
 into images or multi-dimensional arrays.
 
 This crate is part of the [DICOM-rs](https://github.com/Enet4/dicom-rs) project.
+
+## Binary
+
+`dicom-pixeldata` also offers the `dicom-transcode` command-line tool
+(enable Cargo feature `cli`).
+You can use it to transcode a DICOM file to another transfer syntax,
+transforming pixel data along the way.
+
+```none
+Usage: dicom-transcode [OPTIONS] <--ts <TS>|--expl-vr-le|--impl-vr-le|--jpeg-baseline> <FILE>
+
+Arguments:
+  <FILE>  
+
+Options:
+  -o, --output <OUTPUT>        The output file (default is to change the extension to .new.dcm)
+      --quality <QUALITY>      The encoding quality (from 0 to 100)
+      --effort <EFFORT>        The encoding effort (from 0 to 100)
+      --ts <TS>                Transcode to the Transfer Syntax indicated by UID
+      --expl-vr-le             Transcode to Explicit VR Little Endian
+      --impl-vr-le             Transcode to Implicit VR Little Endian
+      --jpeg-baseline          Transcode to JPEG baseline (8-bit)
+      --retain-implementation  Retain the original implementation class UID and version name
+  -v, --verbose                Verbose mode
+  -h, --help                   Print help
+  -V, --version                Print version
+```


### PR DESCRIPTION
### Summary

- [fromimage] Add `--encapsulate` option, which makes it possible to encase arbitrary data into a DICOM encapsulate pixel data fragment
- [fromimage] Add `--transfer-syntax` option to override the transfer syntax UID
- [pixeldata] Add documentation for dicom-transcode
