### PR TITLE
Update implementation class UID and version name (0.8.0)

### DIFF
--- a/object/src/lib.rs
+++ b/object/src/lib.rs
@@ -168,13 +168,13 @@ use std::path::Path;
 ///
 /// This UID may change in future versions,
 /// even between patch versions.
-pub const IMPLEMENTATION_CLASS_UID: &str = "2.25.139623901558105915656014294038307328623";
+pub const IMPLEMENTATION_CLASS_UID: &str = "2.25.156227610253341005307660858504280353500";
 
 /// The current implementation version name generically referring to DICOM-rs.
 ///
 /// This name may change in future versions,
 /// even between patch versions.
-pub const IMPLEMENTATION_VERSION_NAME: &str = "DICOM-rs 0.7.2";
+pub const IMPLEMENTATION_VERSION_NAME: &str = "DICOM-rs 0.8.0";
 
 /// Trait type for a DICOM object.
 /// This is a high-level abstraction where an object is accessed and

--- a/ul/src/lib.rs
+++ b/ul/src/lib.rs
@@ -31,13 +31,13 @@ pub mod pdu;
 ///
 /// This UID may change in future versions,
 /// even between patch versions.
-pub const IMPLEMENTATION_CLASS_UID: &str = "2.25.139623901558105915656014294038307328623";
+pub const IMPLEMENTATION_CLASS_UID: &str = "2.25.156227610253341005307660858504280353500";
 
 /// The current implementation version name generically referring to DICOM-rs.
 ///
 /// This name may change in future versions,
 /// even between patch versions.
-pub const IMPLEMENTATION_VERSION_NAME: &str = "DICOM-rs 0.7.2";
+pub const IMPLEMENTATION_VERSION_NAME: &str = "DICOM-rs 0.8.0";
 
 // re-exports
 


### PR DESCRIPTION
After identifying the the breaking changes in `dicom_ul` which are unfeasible to revert without also losing the new async support, we will move forward with a major release instead of a patch release. 