### PR TITLE
DataSetWriterOptions - handling of explicit length Sequences and Items

### DIFF
--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -1842,7 +1842,7 @@ where
         E: EncodeTo<W>,
     {
         // prepare data set writer
-        let mut dset_writer = DataSetWriter::new(to, encoder, DataSetWriterOptions::default());
+        let mut dset_writer = DataSetWriter::new(to, encoder);
         let required_options = IntoTokensOptions::new(self.charset_changed);
         // write object
         dset_writer

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -41,6 +41,7 @@ use dicom_core::ops::{
 };
 use dicom_encoding::Codec;
 use dicom_parser::dataset::read::{DataSetReaderOptions, OddLengthStrategy};
+use dicom_parser::dataset::write::DataSetWriterOptions;
 use dicom_parser::stateful::decode::CharacterSetOverride;
 use itertools::Itertools;
 use smallvec::SmallVec;
@@ -731,16 +732,19 @@ where
                         uid,
                         name: ts.name(),
                         feature_name: "dicom-transfer-syntax-registry/deflate",
-                    }.fail();
+                    }
+                    .fail();
                 }
 
                 ReadUnsupportedTransferSyntaxSnafu {
                     uid,
                     name: ts.name(),
-                }.fail()
+                }
+                .fail()
             }
             Codec::None | Codec::EncapsulatedPixelData(..) => {
-                let mut dataset = DataSetReader::new_with_ts_cs(from, ts, cs).context(CreateParserSnafu)?;
+                let mut dataset =
+                    DataSetReader::new_with_ts_cs(from, ts, cs).context(CreateParserSnafu)?;
                 InMemDicomObject::build_object(&mut dataset, dict, false, Length::UNDEFINED, None)
             }
         }
@@ -1823,6 +1827,8 @@ where
     /// until _Specific Character Set_ is found in the data set,
     /// in which then that character set will be used.
     ///
+    /// Uses the default [DataSetWriterOptions] for the writer.
+    ///
     /// Note: [`write_dataset_with_ts`] and [`write_dataset_with_ts_cs`]
     /// may be easier to use and _will_ apply a dataset adapter (such as
     /// DeflatedExplicitVRLittleEndian (1.2.840.10008.1.2.99)) whereas this
@@ -1836,7 +1842,7 @@ where
         E: EncodeTo<W>,
     {
         // prepare data set writer
-        let mut dset_writer = DataSetWriter::new(to, encoder);
+        let mut dset_writer = DataSetWriter::new(to, encoder, DataSetWriterOptions::default());
         let required_options = IntoTokensOptions::new(self.charset_changed);
         // write object
         dset_writer
@@ -1849,6 +1855,9 @@ where
     /// Write this object's data set into the given printer,
     /// with the specified transfer syntax and character set,
     /// without preamble, magic code, nor file meta group.
+    ///
+    /// The default [DataSetWriterOptions] is used for the writer. To change
+    /// that, use [`write_dataset_with_ts_cs_options`](Self::write_dataset_with_ts_cs_options).
     ///
     /// If the attribute _Specific Character Set_ is found in the data set,
     /// the last parameter is overridden accordingly.
@@ -1865,7 +1874,8 @@ where
         if let Codec::Dataset(Some(adapter)) = ts.codec() {
             let adapter = adapter.adapt_writer(Box::new(to));
             // prepare data set writer
-            let mut dset_writer = DataSetWriter::with_ts(adapter, ts).context(CreatePrinterSnafu)?;
+            let mut dset_writer =
+                DataSetWriter::with_ts(adapter, ts).context(CreatePrinterSnafu)?;
 
             // write object
             dset_writer
@@ -1875,7 +1885,8 @@ where
             Ok(())
         } else {
             // prepare data set writer
-            let mut dset_writer = DataSetWriter::with_ts_cs(to, ts, cs).context(CreatePrinterSnafu)?;
+            let mut dset_writer =
+                DataSetWriter::with_ts_cs(to, ts, cs).context(CreatePrinterSnafu)?;
 
             // write object
             dset_writer
@@ -1886,9 +1897,42 @@ where
         }
     }
 
+    /// Write this object's data set into the given printer,
+    /// with the specified transfer syntax and character set,
+    /// without preamble, magic code, nor file meta group.
+    ///
+    /// If the attribute _Specific Character Set_ is found in the data set,
+    /// the last parameter is overridden accordingly.
+    /// See also [`write_dataset_with_ts`](Self::write_dataset_with_ts).
+    pub fn write_dataset_with_ts_cs_options<W>(
+        &self,
+        to: W,
+        ts: &TransferSyntax,
+        cs: SpecificCharacterSet,
+        options: DataSetWriterOptions,
+    ) -> Result<(), WriteError>
+    where
+        W: Write,
+    {
+        // prepare data set writer
+        let mut dset_writer =
+            DataSetWriter::with_ts_cs_options(to, ts, cs, options).context(CreatePrinterSnafu)?;
+        let required_options = IntoTokensOptions::new(self.charset_changed);
+
+        // write object
+        dset_writer
+            .write_sequence(self.into_tokens_with_options(required_options))
+            .context(PrintDataSetSnafu)?;
+
+        Ok(())
+    }
+
     /// Write this object's data set into the given writer,
     /// with the specified transfer syntax,
     /// without preamble, magic code, nor file meta group.
+    ///
+    /// The default [DataSetWriterOptions] is used for the writer. To change
+    /// that, use [`write_dataset_with_ts_cs_options`](Self::write_dataset_with_ts_cs_options).
     ///
     /// The default character set is assumed
     /// until the _Specific Character Set_ is found in the data set,
@@ -1898,6 +1942,25 @@ where
         W: Write,
     {
         self.write_dataset_with_ts_cs(to, ts, SpecificCharacterSet::default())
+    }
+
+    /// Write this object's data set into the given writer,
+    /// with the specified transfer syntax,
+    /// without preamble, magic code, nor file meta group.
+    ///
+    /// The default character set is assumed
+    /// until the _Specific Character Set_ is found in the data set,
+    /// after which the text encoder is overridden accordingly.
+    pub fn write_dataset_with_ts_options<W>(
+        &self,
+        to: W,
+        ts: &TransferSyntax,
+        options: DataSetWriterOptions,
+    ) -> Result<(), WriteError>
+    where
+        W: Write,
+    {
+        self.write_dataset_with_ts_cs_options(to, ts, SpecificCharacterSet::default(), options)
     }
 
     /// Encapsulate this object to contain a file meta group
@@ -2545,8 +2608,7 @@ mod tests {
         let meta = file_object.meta();
 
         assert_eq!(
-            meta.media_storage_sop_instance_uid
-                .trim_end_matches('\0'),
+            meta.media_storage_sop_instance_uid.trim_end_matches('\0'),
             sop_uid.trim_end_matches('\0'),
         );
     }
@@ -3859,11 +3921,9 @@ mod tests {
             Some(Length(0)),
         );
 
-        assert!(
-            !obj.update_value(tags::BURNED_IN_ANNOTATION, |_value| {
-                panic!("should not be called")
-            }),
-        );
+        assert!(!obj.update_value(tags::BURNED_IN_ANNOTATION, |_value| {
+            panic!("should not be called")
+        }),);
 
         let o = obj.update_value(tags::ANATOMIC_REGION_SEQUENCE, |value| {
             // add an item

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -1932,7 +1932,7 @@ where
     /// without preamble, magic code, nor file meta group.
     ///
     /// The default [DataSetWriterOptions] is used for the writer. To change
-    /// that, use [`write_dataset_with_ts_cs_options`](Self::write_dataset_with_ts_cs_options).
+    /// that, use [`write_dataset_with_ts_options`](Self::write_dataset_with_ts_options).
     ///
     /// The default character set is assumed
     /// until the _Specific Character Set_ is found in the data set,

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -11,7 +11,6 @@ use dicom_encoding::encode::explicit_le::ExplicitVRLittleEndianEncoder;
 use dicom_encoding::encode::EncoderFor;
 use dicom_encoding::text::{self, TextCodec};
 use dicom_encoding::TransferSyntax;
-use dicom_parser::dataset::write::DataSetWriterOptions;
 use dicom_parser::dataset::{DataSetWriter, IntoTokens};
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 use std::io::{Read, Write};
@@ -780,7 +779,6 @@ impl FileMetaTable {
         let mut dset = DataSetWriter::new(
             writer,
             EncoderFor::new(ExplicitVRLittleEndianEncoder::default()),
-            DataSetWriterOptions::default(),
         );
         //There are no sequences in the `FileMetaTable`, so the value of `invalidate_sq_len` is
         //not important

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -11,6 +11,7 @@ use dicom_encoding::encode::explicit_le::ExplicitVRLittleEndianEncoder;
 use dicom_encoding::encode::EncoderFor;
 use dicom_encoding::text::{self, TextCodec};
 use dicom_encoding::TransferSyntax;
+use dicom_parser::dataset::write::DataSetWriterOptions;
 use dicom_parser::dataset::{DataSetWriter, IntoTokens};
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 use std::io::{Read, Write};
@@ -779,6 +780,7 @@ impl FileMetaTable {
         let mut dset = DataSetWriter::new(
             writer,
             EncoderFor::new(ExplicitVRLittleEndianEncoder::default()),
+            DataSetWriterOptions::default(),
         );
         //There are no sequences in the `FileMetaTable`, so the value of `invalidate_sq_len` is
         //not important
@@ -1397,7 +1399,8 @@ mod tests {
             information_group_length: 0,
             information_version: [0u8, 1u8],
             media_storage_sop_class_uid: "1.2.840.10008.5.1.4.1.1.7".to_owned(),
-            media_storage_sop_instance_uid: "2.25.137731752600317795446120660167595746868".to_owned(),
+            media_storage_sop_instance_uid: "2.25.137731752600317795446120660167595746868"
+                .to_owned(),
             transfer_syntax: "1.2.840.10008.1.2.4.91".to_owned(),
             implementation_class_uid: "2.25.305828488182831875890203105390285383139".to_owned(),
             implementation_version_name: Some("MYTOOL100".to_owned()),
@@ -1416,6 +1419,9 @@ mod tests {
         let table2 = FileMetaTable::from_reader(&mut buf.as_slice())
             .expect("Should not fail to read the table from the written data");
 
-        assert_eq!(table.information_group_length, table2.information_group_length);
+        assert_eq!(
+            table.information_group_length,
+            table2.information_group_length
+        );
     }
 }

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -88,6 +88,10 @@ struct SeqToken {
 pub enum ExplicitLengthSqItemStrategy {
     /// All explicit length items and sequences are written with Length::UNDEFINED.
     ///
+    /// Be advised that even if you create or read a data set with explicit length
+    /// items / sequences, the resulting output of the writer will have undefined
+    /// lengths for all items and sequences.
+    ///  
     /// For reasons stated in the documentation of the `ExplicitLengthSqItemStrategy`, this
     /// is as of yet, the fastest and safest way to handle explicit length items and sequences
     /// and thus default.

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -81,6 +81,52 @@ struct SeqToken {
     len: Length,
 }
 
+/// A strategy for writing Sequences and Items if the writer
+/// encounters a Sequence or Item with explicit (defined) length
+#[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum ExplicitLengthSqItemStrategy {
+    /// All explicit length items and sequences are written with Length::UNDEFINED.
+    ///
+    /// For reasons stated in the documentation of the `ExplicitLengthSqItemStrategy`, this
+    /// is as of yet, the fastest and safest way to handle explicit length items and sequences
+    /// and thus default.
+    #[default]
+    SetUndefined,
+    /// Explicit length items and sequences are written without any change, left as they were encountered
+    /// in the data set.
+    ///
+    /// Lenghts will not be recalculated !
+    ///
+    /// As a consequence, if the content of a sequence or item with explicit length is manipulated after
+    /// it was created or read from a source ( = possibly changes it's real size), this strategy will not
+    /// update the length of the sequence or item and might produce invalid output.
+    NoChange,
+    // Explicit lenght items and sequences could as well be recalculated, as is the behavior
+    // of some DICOM libraries. Because recalculation is expensive and leaving sequences and items
+    // with length undefined is DICOM compliant, this strategy is not implemented (yet).
+    // Racalculate (todo?),
+}
+
+/// The set of options for the data set writer.
+#[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub struct DataSetWriterOptions {
+    /// What to do with sequences and items with explicit lengths.
+    pub explicit_length_sq_item_strategy: ExplicitLengthSqItemStrategy,
+}
+
+impl DataSetWriterOptions {
+    /// Replace the write strategy for explicit length sequences and items of the options.
+    pub fn explicit_length_sq_item_strategy(
+        mut self,
+        exp_length: ExplicitLengthSqItemStrategy,
+    ) -> Self {
+        self.explicit_length_sq_item_strategy = exp_length;
+        self
+    }
+}
+
 /// A stateful device for printing a DICOM data set in sequential order.
 /// This is analogous to the `DatasetReader` type for converting data
 /// set tokens to bytes.
@@ -89,6 +135,7 @@ pub struct DataSetWriter<W, E, T = SpecificCharacterSet> {
     printer: StatefulEncoder<W, E, T>,
     seq_tokens: Vec<SeqToken>,
     last_de: Option<DataElementHeader>,
+    options: DataSetWriterOptions,
 }
 
 impl<'w, W: 'w> DataSetWriter<W, DynEncoder<'w, W>>
@@ -97,7 +144,29 @@ where
 {
     /// Create a new data set writer
     /// with the given transfer syntax specifier.
+    ///
+    /// Uses the default [DataSetWriterOptions] for the writer.
     pub fn with_ts(to: W, ts: &TransferSyntax) -> Result<Self> {
+        Self::with_ts_options(to, ts, DataSetWriterOptions::default())
+    }
+
+    /// Create a new data set writer
+    /// with the given transfer syntax specifier
+    /// and the specific character.
+    ///
+    /// Uses the default [DataSetWriterOptions] for the writer.
+    pub fn with_ts_cs(to: W, ts: &TransferSyntax, charset: SpecificCharacterSet) -> Result<Self> {
+        Self::with_ts_cs_options(to, ts, charset, DataSetWriterOptions::default())
+    }
+
+    /// Create a new data set writer
+    /// with the given transfer syntax specifier
+    /// and options.
+    pub fn with_ts_options(
+        to: W,
+        ts: &TransferSyntax,
+        options: DataSetWriterOptions,
+    ) -> Result<Self> {
         let encoder = ts.encoder_for().context(UnsupportedTransferSyntaxSnafu {
             ts_uid: ts.uid(),
             ts_alias: ts.name(),
@@ -106,41 +175,45 @@ where
             to,
             encoder,
             SpecificCharacterSet::default(),
+            options,
         ))
     }
 
     /// Create a new data set writer
-    /// with the given transfer syntax specifier
-    /// and the specific character set to assume by default.
-    ///
-    /// Note that the data set being written
-    /// can override the character set with the presence of a
-    /// _Specific Character Set_ data element.
-    pub fn with_ts_cs(to: W, ts: &TransferSyntax, charset: SpecificCharacterSet) -> Result<Self> {
+    /// with the given transfer syntax specifier,
+    /// specific character set and options.
+    pub fn with_ts_cs_options(
+        to: W,
+        ts: &TransferSyntax,
+        charset: SpecificCharacterSet,
+        options: DataSetWriterOptions,
+    ) -> Result<Self> {
         let encoder = ts.encoder_for().context(UnsupportedTransferSyntaxSnafu {
             ts_uid: ts.uid(),
             ts_alias: ts.name(),
         })?;
-        Ok(DataSetWriter::new_with_codec(to, encoder, charset))
+        Ok(DataSetWriter::new_with_codec(to, encoder, charset, options))
     }
 }
 
 impl<W, E> DataSetWriter<W, E> {
-    pub fn new(to: W, encoder: E) -> Self {
+    pub fn new(to: W, encoder: E, options: DataSetWriterOptions) -> Self {
         DataSetWriter {
             printer: StatefulEncoder::new(to, encoder, SpecificCharacterSet::default()),
             seq_tokens: Vec::new(),
             last_de: None,
+            options,
         }
     }
 }
 
 impl<W, E, T> DataSetWriter<W, E, T> {
-    pub fn new_with_codec(to: W, encoder: E, text: T) -> Self {
+    pub fn new_with_codec(to: W, encoder: E, text: T, options: DataSetWriterOptions) -> Self {
         DataSetWriter {
             printer: StatefulEncoder::new(to, encoder, text),
             seq_tokens: Vec::new(),
             last_de: None,
+            options,
         }
     }
 }
@@ -165,25 +238,48 @@ where
 
     /// Feed the given data set token for writing the data set.
     pub fn write(&mut self, token: DataToken) -> Result<()> {
-        // adjust the logic of sequence printing:
-        // explicit length sequences or items should not print
-        // the respective delimiter
-
         match token {
-            DataToken::SequenceStart { len, .. } => {
-                self.seq_tokens.push(SeqToken {
-                    typ: SeqTokenType::Sequence,
-                    len,
-                });
-                self.write_impl(&token)?;
+            DataToken::SequenceStart { tag, len, .. } => {
+                match self.options.explicit_length_sq_item_strategy {
+                    ExplicitLengthSqItemStrategy::SetUndefined => {
+                        self.seq_tokens.push(SeqToken {
+                            typ: SeqTokenType::Sequence,
+                            len: Length::UNDEFINED,
+                        });
+                        self.write_impl(&DataToken::SequenceStart {
+                            tag,
+                            len: Length::UNDEFINED,
+                        })?;
+                    }
+                    ExplicitLengthSqItemStrategy::NoChange => {
+                        self.seq_tokens.push(SeqToken {
+                            typ: SeqTokenType::Sequence,
+                            len,
+                        });
+                        self.write_impl(&token)?;
+                    }
+                }
                 Ok(())
             }
             DataToken::ItemStart { len } => {
-                self.seq_tokens.push(SeqToken {
-                    typ: SeqTokenType::Item,
-                    len,
-                });
-                self.write_impl(&token)?;
+                match self.options.explicit_length_sq_item_strategy {
+                    ExplicitLengthSqItemStrategy::SetUndefined => {
+                        self.seq_tokens.push(SeqToken {
+                            typ: SeqTokenType::Item,
+                            len: Length::UNDEFINED,
+                        });
+                        self.write_impl(&DataToken::ItemStart {
+                            len: Length::UNDEFINED,
+                        })?;
+                    }
+                    ExplicitLengthSqItemStrategy::NoChange => {
+                        self.seq_tokens.push(SeqToken {
+                            typ: SeqTokenType::Item,
+                            len,
+                        });
+                        self.write_impl(&token)?;
+                    }
+                }
                 Ok(())
             }
             DataToken::ItemEnd => {
@@ -218,6 +314,7 @@ where
                 });
                 self.write_impl(&token)
             }
+            //DataToken::ItemEnd | DataToken::SequenceEnd => self.write_impl(&token),
             token @ DataToken::ItemValue(_)
             | token @ DataToken::PrimitiveValue(_)
             | token @ DataToken::OffsetTable(_) => self.write_impl(&token),
@@ -283,7 +380,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::super::DataToken;
-    use super::DataSetWriter;
+    use super::{DataSetWriter, DataSetWriterOptions, ExplicitLengthSqItemStrategy};
     use dicom_core::{
         header::{DataElementHeader, Length},
         value::PrimitiveValue,
@@ -291,13 +388,16 @@ mod tests {
     };
     use dicom_encoding::encode::{explicit_le::ExplicitVRLittleEndianEncoder, EncoderFor};
 
-    fn validate_dataset_writer<I>(tokens: I, ground_truth: &[u8])
-    where
+    fn validate_dataset_writer<I>(
+        tokens: I,
+        ground_truth: &[u8],
+        writer_options: DataSetWriterOptions,
+    ) where
         I: IntoIterator<Item = DataToken>,
     {
         let mut raw_out: Vec<u8> = vec![];
         let encoder = EncoderFor::new(ExplicitVRLittleEndianEncoder::default());
-        let mut dset_writer = DataSetWriter::new(&mut raw_out, encoder);
+        let mut dset_writer = DataSetWriter::new(&mut raw_out, encoder, writer_options);
 
         dset_writer.write_sequence(tokens).unwrap();
 
@@ -343,7 +443,33 @@ mod tests {
         ];
 
         #[rustfmt::skip]
-        static GROUND_TRUTH: &[u8] = &[
+        static GROUND_TRUTH_LENGTH_UNDEFINED: &[u8] = &[
+            0x18, 0x00, 0x11, 0x60, // sequence tag: (0018,6011) SequenceOfUltrasoundRegions
+            b'S', b'Q', // VR 
+            0x00, 0x00, // reserved
+            0xff, 0xff, 0xff, 0xff, // seq length: UNDEFINED
+            // -- 12 --
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: UNDEFINED
+            // -- 20 --
+            0x18, 0x00, 0x12, 0x60, b'U', b'S', 0x02, 0x00, 0x01, 0x00, // (0018, 6012) RegionSpatialformat, len = 2, value = 1
+            // -- 30 --
+            0x18, 0x00, 0x14, 0x60, b'U', b'S', 0x02, 0x00, 0x02, 0x00, // (0018, 6012) RegionDataType, len = 2, value = 2
+            // -- 40 --
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: UNDEFINED
+            // -- 48 --
+            0x18, 0x00, 0x12, 0x60, b'U', b'S', 0x02, 0x00, 0x04, 0x00, // (0018, 6012) RegionSpatialformat, len = 2, value = 4
+            // -- 58 --
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            0xfe, 0xff, 0xdd, 0xe0, 0x00, 0x00, 0x00, 0x00, // sequence end
+            0x20, 0x00, 0x00, 0x40, b'L', b'T', 0x04, 0x00, // (0020,4000) ImageComments, len = 4  
+            b'T', b'E', b'S', b'T', // value = "TEST"
+        ];
+
+        #[rustfmt::skip]
+        static GROUND_TRUTH_NO_CHANGE: &[u8] = &[
             0x18, 0x00, 0x11, 0x60, // sequence tag: (0018,6011) SequenceOfUltrasoundRegions
             b'S', b'Q', // VR 
             0x00, 0x00, // reserved
@@ -365,7 +491,15 @@ mod tests {
             b'T', b'E', b'S', b'T', // value = "TEST"
         ];
 
-        validate_dataset_writer(tokens, GROUND_TRUTH);
+        let no_change = DataSetWriterOptions {
+            explicit_length_sq_item_strategy: ExplicitLengthSqItemStrategy::NoChange,
+        };
+        validate_dataset_writer(tokens.clone(), GROUND_TRUTH_NO_CHANGE, no_change);
+        validate_dataset_writer(
+            tokens,
+            GROUND_TRUTH_LENGTH_UNDEFINED,
+            DataSetWriterOptions::default(),
+        );
     }
 
     #[test]
@@ -402,8 +536,7 @@ mod tests {
             // value = "Simões^João "
             b'S', b'i', b'm', 0xF5, b'e', b's', b'^', b'J', b'o', 0xE3, b'o', b' '
         ];
-
-        validate_dataset_writer(tokens, GROUND_TRUTH);
+        validate_dataset_writer(tokens, GROUND_TRUTH, DataSetWriterOptions::default());
     }
 
     #[test]
@@ -477,7 +610,11 @@ mod tests {
             b'T', b'E', b'S', b'T', // value = "TEST"
         ];
 
-        validate_dataset_writer(tokens, GROUND_TRUTH);
+        let no_change = DataSetWriterOptions {
+            explicit_length_sq_item_strategy: ExplicitLengthSqItemStrategy::NoChange,
+        };
+        validate_dataset_writer(tokens.clone(), GROUND_TRUTH, no_change);
+        validate_dataset_writer(tokens, GROUND_TRUTH, DataSetWriterOptions::default());
     }
 
     #[test]
@@ -523,7 +660,27 @@ mod tests {
         ];
 
         #[rustfmt::skip]
-        static GROUND_TRUTH: &[u8] = &[
+        static GROUND_TRUTH_LENGTH_UNDEFINED: &[u8] = &[
+            0x18, 0x00, 0x11, 0x60, // sequence tag: (0018,6011) SequenceOfUltrasoundRegions
+            b'S', b'Q', // VR 
+            0x00, 0x00, // reserved
+            0xff, 0xff, 0xff, 0xff, // length: UNDEFINED
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: undefined
+            0x18, 0x00, 0x12, 0x60, b'U', b'S', 0x02, 0x00, 0x01, 0x00, // (0018, 6012) RegionSpatialformat, len = 2, value = 1
+            0x18, 0x00, 0x14, 0x60, b'U', b'S', 0x02, 0x00, 0x02, 0x00, // (0018, 6012) RegionDataType, len = 2, value = 2
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: undefined
+            0x18, 0x00, 0x12, 0x60, b'U', b'S', 0x02, 0x00, 0x04, 0x00, // (0018, 6012) RegionSpatialformat, len = 2, value = 4
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            0xfe, 0xff, 0xdd, 0xe0, 0x00, 0x00, 0x00, 0x00, // sequence end
+            0x20, 0x00, 0x00, 0x40, b'L', b'T', 0x04, 0x00, // (0020,4000) ImageComments, len = 4  
+            b'T', b'E', b'S', b'T', // value = "TEST"
+        ];
+
+        #[rustfmt::skip]
+        static GROUND_TRUTH_NO_CHANGE: &[u8] = &[
             0x18, 0x00, 0x11, 0x60, // sequence tag: (0018,6011) SequenceOfUltrasoundRegions
             b'S', b'Q', // VR 
             0x00, 0x00, // reserved
@@ -548,8 +705,16 @@ mod tests {
             0x20, 0x00, 0x00, 0x40, b'L', b'T', 0x04, 0x00, // (0020,4000) ImageComments, len = 4  
             b'T', b'E', b'S', b'T', // value = "TEST"
         ];
+        let no_change = DataSetWriterOptions {
+            explicit_length_sq_item_strategy: ExplicitLengthSqItemStrategy::NoChange,
+        };
 
-        validate_dataset_writer(tokens, GROUND_TRUTH);
+        validate_dataset_writer(tokens.clone(), GROUND_TRUTH_NO_CHANGE, no_change);
+        validate_dataset_writer(
+            tokens,
+            GROUND_TRUTH_LENGTH_UNDEFINED,
+            DataSetWriterOptions::default(),
+        );
     }
 
     #[test]
@@ -571,7 +736,35 @@ mod tests {
         ];
 
         #[rustfmt::skip]
-        static GROUND_TRUTH: &[u8] = &[
+        static GROUND_TRUTH_LENGTH_UNDEFINED: &[u8] = &[
+            0xe0, 0x7f, 0x10, 0x00, // (7FE0, 0010) PixelData
+            b'O', b'B', // VR 
+            0x00, 0x00, // reserved
+            0xff, 0xff, 0xff, 0xff, // length: undefined
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: UNDEFINED
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: UNDEFINED
+            // Compressed Fragment
+            0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+            0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+            0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+            0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            // End of pixel data
+            0xfe, 0xff, 0xdd, 0xe0, // sequence end tag
+            0x00, 0x00, 0x00, 0x00,
+            // -- 68 -- padding
+            0xfc, 0xff, 0xfc, 0xff, // (fffc,fffc) DataSetTrailingPadding
+            b'O', b'B', // VR
+            0x00, 0x00, // reserved
+            0x08, 0x00, 0x00, 0x00, // length: 8
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        #[rustfmt::skip]
+        static GROUND_TRUTH_NO_CHANGE: &[u8] = &[
             0xe0, 0x7f, 0x10, 0x00, // (7FE0, 0010) PixelData
             b'O', b'B', // VR 
             0x00, 0x00, // reserved
@@ -597,7 +790,14 @@ mod tests {
             0x08, 0x00, 0x00, 0x00, // length: 8
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
-
-        validate_dataset_writer(tokens, GROUND_TRUTH);
+        let no_change = DataSetWriterOptions {
+            explicit_length_sq_item_strategy: ExplicitLengthSqItemStrategy::NoChange,
+        };
+        validate_dataset_writer(tokens.clone(), GROUND_TRUTH_NO_CHANGE, no_change);
+        validate_dataset_writer(
+            tokens,
+            GROUND_TRUTH_LENGTH_UNDEFINED,
+            DataSetWriterOptions::default(),
+        );
     }
 }

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -175,7 +175,7 @@ where
             ts_uid: ts.uid(),
             ts_alias: ts.name(),
         })?;
-        Ok(DataSetWriter::new_with_codec(
+        Ok(DataSetWriter::new_with_codec_options(
             to,
             encoder,
             SpecificCharacterSet::default(),
@@ -196,12 +196,24 @@ where
             ts_uid: ts.uid(),
             ts_alias: ts.name(),
         })?;
-        Ok(DataSetWriter::new_with_codec(to, encoder, charset, options))
+        Ok(DataSetWriter::new_with_codec_options(
+            to, encoder, charset, options,
+        ))
     }
 }
 
 impl<W, E> DataSetWriter<W, E> {
-    pub fn new(to: W, encoder: E, options: DataSetWriterOptions) -> Self {
+    /// Create a new dataset writer with the given encoder,
+    /// which prints to the given writer.
+    #[inline]
+    pub fn new(to: W, encoder: E) -> Self {
+        DataSetWriter::new_with_options(to, encoder, DataSetWriterOptions::default())
+    }
+
+    /// Create a new dataset writer with the given encoder,
+    /// which prints to the given writer.
+    #[inline]
+    pub fn new_with_options(to: W, encoder: E, options: DataSetWriterOptions) -> Self {
         DataSetWriter {
             printer: StatefulEncoder::new(to, encoder, SpecificCharacterSet::default()),
             seq_tokens: Vec::new(),
@@ -212,7 +224,22 @@ impl<W, E> DataSetWriter<W, E> {
 }
 
 impl<W, E, T> DataSetWriter<W, E, T> {
-    pub fn new_with_codec(to: W, encoder: E, text: T, options: DataSetWriterOptions) -> Self {
+    /// Create a new dataset writer with the given encoder and text codec,
+    /// which prints to the given writer.
+    #[inline]
+    pub fn new_with_codec(to: W, encoder: E, text: T) -> Self {
+        DataSetWriter::new_with_codec_options(to, encoder, text, DataSetWriterOptions::default())
+    }
+
+    /// Create a new dataset writer with the given encoder and text codec,
+    /// which prints to the given writer.
+    #[inline]
+    pub fn new_with_codec_options(
+        to: W,
+        encoder: E,
+        text: T,
+        options: DataSetWriterOptions,
+    ) -> Self {
         DataSetWriter {
             printer: StatefulEncoder::new(to, encoder, text),
             seq_tokens: Vec::new(),
@@ -401,7 +428,8 @@ mod tests {
     {
         let mut raw_out: Vec<u8> = vec![];
         let encoder = EncoderFor::new(ExplicitVRLittleEndianEncoder::default());
-        let mut dset_writer = DataSetWriter::new(&mut raw_out, encoder, writer_options);
+        let mut dset_writer =
+            DataSetWriter::new_with_options(&mut raw_out, encoder, writer_options);
 
         dset_writer.write_sequence(tokens).unwrap();
 


### PR DESCRIPTION

This adds `DatasetWriterOptions` to the `parser` crate and should handle #636 and similar situations.

The options now contain an `ExplicitLengthSqItemStrategy`.

`ExplicitLengthSqItemStrategy::NoChange` - is the previous behavior, where explicit length items and sequences were left with their length unchanged, which in case of modifying the sequences or items content could lead to incorrect explicit length.
As this situation would occur on a regular basis, and the resulting errors are hard to debug, this is no more the default strategy and risks resulting from it's use are documented.

`ExplicitLengthSqItemStrategy::SetUndefined ` is the new default strategy. It simply writes all Items and Sequences with
`Length::UNDEFINED` irrespective of the original `Length`  enum variant.
Upon inspection of the writer byte output, this will appear counterintuitive to the user.
This is documented.

The final strategy -  recalculating the lengths - is not implemented. 
Reasons are:
 - requires propagation of "bytes_written" value from lower level apis or using some mock writer to count bytes
 - recalculation is expensive
 - current state, even though not optimal and counterintuitive, is error free and DICOM compliant
