### PR TITLE
Do not set query retrieve level for worklist

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,12 +57,12 @@ jobs:
           cargo test -p dicom-pixeldata
           cargo check -p dicom
         env:
-          RUSTFLAGS: -W warnings
+          RUSTFLAGS: -A warnings # allows warnings, to not pollute CI with warnings that are no longer valid with stable rust version
       # run Clippy with stable toolchain
       - if: matrix.rust == 'stable'
         run: cargo clippy
         env:
-          RUSTFLAGS: -W warnings
+          RUSTFLAGS: -D warnings
 
   check_windows:
     name: Build (Windows)

--- a/findscu/src/main.rs
+++ b/findscu/src/main.rs
@@ -101,6 +101,7 @@ fn build_query(
     q: Vec<String>,
     patient: bool,
     study: bool,
+    mwl: bool,
     verbose: bool,
 ) -> Result<InMemDicomObject, Error> {
     // read query file if provided
@@ -150,7 +151,8 @@ fn build_query(
         parse_queries(obj, &q).whatever_context("Could not build query object from terms")?;
 
     // try to infer query retrieve level if not defined by the user
-    if obj.get(tags::QUERY_RETRIEVE_LEVEL).is_none() {
+    // but only if not using worklist
+    if !mwl && obj.get(tags::QUERY_RETRIEVE_LEVEL).is_none() {
         // (0008,0052) CS QueryRetrieveLevel
         let level = match (patient, study) {
             (true, false) => "PATIENT",
@@ -191,7 +193,7 @@ fn run() -> Result<(), Error> {
         error!("{}", snafu::Report::from_error(e));
     });
 
-    let dcm_query = build_query(file, query_file, query, patient, study, verbose)?;
+    let dcm_query = build_query(file, query_file, query, patient, study, mwl, verbose)?;
 
     let abstract_syntax = match (patient, study, mwl) {
         // Patient Root Query/Retrieve Information Model - FIND


### PR DESCRIPTION
Fixes #602

Not 100% sure if fix is proper, but without QueryRetrieveLevel in our internal app we already gather worklist since ~1 year without any problems

I also forced `cargo clippy` to fail, when there are any warnings(I also fixed 1 other warning, to pass checks)