### PR TITLE
Add rustfmt to CI to unify code formatting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: clippy
           cache: true
+      - if: matrix.rust == 'stable'
+        run: cargo fmt -- --check
+
       # test project with default + extra features
       - if: matrix.rust == 'stable' || matrix.rust == 'beta'
         run: cargo test --features image,ndarray,sop-class,rle,cli,jpegxl

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+newline_style = "Unix"
+max_width = 100

--- a/.rustfmt_nightly.toml
+++ b/.rustfmt_nightly.toml
@@ -1,0 +1,6 @@
+newline_style = "Unix"
+max_width = 100
+
+# Enable only with nightly channel via - cargo +nightly fmt
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,11 @@
+check:
+    cargo fmt -- --check
+    cargo clippy
+
+fix:
+    cargo fmt
+    cargo clippy --fix --allow-dirty --allow-staged
+
+fix_nightly:
+    cargo +nightly fmt -- --config-path .rustfmt_nightly.toml
+    #cargo +nightly clippy --fix --allow-dirty --allow-staged # To enable, after running format on nightly


### PR DESCRIPTION
I created a justfile to simplify the process of standardizing code to the format currently used in the repository (it uses the just program - https://github.com/casey/just).

This PR only updates the CI and adds a justfile.
I didn’t format the files because I wasn’t sure if or when such a PR could be merged, which could cause minor issues with Git conflicts (especially since there are around 100 modified files).

To make the CI pass, such commands needs to be executed:
```
just fix_nightly # this also groups import, which is unstable feature
just fix
```