### PR TITLE
[pixeldata] Add shortcut transcode paths depending on edge cases

### DIFF
--- a/pixeldata/src/transcode.rs
+++ b/pixeldata/src/transcode.rs
@@ -138,12 +138,16 @@ where
                 Ok(())
             }
             // make some exceptions for transfer syntaxes
-            // which are best transcoded from encapsulated pixel data
+            // which are best transcoded from encapsulated pixel data:
+            // - JPEG baseline -> JPEG XL * (can recompress JPEG)
+            // - JPEG XL recompression -> JPEG baseline (can do lossless conversion)
             (false, false)
-                if current_ts.uid() == uids::JPEG_BASELINE8_BIT
+                if (current_ts.uid() == uids::JPEG_BASELINE8_BIT
                     && (ts.uid() == uids::JPEGXLJPEG_RECOMPRESSION
                         || ts.uid() == uids::JPEGXL
-                        || ts.uid() == uids::JPEGXL_LOSSLESS) =>
+                        || ts.uid() == uids::JPEGXL_LOSSLESS))
+                    || (current_ts.uid() == uids::JPEGXLJPEG_RECOMPRESSION
+                        && ts.uid() == uids::JPEG_BASELINE8_BIT) =>
             {
                 // start by assuming that the codec can work with it as is
                 let writer = match ts.codec() {

--- a/pixeldata/src/transcode.rs
+++ b/pixeldata/src/transcode.rs
@@ -204,7 +204,7 @@ where
                         }
 
                         // change transfer syntax
-                        self.meta_mut().set_transfer_syntax(ts);
+                        self.update_meta(|meta| meta.set_transfer_syntax(ts));
 
                         Ok(())
                     }
@@ -264,7 +264,7 @@ where
     };
 
     // change transfer syntax to Explicit VR little endian
-    obj.meta_mut().set_transfer_syntax(ts);
+    obj.update_meta(|meta| meta.set_transfer_syntax(ts));
 
     Ok(())
 }
@@ -335,7 +335,7 @@ where
     }
 
     // change transfer syntax
-    obj.meta_mut().set_transfer_syntax(ts);
+    obj.update_meta(|meta| meta.set_transfer_syntax(ts));
 
     Ok(())
 }


### PR DESCRIPTION
### Summary

- Let JPEG XL encoders grab pixel data in JPEG baseline directly, and let JPEG XL recompression decoder decode to JPEG baseline directly.
   - It can be beneficial to said encoders and decoders
   - It will still fall back to decoding and encoding if the pixel data writer raises a `NotNative` error
- Refactor transcoder code a bit to reduce redundancy
