### PR TITLE
Revert "[ul] Recover API compatibility with 0.7.1"

### DIFF
--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -24,7 +24,4 @@ mod uid;
 pub(crate) mod pdata;
 
 pub use client::{ClientAssociation, ClientAssociationOptions};
-pub use pdata::{PDataReader, PDataWriter};
-#[cfg(feature = "async")]
-pub use pdata::non_blocking::AsyncPDataWriter;
 pub use server::{ServerAssociation, ServerAssociationOptions};

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -5,34 +5,11 @@ use dicom_encoding::text::{DefaultCharacterSetCodec, TextCodec};
 use snafu::{ensure, OptionExt, ResultExt};
 use tracing::warn;
 
-pub type Error = crate::pdu::ReadError;
-
-pub type Result<T> = std::result::Result<T, Error>;
-
-/// The default maximum PDU size
-#[deprecated(since = "0.7.2", note = "Use dicom_ul::pdu::DEFAULT_MAX_PDU instead")]
-pub const DEFAULT_MAX_PDU: u32 = crate::pdu::DEFAULT_MAX_PDU;
-
-/// The minimum PDU size,
-/// as specified by the standard
-#[deprecated(since = "0.7.2", note = "Use dicom_ul::pdu::MINIMUM_PDU_SIZE instead")]
-pub const MINIMUM_PDU_SIZE: u32 = crate::pdu::MINIMUM_PDU_SIZE;
-
-/// The maximum PDU size,
-/// as specified by the standard
-#[deprecated(since = "0.7.2", note = "Use dicom_ul::pdu::MAXIMUM_PDU_SIZE instead")]
-pub const MAXIMUM_PDU_SIZE: u32 = crate::pdu::MAXIMUM_PDU_SIZE;
-
-/// The length of the PDU header in bytes,
-/// comprising the PDU type (1 byte),
-/// reserved byte (1 byte),
-/// and PDU length (4 bytes).
-#[deprecated(since = "0.7.2", note = "Use dicom_ul::pdu::PDU_HEADER_SIZE instead")]
-pub const PDU_HEADER_SIZE: u32 = crate::pdu::PDU_HEADER_SIZE;
+pub type Result<T> = std::result::Result<T, ReadError>;
 
 pub fn read_pdu(mut buf: impl Buf, max_pdu_length: u32, strict: bool) -> Result<Option<Pdu>> {
     ensure!(
-        (super::MINIMUM_PDU_SIZE..=super::MAXIMUM_PDU_SIZE).contains(&max_pdu_length),
+        (MINIMUM_PDU_SIZE..=MAXIMUM_PDU_SIZE).contains(&max_pdu_length),
         InvalidMaxPduSnafu { max_pdu_length }
     );
 
@@ -62,10 +39,10 @@ pub fn read_pdu(mut buf: impl Buf, max_pdu_length: u32, strict: bool) -> Result<
         );
     } else if pdu_length > max_pdu_length {
         ensure!(
-            pdu_length <= super::MAXIMUM_PDU_SIZE,
+            pdu_length <= MAXIMUM_PDU_SIZE,
             PduTooLargeSnafu {
                 pdu_length,
-                max_pdu_length: super::MAXIMUM_PDU_SIZE
+                max_pdu_length: MAXIMUM_PDU_SIZE
             }
         );
         tracing::warn!(

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -5,8 +5,6 @@ use dicom_encoding::text::TextCodec;
 use snafu::{Backtrace, ResultExt, Snafu};
 use std::io::Write;
 
-pub type Error = crate::pdu::WriteError;
-
 pub type Result<T> = std::result::Result<T, WriteError>;
 
 #[derive(Debug, Snafu)]


### PR DESCRIPTION
Reverts Enet4/dicom-rs#582, because the pull request does not fulfill a complete compatibility with users of the previous users. To be decided whether to move forward with this.