### PR TITLE
Add support for non-finite float handling in DICOM JSON

### DIFF
--- a/json/src/de/mod.rs
+++ b/json/src/de/mod.rs
@@ -535,4 +535,41 @@ mod tests {
 
         assert!(super::from_value::<InMemDicomObject>(serialized).is_ok());
     }
+
+    #[test]
+    fn can_resolve_nan_and_inf_float() {
+        let serialized = serde_json::json!({
+            "00020011": {
+                "vr": "FL",
+                "Value": [
+                    5492.8545,
+                    5462.5205,
+                    "NaN",
+                    "-inf",
+                    "inf"
+                ]
+            }
+        });
+
+        let obj: InMemDicomObject = super::from_value(serialized).unwrap();
+        let tag = Tag(0x0002, 0x0011);
+        let element = obj.get(tag).unwrap();
+
+        // verify NAN, INFINITY, and NEG_INFINITY are correctly deserialized to f32::NAN, f32::INFINITY, and f32::NEG_INFINITY
+        let actual_values = element.float32_slice().unwrap();
+        let expected_values = &[
+            5492.8545,
+            5462.5205,
+            f32::NAN,
+            f32::NEG_INFINITY,
+            f32::INFINITY,
+        ];
+
+        // need special comparison for NAN values since assert_eq will not match
+        assert_eq!(actual_values.len(), expected_values.len());
+        assert!(actual_values
+            .iter()
+            .zip(expected_values.iter())
+            .all(|(&a, &b)| (a == b) || (a.is_nan() && b.is_nan())));
+    }
 }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -83,6 +83,13 @@ mod ser;
 pub use crate::de::{from_reader, from_slice, from_str, from_value};
 pub use crate::ser::{to_string, to_string_pretty, to_value, to_vec, to_writer};
 
+/// Represents the serialized representation of "NaN" (Not a Number) for 32-bit float (FL) and 64-bit float (FD) in DICOM JSON.
+pub const NAN: &str = "NaN";
+/// Represents the serialized representation of "inf" (positive infinity) for 32-bit float (FL) and 64-bit float (FD) in DICOM JSON.
+pub const INFINITY: &str = "inf";
+/// Represents the serialized representation of "-inf" (negative infinity) for 32-bit float (FL) and 64-bit float (FD) in DICOM JSON.
+pub const NEG_INFINITY: &str = "-inf";
+
 /// A wrapper type for DICOM JSON serialization using [Serde](serde).
 ///
 /// Serializing this type will yield JSON data according to the standard.

--- a/json/src/ser/value.rs
+++ b/json/src/ser/value.rs
@@ -1,9 +1,10 @@
 //! DICOM value serialization
-use core::f32;
 
 use dicom_core::PrimitiveValue;
 use serde::ser::SerializeSeq;
 use serde::Serialize;
+
+use crate::{INFINITY, NAN, NEG_INFINITY};
 
 /// Wrapper type for [primitive values][1]
 /// which should always be encoded as strings.
@@ -105,11 +106,11 @@ impl Serialize for AsNumbers<'_> {
                     if number.is_finite() {
                         ser.serialize_element(&number)?;
                     } else if number.is_nan() {
-                        ser.serialize_element(&f32::NAN.to_string())?;
+                        ser.serialize_element(NAN)?;
                     } else if number.is_infinite() && number.is_sign_positive() {
-                        ser.serialize_element(&f32::INFINITY.to_string())?;
+                        ser.serialize_element(INFINITY)?;
                     } else if number.is_infinite() && number.is_sign_negative() {
-                        ser.serialize_element(&f32::NEG_INFINITY.to_string())?;
+                        ser.serialize_element(NEG_INFINITY)?;
                     } else {
                         ser.serialize_element(&Option::<()>::None)?;
                     }
@@ -122,11 +123,11 @@ impl Serialize for AsNumbers<'_> {
                     if number.is_finite() {
                         ser.serialize_element(&number)?;
                     } else if number.is_nan() {
-                        ser.serialize_element(&f64::NAN.to_string())?;
+                        ser.serialize_element(NAN)?;
                     } else if number.is_infinite() && number.is_sign_positive() {
-                        ser.serialize_element(&f64::INFINITY.to_string())?;
+                        ser.serialize_element(INFINITY)?;
                     } else if number.is_infinite() && number.is_sign_negative() {
-                        ser.serialize_element(&f64::NEG_INFINITY.to_string())?;
+                        ser.serialize_element(NEG_INFINITY)?;
                     } else {
                         ser.serialize_element(&Option::<()>::None)?;
                     }


### PR DESCRIPTION
We encountered a few unusual DICOM files that store NaN, inf, and -inf values in float tags. These values appear to be valid according to the [DICOM Standard](https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html).

This pull request adds support for serializing non-finite float values to DICOM JSON. Previously, these values were serialized to `null` causing the values to dissapear.

**Changes:**

- Added proper handling for non-finite float values (NaN, inf, -inf) during DICOM JSON serialization.

- Added a test to verify deserialization logic correctly parses these values from their DICOM JSON representations.

**Verification:**

- Tested with several DICOM files containing NaN, inf, and -inf values.

- Ensured that all non-finite float values remain intact after serializing and deserializing them to and from DICOM JSON and DICOM.