### PR TITLE
[ul] BUG: Share underlying buffer from client/server to `PDataReader`

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -142,7 +142,12 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Chunks of data are read into `read_buffer`,
 /// which should be passed in subsequent calls
 /// to receive more PDUs from the same stream.
-pub fn get_client_pdu<R>(reader: &mut R, read_buffer: &mut BytesMut, max_pdu_length: u32, strict: bool) -> Result<Pdu>
+pub fn get_client_pdu<R>(
+    reader: &mut R,
+    read_buffer: &mut BytesMut,
+    max_pdu_length: u32,
+    strict: bool,
+) -> Result<Pdu>
 where
     R: Read,
 {
@@ -688,7 +693,9 @@ impl<'a> ClientAssociationOptions<'a> {
         let mut buf = BytesMut::with_capacity(MAXIMUM_PDU_SIZE as usize);
         let msg = get_client_pdu(&mut socket, &mut buf, MAXIMUM_PDU_SIZE, self.strict)?;
         if !buf.is_empty() {
-            tracing::warn!("Received more data than expected in the first PDU, further issues may arise");
+            tracing::warn!(
+                "Received more data than expected in the first PDU, further issues may arise"
+            );
         }
 
         match msg {
@@ -1046,7 +1053,11 @@ where
     /// receives more data PDUs once the bytes collected are consumed.
     pub fn receive_pdata(&mut self) -> PDataReader<&mut std::net::TcpStream> {
         println!("read_buffer: {:x?}", self.read_buffer);
-        PDataReader::new(&mut self.socket, self.requestor_max_pdu_length, &mut self.read_buffer)
+        PDataReader::new(
+            &mut self.socket,
+            self.requestor_max_pdu_length,
+            &mut self.read_buffer,
+        )
     }
 
     /// Release implementation function,
@@ -1544,7 +1555,11 @@ pub mod non_blocking {
         /// receives more data PDUs once the bytes collected are consumed.
         #[cfg(feature = "async")]
         pub fn receive_pdata(&mut self) -> PDataReader<&mut tokio::net::TcpStream> {
-            PDataReader::new(&mut self.socket, self.requestor_max_pdu_length, &mut self.read_buffer)
+            PDataReader::new(
+                &mut self.socket,
+                self.requestor_max_pdu_length,
+                &mut self.read_buffer,
+            )
         }
 
         /// Release implementation function,

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -978,7 +978,6 @@ where
             {
                 Some(pdu) => {
                     self.read_buffer.advance(buf.position() as usize);
-                    println!("Read buffer remaining: {:?}", self.read_buffer.len());
                     return Ok(pdu);
                 }
                 None => {
@@ -1052,7 +1051,6 @@ where
     /// Returns a reader which automatically
     /// receives more data PDUs once the bytes collected are consumed.
     pub fn receive_pdata(&mut self) -> PDataReader<&mut std::net::TcpStream> {
-        println!("read_buffer: {:x?}", self.read_buffer);
         PDataReader::new(
             &mut self.socket,
             self.requestor_max_pdu_length,

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -171,7 +171,7 @@ where
             .context(ReadPduSnafu)
             .context(ReceiveSnafu)?;
         let bytes_read = recv.len();
-        read_buffer.extend_from_slice(&recv);
+        read_buffer.extend_from_slice(recv);
         reader.consume(bytes_read);
         ensure!(bytes_read != 0, ConnectionClosedSnafu);
     };

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -971,6 +971,7 @@ where
             {
                 Some(pdu) => {
                     self.read_buffer.advance(buf.position() as usize);
+                    println!("Read buffer remaining: {:?}", self.read_buffer.len());
                     return Ok(pdu);
                 }
                 None => {
@@ -1044,7 +1045,8 @@ where
     /// Returns a reader which automatically
     /// receives more data PDUs once the bytes collected are consumed.
     pub fn receive_pdata(&mut self) -> PDataReader<&mut std::net::TcpStream> {
-        PDataReader::new(&mut self.socket, self.requestor_max_pdu_length)
+        println!("read_buffer: {:x?}", self.read_buffer);
+        PDataReader::new(&mut self.socket, self.requestor_max_pdu_length, &mut self.read_buffer)
     }
 
     /// Release implementation function,
@@ -1542,7 +1544,7 @@ pub mod non_blocking {
         /// receives more data PDUs once the bytes collected are consumed.
         #[cfg(feature = "async")]
         pub fn receive_pdata(&mut self) -> PDataReader<&mut tokio::net::TcpStream> {
-            PDataReader::new(&mut self.socket, self.requestor_max_pdu_length)
+            PDataReader::new(&mut self.socket, self.requestor_max_pdu_length, &mut self.read_buffer)
         }
 
         /// Release implementation function,

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -24,7 +24,7 @@ mod uid;
 pub(crate) mod pdata;
 
 pub use client::{ClientAssociation, ClientAssociationOptions};
-pub use pdata::{PDataReader, PDataWriter};
 #[cfg(feature = "async")]
 pub use pdata::non_blocking::AsyncPDataWriter;
+pub use pdata::{PDataReader, PDataWriter};
 pub use server::{ServerAssociation, ServerAssociationOptions};

--- a/ul/src/association/pdata.rs
+++ b/ul/src/association/pdata.rs
@@ -951,7 +951,7 @@ mod tests {
 
         let mut buf = Vec::new();
         {
-            let  mut read_buf = BytesMut::new();
+            let mut read_buf = BytesMut::new();
             let mut reader = PDataReader::new(&mut pdu_stream, MINIMUM_PDU_SIZE, &mut read_buf);
             reader.read_to_end(&mut buf).unwrap();
         }
@@ -996,7 +996,7 @@ mod tests {
         let inner = pdu_stream.into_inner();
         let mut stream = tokio::io::BufReader::new(inner.as_slice());
         {
-            let  mut read_buf = BytesMut::new();
+            let mut read_buf = BytesMut::new();
             let mut reader = PDataReader::new(&mut stream, MINIMUM_PDU_SIZE, &mut read_buf);
             reader.read_to_end(&mut buf).await.unwrap();
         }

--- a/ul/src/association/pdata.rs
+++ b/ul/src/association/pdata.rs
@@ -235,24 +235,24 @@ where
 /// # }
 /// ```
 #[must_use]
-pub struct PDataReader<R> {
+pub struct PDataReader<'a, R> {
     buffer: VecDeque<u8>,
     stream: R,
     presentation_context_id: Option<u8>,
     max_data_length: u32,
     last_pdu: bool,
-    read_buffer: BytesMut,
+    read_buffer: &'a mut BytesMut,
 }
 
-impl<R> PDataReader<R> {
-    pub fn new(stream: R, max_data_length: u32) -> Self {
+impl<'a, R> PDataReader<'a, R> {
+    pub fn new(stream: R, max_data_length: u32, remaining: &'a mut BytesMut) -> Self {
         PDataReader {
             buffer: VecDeque::with_capacity(max_data_length as usize),
             stream,
             presentation_context_id: None,
             max_data_length,
             last_pdu: false,
-            read_buffer: BytesMut::with_capacity(max_data_length as usize),
+            read_buffer: remaining,
         }
     }
 
@@ -267,7 +267,7 @@ impl<R> PDataReader<R> {
     }
 }
 
-impl<R> Read for PDataReader<R>
+impl<'a, R> Read for PDataReader<'a, R>
 where
     R: Read,
 {
@@ -594,7 +594,7 @@ pub mod non_blocking {
         }
     }
 
-    impl<R> AsyncRead for PDataReader<R>
+    impl<'a, R> AsyncRead for PDataReader<'a, R>
     where
         R: AsyncRead + Unpin,
     {
@@ -683,6 +683,7 @@ mod tests {
 
     use super::PDataReader;
 
+    use bytes::BytesMut;
     #[cfg(feature = "async")]
     use tokio::io::AsyncWriteExt;
 
@@ -950,7 +951,8 @@ mod tests {
 
         let mut buf = Vec::new();
         {
-            let mut reader = PDataReader::new(&mut pdu_stream, MINIMUM_PDU_SIZE);
+            let  mut read_buf = BytesMut::new();
+            let mut reader = PDataReader::new(&mut pdu_stream, MINIMUM_PDU_SIZE, &mut read_buf);
             reader.read_to_end(&mut buf).unwrap();
         }
         assert_eq!(buf, my_data);
@@ -994,7 +996,8 @@ mod tests {
         let inner = pdu_stream.into_inner();
         let mut stream = tokio::io::BufReader::new(inner.as_slice());
         {
-            let mut reader = PDataReader::new(&mut stream, MINIMUM_PDU_SIZE);
+            let  mut read_buf = BytesMut::new();
+            let mut reader = PDataReader::new(&mut stream, MINIMUM_PDU_SIZE, &mut read_buf);
             reader.read_to_end(&mut buf).await.unwrap();
         }
         assert_eq!(buf, my_data);

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -795,7 +795,7 @@ impl ServerAssociation<TcpStream> {
     /// Returns a reader which automatically
     /// receives more data PDUs once the bytes collected are consumed.
     pub fn receive_pdata(&mut self) -> PDataReader<&mut TcpStream> {
-        PDataReader::new(&mut self.socket, self.acceptor_max_pdu_length)
+        PDataReader::new(&mut self.socket, self.acceptor_max_pdu_length, &mut self.read_buffer)
     }
 
     /// Obtain access to the inner TCP stream

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -795,7 +795,11 @@ impl ServerAssociation<TcpStream> {
     /// Returns a reader which automatically
     /// receives more data PDUs once the bytes collected are consumed.
     pub fn receive_pdata(&mut self) -> PDataReader<&mut TcpStream> {
-        PDataReader::new(&mut self.socket, self.acceptor_max_pdu_length, &mut self.read_buffer)
+        PDataReader::new(
+            &mut self.socket,
+            self.acceptor_max_pdu_length,
+            &mut self.read_buffer,
+        )
     }
 
     /// Obtain access to the inner TCP stream


### PR DESCRIPTION
By creating a new read buffer in PDataReader, we potentially miss out on
any bytes that the `receive()` method read but didn't process yet.

Additionally, we lose the opposite when returning out of `PDataReader`:
remaining data in the PDataReader buffer that it didn't process.

The solution here is to mutably share that underlying read buffer with the
`PDataReader` so that it can continue from where the `receive()` method
left off _and_ pass any data that it didn't read back to the read buffer
of the main `Client` or `Server` object.