### PR TITLE
[encoding] Clippy lint fix (2025-02)

### DIFF
--- a/encoding/src/decode/basic.rs
+++ b/encoding/src/decode/basic.rs
@@ -20,128 +20,112 @@ impl BasicDecode for LittleEndianBasicDecoder {
     where
         S: Read,
     {
-        ByteOrdered::le(source).read_u16().map_err(Into::into)
+        ByteOrdered::le(source).read_u16()
     }
 
     fn decode_us_into<S>(&self, source: S, target: &mut [u16]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::le(source)
-            .read_u16_into(target)
-            .map_err(Into::into)
+        ByteOrdered::le(source).read_u16_into(target)
     }
 
     fn decode_ul<S>(&self, source: S) -> Result<u32>
     where
         S: Read,
     {
-        ByteOrdered::le(source).read_u32().map_err(Into::into)
+        ByteOrdered::le(source).read_u32()
     }
 
     fn decode_ul_into<S>(&self, source: S, target: &mut [u32]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::le(source)
-            .read_u32_into(target)
-            .map_err(Into::into)
+        ByteOrdered::le(source).read_u32_into(target)
     }
 
     fn decode_uv<S>(&self, source: S) -> Result<u64>
     where
         S: Read,
     {
-        ByteOrdered::le(source).read_u64().map_err(Into::into)
+        ByteOrdered::le(source).read_u64()
     }
 
     fn decode_uv_into<S>(&self, source: S, target: &mut [u64]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::le(source)
-            .read_u64_into(target)
-            .map_err(Into::into)
+        ByteOrdered::le(source).read_u64_into(target)
     }
 
     fn decode_ss<S>(&self, source: S) -> Result<i16>
     where
         S: Read,
     {
-        ByteOrdered::le(source).read_i16().map_err(Into::into)
+        ByteOrdered::le(source).read_i16()
     }
 
     fn decode_ss_into<S>(&self, source: S, target: &mut [i16]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::le(source)
-            .read_i16_into(target)
-            .map_err(Into::into)
+        ByteOrdered::le(source).read_i16_into(target)
     }
 
     fn decode_sl<S>(&self, source: S) -> Result<i32>
     where
         S: Read,
     {
-        ByteOrdered::le(source).read_i32().map_err(Into::into)
+        ByteOrdered::le(source).read_i32()
     }
 
     fn decode_sl_into<S>(&self, source: S, target: &mut [i32]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::le(source)
-            .read_i32_into(target)
-            .map_err(Into::into)
+        ByteOrdered::le(source).read_i32_into(target)
     }
 
     fn decode_sv<S>(&self, source: S) -> Result<i64>
     where
         S: Read,
     {
-        ByteOrdered::le(source).read_i64().map_err(Into::into)
+        ByteOrdered::le(source).read_i64()
     }
 
     fn decode_sv_into<S>(&self, source: S, target: &mut [i64]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::le(source)
-            .read_i64_into(target)
-            .map_err(Into::into)
+        ByteOrdered::le(source).read_i64_into(target)
     }
 
     fn decode_fl<S>(&self, source: S) -> Result<f32>
     where
         S: Read,
     {
-        ByteOrdered::le(source).read_f32().map_err(Into::into)
+        ByteOrdered::le(source).read_f32()
     }
 
     fn decode_fl_into<S>(&self, source: S, target: &mut [f32]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::le(source)
-            .read_f32_into(target)
-            .map_err(Into::into)
+        ByteOrdered::le(source).read_f32_into(target)
     }
 
     fn decode_fd<S>(&self, source: S) -> Result<f64>
     where
         S: Read,
     {
-        ByteOrdered::le(source).read_f64().map_err(Into::into)
+        ByteOrdered::le(source).read_f64()
     }
 
     fn decode_fd_into<S>(&self, source: S, target: &mut [f64]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::le(source)
-            .read_f64_into(target)
-            .map_err(Into::into)
+        ByteOrdered::le(source).read_f64_into(target)
     }
 }
 
@@ -158,128 +142,112 @@ impl BasicDecode for BigEndianBasicDecoder {
     where
         S: Read,
     {
-        ByteOrdered::be(source).read_u16().map_err(Into::into)
+        ByteOrdered::be(source).read_u16()
     }
 
     fn decode_us_into<S>(&self, source: S, target: &mut [u16]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::be(source)
-            .read_u16_into(target)
-            .map_err(Into::into)
+        ByteOrdered::be(source).read_u16_into(target)
     }
 
     fn decode_ul<S>(&self, source: S) -> Result<u32>
     where
         S: Read,
     {
-        ByteOrdered::be(source).read_u32().map_err(Into::into)
+        ByteOrdered::be(source).read_u32()
     }
 
     fn decode_ul_into<S>(&self, source: S, target: &mut [u32]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::be(source)
-            .read_u32_into(target)
-            .map_err(Into::into)
+        ByteOrdered::be(source).read_u32_into(target)
     }
 
     fn decode_uv<S>(&self, source: S) -> Result<u64>
     where
         S: Read,
     {
-        ByteOrdered::be(source).read_u64().map_err(Into::into)
+        ByteOrdered::be(source).read_u64()
     }
 
     fn decode_uv_into<S>(&self, source: S, target: &mut [u64]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::be(source)
-            .read_u64_into(target)
-            .map_err(Into::into)
+        ByteOrdered::be(source).read_u64_into(target)
     }
 
     fn decode_ss<S>(&self, source: S) -> Result<i16>
     where
         S: Read,
     {
-        ByteOrdered::be(source).read_i16().map_err(Into::into)
+        ByteOrdered::be(source).read_i16()
     }
 
     fn decode_ss_into<S>(&self, source: S, target: &mut [i16]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::be(source)
-            .read_i16_into(target)
-            .map_err(Into::into)
+        ByteOrdered::be(source).read_i16_into(target)
     }
 
     fn decode_sl<S>(&self, source: S) -> Result<i32>
     where
         S: Read,
     {
-        ByteOrdered::be(source).read_i32().map_err(Into::into)
+        ByteOrdered::be(source).read_i32()
     }
 
     fn decode_sl_into<S>(&self, source: S, target: &mut [i32]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::be(source)
-            .read_i32_into(target)
-            .map_err(Into::into)
+        ByteOrdered::be(source).read_i32_into(target)
     }
 
     fn decode_sv<S>(&self, source: S) -> Result<i64>
     where
         S: Read,
     {
-        ByteOrdered::be(source).read_i64().map_err(Into::into)
+        ByteOrdered::be(source).read_i64()
     }
 
     fn decode_sv_into<S>(&self, source: S, target: &mut [i64]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::be(source)
-            .read_i64_into(target)
-            .map_err(Into::into)
+        ByteOrdered::be(source).read_i64_into(target)
     }
 
     fn decode_fl<S>(&self, source: S) -> Result<f32>
     where
         S: Read,
     {
-        ByteOrdered::be(source).read_f32().map_err(Into::into)
+        ByteOrdered::be(source).read_f32()
     }
 
     fn decode_fl_into<S>(&self, source: S, target: &mut [f32]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::be(source)
-            .read_f32_into(target)
-            .map_err(Into::into)
+        ByteOrdered::be(source).read_f32_into(target)
     }
 
     fn decode_fd<S>(&self, source: S) -> Result<f64>
     where
         S: Read,
     {
-        ByteOrdered::be(source).read_f64().map_err(Into::into)
+        ByteOrdered::be(source).read_f64()
     }
 
     fn decode_fd_into<S>(&self, source: S, target: &mut [f64]) -> Result<()>
     where
         S: Read,
     {
-        ByteOrdered::be(source)
-            .read_f64_into(target)
-            .map_err(Into::into)
+        ByteOrdered::be(source).read_f64_into(target)
     }
 }
 

--- a/json/src/de/mod.rs
+++ b/json/src/de/mod.rs
@@ -104,7 +104,6 @@ where
         deserializer
             .deserialize_map(InMemDicomObjectVisitor::default())
             .map(DicomJson::from)
-            .map_err(From::from)
     }
 }
 

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -890,7 +890,7 @@ where
         let private_creator = self.find_private_creator(group, creator);
         if let Some(tag) = private_creator {
             // Private creator already exists
-            let tag = Tag(group, tag.element() << 8 | (element as u16));
+            let tag = Tag(group, (tag.element() << 8) | element as u16);
             Ok(self.put_element(DataElement::new(tag, vr, value)))
         } else {
             // Find last reserved block of tags.
@@ -906,7 +906,7 @@ where
                 self.put_str(tag, VR::LO, creator);
 
                 // Put private element
-                let tag = Tag(group, next_available << 8 | (element as u16));
+                let tag = Tag(group, (next_available << 8) | element as u16);
                 Ok(self.put_element(DataElement::new(tag, vr, value)))
             } else {
                 NoSpaceSnafu { group }.fail()

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -895,8 +895,7 @@ where
             .map(|(header, bytes_read)| {
                 self.position += bytes_read as u64;
                 header
-            })
-            .map_err(From::from)?;
+            })?;
 
         //If we are decoding the PixelPadding element, make sure the VR is the same as the pixel
         //representation (US by default, SS for signed data).
@@ -917,7 +916,6 @@ where
                 self.position += 8;
                 header
             })
-            .map_err(From::from)
     }
 
     fn read_value(&mut self, header: &DataElementHeader) -> Result<PrimitiveValue> {

--- a/transfer-syntax-registry/src/adapters/jpeg.rs
+++ b/transfer-syntax-registry/src/adapters/jpeg.rs
@@ -371,7 +371,7 @@ fn narrow_8bit(frame_data: &[u8], bits_stored: u16) -> EncodeResult<Cow<[u8]>> {
         9..=16 => {
             let mut v = Vec::with_capacity(frame_data.len() / 2);
             for chunk in frame_data.chunks(2) {
-                let b = u16::from(chunk[0]) | u16::from(chunk[1]) << 8;
+                let b = u16::from(chunk[0]) | (u16::from(chunk[1]) << 8);
                 v.push((b >> (bits_stored - 8)) as u8);
             }
             Ok(Cow::Owned(v))


### PR DESCRIPTION
Unnecessary Into::into error mapping
