### PR TITLE
Broken pixel_data fix: support parsing improperly closed encapsulated pixel data

### DIFF
--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -374,6 +374,13 @@ where
                         }
                     }
                 }
+                Err(DecoderError::DecodeItemHeader {
+                    source: dicom_encoding::decode::Error::ReadItemHeader { source, .. },
+                    ..
+                }) if source.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    self.hard_break = true;
+                    None
+                }
                 Err(e) => {
                     self.hard_break = true;
                     Some(Err(e).context(ReadItemHeaderSnafu))

--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -377,7 +377,12 @@ where
                 Err(DecoderError::DecodeItemHeader {
                     source: dicom_encoding::decode::Error::ReadItemHeader { source, .. },
                     ..
-                }) if source.kind() == std::io::ErrorKind::UnexpectedEof => {
+                }) if source.kind() == std::io::ErrorKind::UnexpectedEof
+                   && self.seq_delimiters.pop().map_or(false, |t| t.pixel_data)
+                 => {
+                    // Note: if `UnexpectedEof` was reached while inside a 
+                    // PixelData Sequence, then we assume that
+                    // the end of a DICOM object was reached gracefully.
                     self.hard_break = true;
                     None
                 }


### PR DESCRIPTION
Hello @Enet4 .
So I stumbled upon some Dicom files produced on a new Siemens machine and was unable to open them with Dcmtk, Pydicom nor dicom-rs.

I found this (fix](https://github.com/fo-dicom/fo-dicom/pull/1718)) that addressed the very same issue inside fo-dicom.

By reading your code and applying this little hack, I was able to get the files working.

Would you be willing to incorporate such a fix and document it please ?

This is a sample Dicom from the machine:
[Anonymised.zip](https://github.com/user-attachments/files/17925385/Anonymised.zip)


Thank you