### PR TITLE
[pixeldata] Apply VOI LUT when rendering images

### DIFF
--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -626,7 +626,7 @@ pub fn photometric_interpretation<D: DataDictionary + Clone>(
 ///
 /// See [section C.8.11.3.1.5][1] of the standard for more details.
 ///
-/// [1]: https://dicom.nema.org/dicom/2013/output/chtml/part03/sect_C.8.html#sect_C.8.11.3.1.5
+/// [1]: https://dicom.nema.org/medical/dicom/2024d/output/chtml/part03/sect_C.8.11.3.html#sect_C.8.11.3.1.5
 #[derive(Clone, Debug)]
 pub struct VoiLut {
     /// Minimum pixel value to be mapped. All values below this should be mapped
@@ -734,6 +734,11 @@ fn parse_voi_lut_entry<D: DataDictionary + Clone>(entry: &InMemDicomObject<D>) -
     })
 }
 
+/// Get the VOI LUT Sequence from the DICOM object
+///
+/// This function will look for the _VOI LUT Sequence_ (0028,3010) attribute
+/// at the root, then the per frame functional groups,
+/// and then the shared functional group.
 pub fn voi_lut_sequence<D: DataDictionary + Clone>(
     obj: &FileDicomObject<InMemDicomObject<D>>,
 ) -> Option<Vec<VoiLut>> {

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -71,6 +71,7 @@ where
                     .map(|v| VoiLutFunction::try_from((*v).as_str()).ok())
                     .collect()
             });
+        let voi_lut_sequence = voi_lut_sequence(self);
 
         ensure!(
             rescale_intercept.len() == rescale_slope.len(),
@@ -178,6 +179,7 @@ where
             rescale,
             voi_lut_function,
             window,
+            voi_lut_sequence,
             enforce_frame_fg_vm_match: false,
         })
     }
@@ -236,6 +238,7 @@ where
                     .map(|v| VoiLutFunction::try_from((*v).as_str()).ok())
                     .collect()
             });
+        let voi_lut_sequence = voi_lut_sequence(self);
 
         let decoded_pixel_data = match pixel_data.value() {
             DicomValue::PixelSequence(v) => {
@@ -356,6 +359,7 @@ where
             rescale: rescale,
             voi_lut_function,
             window,
+            voi_lut_sequence,
             enforce_frame_fg_vm_match: false,
         })
     }

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -682,7 +682,7 @@ impl DecodedPixelData<'_> {
                             self.number_of_frames,
                             len
                         );
-                        Ok(Some(&inner[0..0]))
+                        Ok(Some(&inner[0..1]))
                     }
                 }
             }

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -660,6 +660,7 @@ impl DecodedPixelData<'_> {
         }
     }
 
+    /// Retrieve the VOI LUT sequence defined by the object, if any
     pub fn voi_lut_sequence(&self) -> Result<Option<&[VoiLut]>> {
         if let Some(inner) = &self.voi_lut_sequence {
             match &inner.len() {

--- a/pixeldata/src/transform.rs
+++ b/pixeldata/src/transform.rs
@@ -2,6 +2,8 @@
 
 use snafu::Snafu;
 
+use crate::attribute::VoiLut;
+
 /// Description of a modality rescale function,
 /// defined by a _rescale slope_ and _rescale intercept_.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -187,6 +189,53 @@ fn window_level_sigmoid(value: f64, window_width: f64, window_center: f64, y_max
     // C.11.2.1.3.1
 
     y_max / (1. + f64::exp(-4. * (value - wc) / ww))
+}
+
+/// A full description of a VOI LUT function transformation
+/// based on an explicit LUT.
+pub struct VoiLutTransform<'a> {
+    lut: &'a VoiLut,
+    shift: u32,
+}
+
+impl<'a> VoiLutTransform<'a> {
+    /// Create a new LUT transformation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `lut.data` is empty, or if `bits_stored` is smaller than
+    /// `lut.bits_stored`.
+    pub fn new(lut: &'a VoiLut, bits_stored: u16) -> Self {
+        if lut.data.is_empty() {
+            // we'll do unchecked accesses to the first and last items in apply()
+            panic!("LUT data is empty");
+        }
+
+        if bits_stored < (lut.bits_stored as u16) {
+            panic!(
+                "LUT with BitsStored {} cannot be used for an image with BitsStored {}",
+                lut.bits_stored, bits_stored
+            );
+        }
+
+        let shift = (bits_stored.next_power_of_two() - (lut.bits_stored as u16)) as u32;
+
+        VoiLutTransform { lut, shift }
+    }
+
+    /// Apply the LUT transformation on a rescaled value.
+    pub fn apply(&self, value: f64) -> f64 {
+        let value_rounded = value.round().clamp(i32::MIN as f64, i32::MAX as f64) as i32;
+        let y = (*(if value_rounded <= self.lut.min_pixel_value {
+            self.lut.data.first().unwrap()
+        } else {
+            self.lut
+                .data
+                .get((value_rounded - self.lut.min_pixel_value) as usize)
+                .unwrap_or(self.lut.data.last().unwrap())
+        })) << self.shift;
+        y as f64
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes: #232

Tested on couple of images locally, this seems to do the job.

There are couple of items I'd like to address before considering this one ready:
- add couple of unit tests
- get your feedback @Enet4 on whether the data structures like `VoiLut` are in the right place...
- maybe fix the naming, somehow "VOI LUT" can refer to lot of similar but different things :grimacing: This seems to be an issue with the standard already, but any feedback on how to make names clearer is welcome
- do we want to make the API public already? Else we could gate the new structs behind `pub(crate)` for now