### PR TITLE
Fix issues around `dicom_ul::get_client_pdu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,7 @@ dependencies = [
 name = "dicom-scpproxy"
 version = "0.7.0"
 dependencies = [
+ "bytes",
  "clap",
  "dicom-dictionary-std",
  "dicom-ul",

--- a/scpproxy/Cargo.toml
+++ b/scpproxy/Cargo.toml
@@ -17,3 +17,4 @@ dicom-dictionary-std = { path = "../dictionary-std/", version = "0.7.0" }
 snafu = "0.8"
 tracing = "0.1.34"
 tracing-subscriber = "0.3.11"
+bytes = "1.6"

--- a/scpproxy/src/main.rs
+++ b/scpproxy/src/main.rs
@@ -107,7 +107,7 @@ fn run(
                                     })
                                     .context(SendMessageSnafu)?;
                             }
-                            Err(dicom_ul::association::client::Error::ReceiveResponse{ .. }) => {
+                            Err(dicom_ul::association::client::Error::ConnectionClosed) => {
                                 message_tx
                                     .send(ThreadMessage::Shutdown {
                                         initiator: ProviderType::Scu,
@@ -145,7 +145,7 @@ fn run(
                                     })
                                     .context(SendMessageSnafu)?;
                             }
-                            Err(dicom_ul::association::client::Error::ReceiveResponse{ .. }) => {
+                            Err(dicom_ul::association::client::Error::ConnectionClosed) => {
                                 message_tx
                                     .send(ThreadMessage::Shutdown {
                                         initiator: ProviderType::Scp,

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -145,7 +145,7 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Helper function to get a PDU from a reader.
-/// 
+///
 /// Chunks of data are read into `read_buffer`,
 /// which should be passed in subsequent calls
 /// to receive more PDUs from the same stream.
@@ -171,11 +171,11 @@ where
         let recv = reader
             .fill_buf()
             .context(ReadPduSnafu)
-            .context(ReceiveSnafu)?
-            .to_vec();
-        reader.consume(recv.len());
+            .context(ReceiveSnafu)?;
+        let bytes_read = recv.len();
         read_buffer.extend_from_slice(&recv);
-        ensure!(!recv.is_empty(), ConnectionClosedSnafu);
+        reader.consume(bytes_read);
+        ensure!(bytes_read != 0, ConnectionClosedSnafu);
     };
     Ok(msg)
 }


### PR DESCRIPTION
### Summary

- [ul] adjust `get_client_pdu` to prevent trailing data loss
   - the function now receives the reader buffer from the caller, thus being able to retain trailing bytes after the returned PDU
   - leave a note that association establishment is still buggy because it does not save the buffer used for receiving the association response (#589)
- [ul] optimize `get_client_pdu` to not allocate a `Vec` per reader buffer fill
- [scpproxy] Tweak `dicom-scpproxy` to handle `dicom_ul closed connection errors correctly
