### PR TITLE
[parser] [object] Revert use of inspect method for more Rust compiler compatibility

### DIFF
--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -940,10 +940,11 @@ where
     /// reporting whether it was present.
     pub fn remove_element_by_name(&mut self, name: &str) -> Result<bool, AccessByNameError> {
         let tag = self.lookup_name(name)?;
-        Ok(self.entries.remove(&tag).is_some()).inspect(|&removed| {
+        Ok(self.entries.remove(&tag).is_some()).map(|removed| {
             if removed {
                 self.len = Length::UNDEFINED;
             }
+            removed
         })
     }
 
@@ -951,8 +952,9 @@ where
     pub fn take_element(&mut self, tag: Tag) -> Result<InMemElement<D>> {
         self.entries
             .remove(&tag)
-            .inspect(|_| {
+            .map(|e| {
                 self.len = Length::UNDEFINED;
+                e
             })
             .context(NoSuchDataElementTagSnafu { tag })
     }
@@ -961,8 +963,9 @@ where
     /// if it is present,
     /// returns `None` otherwise.
     pub fn take(&mut self, tag: Tag) -> Option<InMemElement<D>> {
-        self.entries.remove(&tag).inspect(|_| {
+        self.entries.remove(&tag).map(|e| {
             self.len = Length::UNDEFINED;
+            e
         })
     }
 
@@ -974,8 +977,9 @@ where
         let tag = self.lookup_name(name)?;
         self.entries
             .remove(&tag)
-            .inspect(|_| {
+            .map(|e| {
                 self.len = Length::UNDEFINED;
+                e
             })
             .with_context(|| NoSuchDataElementAliasSnafu {
                 tag,

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -913,8 +913,9 @@ where
             .context(DecodeItemHeaderSnafu {
                 position: self.position,
             })
-            .inspect(|_| {
+            .map(|header| {
                 self.position += 8;
+                header
             })
             .map_err(From::from)
     }


### PR DESCRIPTION
This reverts some of the changes done in #580. `Result::inspect` and `Option::inspect` were only introduced in 1.76.0, but there is some interest in using the DICOM-rs library with older versions.

Resolves #585.