### PR TITLE
Fallback to shared groups on missing per frame tag

### DIFF
--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -639,8 +639,7 @@ mod tests {
         assert!(
             size <= max_size,
             "GetAttributeError size is too large ({} > {})",
-            size,
-            max_size
+            size, max_size
         );
     }
 

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -646,8 +646,7 @@ mod tests {
         assert!(
             size <= max_size,
             "GetAttributeError size is too large ({} > {})",
-            size,
-            max_size
+            size, max_size
         );
     }
 

--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -771,9 +771,7 @@ mod tests {
         dcm.apply(AttributeOp::new(
             (
                 tags::SHARED_FUNCTIONAL_GROUPS_SEQUENCE,
-                0,
                 tags::PIXEL_VALUE_TRANSFORMATION_SEQUENCE,
-                0,
                 tags::RESCALE_INTERCEPT,
             ),
             AttributeAction::Set(dicom_value!(F64, 3.0)),


### PR DESCRIPTION
Some DICOMs provide tags under `SharedFunctionalGroupsSequence` that are not present under `PerFrameFunctionalGroupsSequence`. In such cases, getter functions like `window_width()` will return an empty vector rather than falling back to a check on `SharedFunctionalGroupsSequence`. Thus a guard is needed so that when `PerFrameFunctionalGroupsSequence` exists but does not contain the target tag, a fallback check on `SharedFunctionalGroupsSequence` will happen.

This PR implements such a guard by modifying `get_from_per_frame()` and `get_from_shared()` such that empty iterator returns are instead mapped to `None`. The existing logic of the getter functions will then fall back to a shared check.