### PR TITLE
Use the voi function, window and rescale of the decoded frame

### DIFF
--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -2155,12 +2155,42 @@ where
             .fail()?;
         }
 
-        let rescale = zip(&rescale_intercept, &rescale_slope)
+        let rescale_data = zip(&rescale_intercept, &rescale_slope)
             .map(|(intercept, slope)| Rescale {
                 intercept: *intercept,
                 slope: *slope,
             })
-            .collect();
+            .collect::<Vec<Rescale>>();
+
+        let rescale = {
+            if rescale_data.len() > frame as usize {
+                vec![rescale_data[frame as usize]]
+            } else if rescale_data.len() > 0 {
+                vec![rescale_data[0]]
+            } else {
+                vec![]
+            }
+        };
+
+        let window = window.and_then(|window_vec| {
+            if window_vec.len() > frame as usize {
+                Some(vec![window_vec[frame as usize]])
+            } else if window_vec.len() > 0 {
+                Some(vec![window_vec[0]])
+            } else {
+                None
+            }
+        });
+
+        let voi_lut_function = voi_lut_function.and_then(|voi_lut| {
+            if voi_lut.len() > frame as usize {
+                Some(vec![voi_lut[frame as usize]])
+            } else if voi_lut.len() > 0 {
+                Some(vec![voi_lut[0]])
+            } else {
+                None
+            }
+        });
 
         // Try decoding it using a registered pixel data decoder
         if let Codec::EncapsulatedPixelData(Some(decoder), _) = ts.codec() {

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -2165,7 +2165,7 @@ where
         let rescale = {
             if rescale_data.len() > frame as usize {
                 vec![rescale_data[frame as usize]]
-            } else if rescale_data.len() > 0 {
+            } else if !rescale_data.is_empty() {
                 vec![rescale_data[0]]
             } else {
                 vec![]
@@ -2175,7 +2175,7 @@ where
         let window = window.and_then(|window_vec| {
             if window_vec.len() > frame as usize {
                 Some(vec![window_vec[frame as usize]])
-            } else if window_vec.len() > 0 {
+            } else if !window_vec.is_empty() {
                 Some(vec![window_vec[0]])
             } else {
                 None
@@ -2185,7 +2185,7 @@ where
         let voi_lut_function = voi_lut_function.and_then(|voi_lut| {
             if voi_lut.len() > frame as usize {
                 Some(vec![voi_lut[frame as usize]])
-            } else if voi_lut.len() > 0 {
+            } else if !voi_lut.is_empty() {
                 Some(vec![voi_lut[0]])
             } else {
                 None

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -2162,35 +2162,30 @@ where
             })
             .collect::<Vec<Rescale>>();
 
-        let rescale = {
-            if rescale_data.len() > frame as usize {
-                vec![rescale_data[frame as usize]]
-            } else if !rescale_data.is_empty() {
-                vec![rescale_data[0]]
-            } else {
-                vec![]
-            }
-        };
+        let rescale = rescale_data
+            .get(frame as usize)
+            .or(rescale_data.first())
+            .copied()
+            .map(|inner| vec![inner])
+            .unwrap_or_default();
 
-        let window = window.and_then(|window_vec| {
-            if window_vec.len() > frame as usize {
-                Some(vec![window_vec[frame as usize]])
-            } else if !window_vec.is_empty() {
-                Some(vec![window_vec[0]])
-            } else {
-                None
-            }
-        });
+        let window = window
+            .and_then(|inner| {
+                inner
+                    .get(frame as usize)
+                    .or(inner.first())
+                    .copied()
+                    .map(|el| vec![el])
+            });
 
-        let voi_lut_function = voi_lut_function.and_then(|voi_lut| {
-            if voi_lut.len() > frame as usize {
-                Some(vec![voi_lut[frame as usize]])
-            } else if !voi_lut.is_empty() {
-                Some(vec![voi_lut[0]])
-            } else {
-                None
-            }
-        });
+        let voi_lut_function = voi_lut_function
+            .and_then(|inner| {
+                inner
+                    .get(frame as usize)
+                    .or(inner.first())
+                    .copied()
+                    .map(|el| vec![el])
+            });
 
         // Try decoding it using a registered pixel data decoder
         if let Codec::EncapsulatedPixelData(Some(decoder), _) = ts.codec() {


### PR DESCRIPTION
When decoding a single frame, frame_number is set to 1 but the voi_lut_function, the rescale and the window data is kept as an array. This change will use the data corresponding to the frame it will fallback to the first element if possible.