### PR TITLE
Add odd length reading strategy fod Dicom Dump

### DIFF
--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -355,14 +355,6 @@ impl Display for ColorModeError {
 
 impl std::error::Error for ColorModeError {}
 
-/*#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
-pub enum OddLengthTextStrategy {
-    Accept,
-    NextEven,
-    Fail
-}
-*/
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DumpValue<T>
 where

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -355,6 +355,14 @@ impl Display for ColorModeError {
 
 impl std::error::Error for ColorModeError {}
 
+/*#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+pub enum OddLengthTextStrategy {
+    Accept,
+    NextEven,
+    Fail
+}
+*/
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DumpValue<T>
 where

--- a/dump/src/main.rs
+++ b/dump/src/main.rs
@@ -33,7 +33,7 @@ struct App {
     /// as in the next even number.
     ///
     /// fail: Raise an error instead
-    #[clap(short = 'o', long = "odd_length_strategy", value_parser = parse_strategy, default_value = "accept")]
+    #[clap(short = 'o', long = "odd-length-strategy", value_parser = parse_strategy, default_value = "accept")]
     odd_length_strategy: OddLengthStrategy,
     /// Print text values to the end
     /// (limited to `width` by default).

--- a/dump/src/main.rs
+++ b/dump/src/main.rs
@@ -3,8 +3,8 @@
 use clap::Parser;
 use dicom_core::Tag;
 use dicom_dictionary_std::tags;
-use dicom_dump::{ColorMode, DumpOptions, DumpFormat};
-use dicom_object::{OpenFileOptions, StandardDataDictionary};
+use dicom_dump::{ColorMode, DumpFormat, DumpOptions};
+use dicom_object::{file::OddLengthStrategy, OpenFileOptions, StandardDataDictionary};
 use snafu::{Report, Whatever};
 use std::io::{ErrorKind, IsTerminal};
 use std::path::PathBuf;
@@ -13,7 +13,6 @@ use std::path::PathBuf;
 const ERROR_READ: i32 = -2;
 /// Exit code for when an error emerged while dumping the file.
 const ERROR_PRINT: i32 = -3;
-
 
 /// Dump the contents of DICOM files
 #[derive(Debug, Parser)]
@@ -25,10 +24,21 @@ struct App {
     /// Read the file up to this tag
     #[clap(long = "until", value_parser = parse_tag)]
     read_until: Option<Tag>,
+    /// Strategy for handling odd-length text values
+    ///
+    /// accept: Accept elements with an odd length as is,
+    /// continuing data set reading normally.
+    ///
+    /// next_even: Assume that the real length is `length + 1`,
+    /// as in the next even number.
+    ///
+    /// fail: Raise an error instead
+    #[clap(short = 'o', long = "odd_length_strategy", value_parser = parse_strategy, default_value = "accept")]
+    odd_length_strategy: OddLengthStrategy,
     /// Print text values to the end
     /// (limited to `width` by default).
-    /// 
-    /// Does not apply if output is not a tty 
+    ///
+    /// Does not apply if output is not a tty
     /// or if output type is json
     #[clap(long = "no-text-limit")]
     no_text_limit: bool,
@@ -38,8 +48,8 @@ struct App {
     no_limit: bool,
     /// The width of the display
     /// (default is to check automatically).
-    /// 
-    /// Does not apply if output is not a tty 
+    ///
+    /// Does not apply if output is not a tty
     /// or if output type is json
     #[clap(short = 'w', long = "width")]
     width: Option<u32>,
@@ -53,6 +63,15 @@ struct App {
     #[arg(value_enum)]
     #[clap(short = 'f', long = "format", default_value = "text")]
     format: DumpFormat,
+}
+
+fn parse_strategy(s: &str) -> Result<OddLengthStrategy, &'static str> {
+    match s {
+        "accept" => Ok(OddLengthStrategy::Accept),
+        "next_even" => Ok(OddLengthStrategy::NextEven),
+        "fail" => Ok(OddLengthStrategy::Fail),
+        _ => Err("invalid strategy"),
+    }
 }
 
 fn parse_tag(s: &str) -> Result<Tag, &'static str> {
@@ -75,6 +94,7 @@ fn run() -> Result<(), Whatever> {
     let App {
         files: filenames,
         read_until,
+        odd_length_strategy,
         no_text_limit,
         no_limit,
         width,
@@ -91,7 +111,7 @@ fn run() -> Result<(), Whatever> {
     options
         .no_text_limit(no_text_limit)
         // No limit when output is not a terminal
-        .no_limit(if !is_terminal() { true } else {no_limit})
+        .no_limit(if !is_terminal() { true } else { no_limit })
         .width(width)
         .color_mode(color)
         .format(format);
@@ -107,6 +127,8 @@ fn run() -> Result<(), Whatever> {
             None => OpenFileOptions::new(),
         };
 
+        let open_options = open_options.odd_length_strategy(odd_length_strategy);
+
         match open_options.open_file(filename) {
             Err(e) => {
                 eprintln!("{}", Report::from_error(e));
@@ -118,8 +140,8 @@ fn run() -> Result<(), Whatever> {
             Ok(mut obj) => {
                 if options.format == DumpFormat::Json {
                     // JSON output doesn't currently support encapsulated pixel data
-                    if let Ok(elem) = obj.element(tags::PIXEL_DATA){
-                        if let dicom_core::value::Value::PixelSequence(_) = elem.value(){
+                    if let Ok(elem) = obj.element(tags::PIXEL_DATA) {
+                        if let dicom_core::value::Value::PixelSequence(_) = elem.value() {
                             eprintln!("[WARN] Encapsulated pixel data not supported in JSON output, skipping");
                             obj.remove_element(tags::PIXEL_DATA);
                         }


### PR DESCRIPTION
added option to change the default "accept" odd length text strategy for the dicom-dump reader.

Comes in handy for ruling out padding / length problems in dicom files.