### PR TITLE
Encoder draft

### DIFF
--- a/encoding/src/encode/mod.rs
+++ b/encoding/src/encode/mod.rs
@@ -6,6 +6,7 @@ use snafu::{Backtrace, ResultExt, Snafu};
 use std::fmt;
 use std::io::{self, Write};
 use std::marker::PhantomData;
+use std::rc::Rc;
 
 pub mod basic;
 pub mod explicit_be;
@@ -554,6 +555,61 @@ where
 }
 
 impl<T: ?Sized, W: ?Sized> EncodeTo<W> for Box<T>
+where
+    T: EncodeTo<W>,
+{
+    fn encode_tag(&self, to: &mut W, tag: Tag) -> Result<()>
+    where
+        W: Write,
+    {
+        (**self).encode_tag(to, tag)
+    }
+
+    fn encode_element_header(&self, to: &mut W, de: DataElementHeader) -> Result<usize>
+    where
+        W: Write,
+    {
+        (**self).encode_element_header(to, de)
+    }
+
+    fn encode_item_header(&self, to: &mut W, len: u32) -> Result<()>
+    where
+        W: Write,
+    {
+        (**self).encode_item_header(to, len)
+    }
+
+    fn encode_item_delimiter(&self, to: &mut W) -> Result<()>
+    where
+        W: Write,
+    {
+        (**self).encode_item_delimiter(to)
+    }
+
+    fn encode_sequence_delimiter(&self, to: &mut W) -> Result<()>
+    where
+        W: Write,
+    {
+        (**self).encode_sequence_delimiter(to)
+    }
+
+    /// Encode and write a primitive DICOM value to the given destination.
+    fn encode_primitive(&self, to: &mut W, value: &PrimitiveValue) -> Result<usize>
+    where
+        W: Write,
+    {
+        (**self).encode_primitive(to, value)
+    }
+
+    fn encode_offset_table(&self, to: &mut W, offset_table: &[u32]) -> Result<usize>
+    where
+        W: Write,
+    {
+        (**self).encode_offset_table(to, offset_table)
+    }
+}
+
+impl<T: ?Sized, W: ?Sized> EncodeTo<W> for Rc<T>
 where
     T: EncodeTo<W>,
 {

--- a/encoding/src/transfer_syntax/mod.rs
+++ b/encoding/src/transfer_syntax/mod.rs
@@ -33,6 +33,7 @@ use crate::encode::{
     implicit_le::ImplicitVRLittleEndianEncoder, EncodeTo, EncoderFor,
 };
 use std::io::{Read, Write};
+use std::rc::Rc;
 
 pub use byteordered::Endianness;
 
@@ -40,7 +41,7 @@ pub use byteordered::Endianness;
 pub type DynDecoder<S> = Box<dyn DecodeFrom<S>>;
 
 /// An encoder with its type erased.
-pub type DynEncoder<'w, W> = Box<dyn EncodeTo<W> + 'w>;
+pub type DynEncoder<'w, W> = Rc<dyn EncodeTo<W> + 'w>;
 
 /// A DICOM transfer syntax specifier.
 ///
@@ -606,13 +607,13 @@ impl<D, R, W> TransferSyntax<D, R, W> {
         T: ?Sized + Write + 'w,
     {
         match (self.byte_order, self.explicit_vr) {
-            (Endianness::Little, false) => Some(Box::new(EncoderFor::new(
+            (Endianness::Little, false) => Some(Rc::new(EncoderFor::new(
                 ImplicitVRLittleEndianEncoder::default(),
             ))),
-            (Endianness::Little, true) => Some(Box::new(EncoderFor::new(
+            (Endianness::Little, true) => Some(Rc::new(EncoderFor::new(
                 ExplicitVRLittleEndianEncoder::default(),
             ))),
-            (Endianness::Big, true) => Some(Box::new(EncoderFor::new(
+            (Endianness::Big, true) => Some(Rc::new(EncoderFor::new(
                 ExplicitVRBigEndianEncoder::default(),
             ))),
             _ => None,

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -1830,7 +1830,7 @@ where
     /// without preamble, magic code, nor file meta group.
     ///
     /// The default [DataSetWriterOptions] is used for the writer. To change
-    /// that, use [`write_dataset_with_ts_cs_options`](Self::write_dataset_with_ts_cs_options).
+    /// that, use [`write_dataset_with_ts_options`](Self::write_dataset_with_ts_options).
     ///
     /// The default character set is assumed
     /// until the _Specific Character Set_ is found in the data set,

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -1751,7 +1751,7 @@ where
     pub fn write_dataset<W, E>(&self, to: W, encoder: E) -> Result<(), WriteError>
     where
         W: Write,
-        E: EncodeTo<W>,
+        E: EncodeTo<W> + Clone,
     {
         // prepare data set writer
         let mut dset_writer = DataSetWriter::new(to, encoder, DataSetWriterOptions::default());
@@ -2208,6 +2208,7 @@ mod tests {
         // assumes that Undefined lengths are equal.
         assert_eq!(format!("{:?}", obj1), format!("{:?}", obj2))
     }
+    use std::rc::Rc;
 
     #[test]
     fn inmem_object_compare() {
@@ -2324,7 +2325,7 @@ mod tests {
 
         let mut out = Vec::new();
 
-        let printer = EncoderFor::new(ImplicitVRLittleEndianEncoder::default());
+        let printer = Rc::new(EncoderFor::new(ImplicitVRLittleEndianEncoder::default()));
 
         obj.write_dataset(&mut out, printer).unwrap();
 

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -11,6 +11,7 @@ use dicom_encoding::encode::explicit_le::ExplicitVRLittleEndianEncoder;
 use dicom_encoding::encode::EncoderFor;
 use dicom_encoding::text::{self, TextCodec};
 use dicom_encoding::TransferSyntax;
+use dicom_parser::dataset::write::DataSetWriterOptions;
 use dicom_parser::dataset::{DataSetWriter, IntoTokens};
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 use std::io::{Read, Write};
@@ -774,6 +775,7 @@ impl FileMetaTable {
         let mut dset = DataSetWriter::new(
             writer,
             EncoderFor::new(ExplicitVRLittleEndianEncoder::default()),
+            DataSetWriterOptions::default(),
         );
         //There are no sequences in the `FileMetaTable`, so the value of `invalidate_sq_len` is
         //not important
@@ -1392,7 +1394,8 @@ mod tests {
             information_group_length: 0,
             information_version: [0u8, 1u8],
             media_storage_sop_class_uid: "1.2.840.10008.5.1.4.1.1.7".to_owned(),
-            media_storage_sop_instance_uid: "2.25.137731752600317795446120660167595746868".to_owned(),
+            media_storage_sop_instance_uid: "2.25.137731752600317795446120660167595746868"
+                .to_owned(),
             transfer_syntax: "1.2.840.10008.1.2.4.91".to_owned(),
             implementation_class_uid: "2.25.305828488182831875890203105390285383139".to_owned(),
             implementation_version_name: Some("MYTOOL100".to_owned()),
@@ -1411,6 +1414,9 @@ mod tests {
         let table2 = FileMetaTable::from_reader(&mut buf.as_slice())
             .expect("Should not fail to read the table from the written data");
 
-        assert_eq!(table.information_group_length, table2.information_group_length);
+        assert_eq!(
+            table.information_group_length,
+            table2.information_group_length
+        );
     }
 }

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -15,6 +15,7 @@ use dicom_parser::dataset::write::DataSetWriterOptions;
 use dicom_parser::dataset::{DataSetWriter, IntoTokens};
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 use std::io::{Read, Write};
+use std::rc::Rc;
 
 use crate::ops::{
     ApplyError, ApplyResult, IllegalExtendSnafu, IncompatibleTypesSnafu, MandatorySnafu,
@@ -774,7 +775,7 @@ impl FileMetaTable {
     pub fn write<W: Write>(&self, writer: W) -> Result<()> {
         let mut dset = DataSetWriter::new(
             writer,
-            EncoderFor::new(ExplicitVRLittleEndianEncoder::default()),
+            Rc::new(EncoderFor::new(ExplicitVRLittleEndianEncoder::default())),
             DataSetWriterOptions::default(),
         );
         //There are no sequences in the `FileMetaTable`, so the value of `invalidate_sq_len` is

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -88,6 +88,10 @@ struct SeqToken {
 pub enum ExplicitLengthSqItemStrategy {
     /// All explicit length items and sequences are written with Length::UNDEFINED.
     ///
+    /// Be advised that even if you create or read a data set with explicit length
+    /// items / sequences, the resulting output of the writer will have undefined
+    /// lengths for all items and sequences.
+    ///  
     /// For reasons stated in the documentation of the `ExplicitLengthSqItemStrategy`, this
     /// is as of yet, the fastest and safest way to handle explicit length items and sequences
     /// and thus default.

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -81,6 +81,52 @@ struct SeqToken {
     len: Length,
 }
 
+/// A strategy for writing Sequences and Items if the writer
+/// encounters a Sequence or Item with explicit (defined) length
+#[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum ExplicitLengthSqItemStrategy {
+    /// All explicit length items and sequences are written with Length::UNDEFINED.
+    ///
+    /// For reasons stated in the documentation of the `ExplicitLengthSqItemStrategy`, this
+    /// is as of yet, the fastest and safest way to handle explicit length items and sequences
+    /// and thus default.
+    #[default]
+    SetUndefined,
+    /// Explicit length items and sequences are written without any change, left as they were encountered
+    /// in the data set.
+    ///
+    /// Lenghts will not be recalculated !
+    ///
+    /// As a consequence, if the content of a sequence or item with explicit length is manipulated after
+    /// it was created or read from a source ( = possibly changes it's real size), this strategy will not
+    /// update the length of the sequence or item and might produce invalid output.
+    NoChange,
+    // Explicit lenght items and sequences could as well be recalculated, as is the behavior
+    // of some DICOM libraries. Because recalculation is expensive and leaving sequences and items
+    // with length undefined is DICOM compliant, this strategy is not implemented (yet).
+    // Racalculate (todo?),
+}
+
+/// The set of options for the data set writer.
+#[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub struct DataSetWriterOptions {
+    /// What to do with sequences and items with explicit lengths.
+    pub explicit_length_sq_item_strategy: ExplicitLengthSqItemStrategy,
+}
+
+impl DataSetWriterOptions {
+    /// Replace the write strategy for explicit length sequences and items of the options.
+    pub fn explicit_length_sq_item_strategy(
+        mut self,
+        exp_length: ExplicitLengthSqItemStrategy,
+    ) -> Self {
+        self.explicit_length_sq_item_strategy = exp_length;
+        self
+    }
+}
+
 /// A stateful device for printing a DICOM data set in sequential order.
 /// This is analogous to the `DatasetReader` type for converting data
 /// set tokens to bytes.
@@ -89,6 +135,7 @@ pub struct DataSetWriter<W, E, T = SpecificCharacterSet> {
     printer: StatefulEncoder<W, E, T>,
     seq_tokens: Vec<SeqToken>,
     last_de: Option<DataElementHeader>,
+    options: DataSetWriterOptions,
 }
 
 impl<'w, W: 'w> DataSetWriter<W, DynEncoder<'w, W>>
@@ -97,7 +144,29 @@ where
 {
     /// Create a new data set writer
     /// with the given transfer syntax specifier.
+    ///
+    /// Uses the default [DataSetWriterOptions] for the writer.
     pub fn with_ts(to: W, ts: &TransferSyntax) -> Result<Self> {
+        Self::with_ts_options(to, ts, DataSetWriterOptions::default())
+    }
+
+    /// Create a new data set writer
+    /// with the given transfer syntax specifier
+    /// and the specific character.
+    ///
+    /// Uses the default [DataSetWriterOptions] for the writer.
+    pub fn with_ts_cs(to: W, ts: &TransferSyntax, charset: SpecificCharacterSet) -> Result<Self> {
+        Self::with_ts_cs_options(to, ts, charset, DataSetWriterOptions::default())
+    }
+
+    /// Create a new data set writer
+    /// with the given transfer syntax specifier
+    /// and options.
+    pub fn with_ts_options(
+        to: W,
+        ts: &TransferSyntax,
+        options: DataSetWriterOptions,
+    ) -> Result<Self> {
         let encoder = ts.encoder_for().context(UnsupportedTransferSyntaxSnafu {
             ts_uid: ts.uid(),
             ts_alias: ts.name(),
@@ -106,41 +175,45 @@ where
             to,
             encoder,
             SpecificCharacterSet::default(),
+            options,
         ))
     }
 
     /// Create a new data set writer
-    /// with the given transfer syntax specifier
-    /// and the specific character set to assume by default.
-    ///
-    /// Note that the data set being written
-    /// can override the character set with the presence of a
-    /// _Specific Character Set_ data element.
-    pub fn with_ts_cs(to: W, ts: &TransferSyntax, charset: SpecificCharacterSet) -> Result<Self> {
+    /// with the given transfer syntax specifier,
+    /// specific character set and options.
+    pub fn with_ts_cs_options(
+        to: W,
+        ts: &TransferSyntax,
+        charset: SpecificCharacterSet,
+        options: DataSetWriterOptions,
+    ) -> Result<Self> {
         let encoder = ts.encoder_for().context(UnsupportedTransferSyntaxSnafu {
             ts_uid: ts.uid(),
             ts_alias: ts.name(),
         })?;
-        Ok(DataSetWriter::new_with_codec(to, encoder, charset))
+        Ok(DataSetWriter::new_with_codec(to, encoder, charset, options))
     }
 }
 
 impl<W, E> DataSetWriter<W, E> {
-    pub fn new(to: W, encoder: E) -> Self {
+    pub fn new(to: W, encoder: E, options: DataSetWriterOptions) -> Self {
         DataSetWriter {
             printer: StatefulEncoder::new(to, encoder, SpecificCharacterSet::default()),
             seq_tokens: Vec::new(),
             last_de: None,
+            options,
         }
     }
 }
 
 impl<W, E, T> DataSetWriter<W, E, T> {
-    pub fn new_with_codec(to: W, encoder: E, text: T) -> Self {
+    pub fn new_with_codec(to: W, encoder: E, text: T, options: DataSetWriterOptions) -> Self {
         DataSetWriter {
             printer: StatefulEncoder::new(to, encoder, text),
             seq_tokens: Vec::new(),
             last_de: None,
+            options,
         }
     }
 }
@@ -165,25 +238,48 @@ where
 
     /// Feed the given data set token for writing the data set.
     pub fn write(&mut self, token: DataToken) -> Result<()> {
-        // adjust the logic of sequence printing:
-        // explicit length sequences or items should not print
-        // the respective delimiter
-
         match token {
-            DataToken::SequenceStart { len, .. } => {
-                self.seq_tokens.push(SeqToken {
-                    typ: SeqTokenType::Sequence,
-                    len,
-                });
-                self.write_impl(&token)?;
+            DataToken::SequenceStart { tag, len, .. } => {
+                match self.options.explicit_length_sq_item_strategy {
+                    ExplicitLengthSqItemStrategy::SetUndefined => {
+                        self.seq_tokens.push(SeqToken {
+                            typ: SeqTokenType::Sequence,
+                            len: Length::UNDEFINED,
+                        });
+                        self.write_impl(&DataToken::SequenceStart {
+                            tag,
+                            len: Length::UNDEFINED,
+                        })?;
+                    }
+                    ExplicitLengthSqItemStrategy::NoChange => {
+                        self.seq_tokens.push(SeqToken {
+                            typ: SeqTokenType::Sequence,
+                            len,
+                        });
+                        self.write_impl(&token)?;
+                    }
+                }
                 Ok(())
             }
             DataToken::ItemStart { len } => {
-                self.seq_tokens.push(SeqToken {
-                    typ: SeqTokenType::Item,
-                    len,
-                });
-                self.write_impl(&token)?;
+                match self.options.explicit_length_sq_item_strategy {
+                    ExplicitLengthSqItemStrategy::SetUndefined => {
+                        self.seq_tokens.push(SeqToken {
+                            typ: SeqTokenType::Item,
+                            len: Length::UNDEFINED,
+                        });
+                        self.write_impl(&DataToken::ItemStart {
+                            len: Length::UNDEFINED,
+                        })?;
+                    }
+                    ExplicitLengthSqItemStrategy::NoChange => {
+                        self.seq_tokens.push(SeqToken {
+                            typ: SeqTokenType::Item,
+                            len,
+                        });
+                        self.write_impl(&token)?;
+                    }
+                }
                 Ok(())
             }
             DataToken::ItemEnd => {
@@ -218,6 +314,7 @@ where
                 });
                 self.write_impl(&token)
             }
+            //DataToken::ItemEnd | DataToken::SequenceEnd => self.write_impl(&token),
             token @ DataToken::ItemValue(_)
             | token @ DataToken::PrimitiveValue(_)
             | token @ DataToken::OffsetTable(_) => self.write_impl(&token),
@@ -283,7 +380,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::super::DataToken;
-    use super::DataSetWriter;
+    use super::{DataSetWriter, DataSetWriterOptions, ExplicitLengthSqItemStrategy};
     use dicom_core::{
         header::{DataElementHeader, Length},
         value::PrimitiveValue,
@@ -291,13 +388,16 @@ mod tests {
     };
     use dicom_encoding::encode::{explicit_le::ExplicitVRLittleEndianEncoder, EncoderFor};
 
-    fn validate_dataset_writer<I>(tokens: I, ground_truth: &[u8])
-    where
+    fn validate_dataset_writer<I>(
+        tokens: I,
+        ground_truth: &[u8],
+        writer_options: DataSetWriterOptions,
+    ) where
         I: IntoIterator<Item = DataToken>,
     {
         let mut raw_out: Vec<u8> = vec![];
         let encoder = EncoderFor::new(ExplicitVRLittleEndianEncoder::default());
-        let mut dset_writer = DataSetWriter::new(&mut raw_out, encoder);
+        let mut dset_writer = DataSetWriter::new(&mut raw_out, encoder, writer_options);
 
         dset_writer.write_sequence(tokens).unwrap();
 
@@ -343,7 +443,33 @@ mod tests {
         ];
 
         #[rustfmt::skip]
-        static GROUND_TRUTH: &[u8] = &[
+        static GROUND_TRUTH_LENGTH_UNDEFINED: &[u8] = &[
+            0x18, 0x00, 0x11, 0x60, // sequence tag: (0018,6011) SequenceOfUltrasoundRegions
+            b'S', b'Q', // VR 
+            0x00, 0x00, // reserved
+            0xff, 0xff, 0xff, 0xff, // seq length: UNDEFINED
+            // -- 12 --
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: UNDEFINED
+            // -- 20 --
+            0x18, 0x00, 0x12, 0x60, b'U', b'S', 0x02, 0x00, 0x01, 0x00, // (0018, 6012) RegionSpatialformat, len = 2, value = 1
+            // -- 30 --
+            0x18, 0x00, 0x14, 0x60, b'U', b'S', 0x02, 0x00, 0x02, 0x00, // (0018, 6012) RegionDataType, len = 2, value = 2
+            // -- 40 --
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: UNDEFINED
+            // -- 48 --
+            0x18, 0x00, 0x12, 0x60, b'U', b'S', 0x02, 0x00, 0x04, 0x00, // (0018, 6012) RegionSpatialformat, len = 2, value = 4
+            // -- 58 --
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            0xfe, 0xff, 0xdd, 0xe0, 0x00, 0x00, 0x00, 0x00, // sequence end
+            0x20, 0x00, 0x00, 0x40, b'L', b'T', 0x04, 0x00, // (0020,4000) ImageComments, len = 4  
+            b'T', b'E', b'S', b'T', // value = "TEST"
+        ];
+
+        #[rustfmt::skip]
+        static GROUND_TRUTH_NO_CHANGE: &[u8] = &[
             0x18, 0x00, 0x11, 0x60, // sequence tag: (0018,6011) SequenceOfUltrasoundRegions
             b'S', b'Q', // VR 
             0x00, 0x00, // reserved
@@ -365,7 +491,15 @@ mod tests {
             b'T', b'E', b'S', b'T', // value = "TEST"
         ];
 
-        validate_dataset_writer(tokens, GROUND_TRUTH);
+        let no_change = DataSetWriterOptions {
+            explicit_length_sq_item_strategy: ExplicitLengthSqItemStrategy::NoChange,
+        };
+        validate_dataset_writer(tokens.clone(), GROUND_TRUTH_NO_CHANGE, no_change);
+        validate_dataset_writer(
+            tokens,
+            GROUND_TRUTH_LENGTH_UNDEFINED,
+            DataSetWriterOptions::default(),
+        );
     }
 
     #[test]
@@ -402,8 +536,7 @@ mod tests {
             // value = "Simões^João "
             b'S', b'i', b'm', 0xF5, b'e', b's', b'^', b'J', b'o', 0xE3, b'o', b' '
         ];
-
-        validate_dataset_writer(tokens, GROUND_TRUTH);
+        validate_dataset_writer(tokens, GROUND_TRUTH, DataSetWriterOptions::default());
     }
 
     #[test]
@@ -477,7 +610,11 @@ mod tests {
             b'T', b'E', b'S', b'T', // value = "TEST"
         ];
 
-        validate_dataset_writer(tokens, GROUND_TRUTH);
+        let no_change = DataSetWriterOptions {
+            explicit_length_sq_item_strategy: ExplicitLengthSqItemStrategy::NoChange,
+        };
+        validate_dataset_writer(tokens.clone(), GROUND_TRUTH, no_change);
+        validate_dataset_writer(tokens, GROUND_TRUTH, DataSetWriterOptions::default());
     }
 
     #[test]
@@ -523,7 +660,27 @@ mod tests {
         ];
 
         #[rustfmt::skip]
-        static GROUND_TRUTH: &[u8] = &[
+        static GROUND_TRUTH_LENGTH_UNDEFINED: &[u8] = &[
+            0x18, 0x00, 0x11, 0x60, // sequence tag: (0018,6011) SequenceOfUltrasoundRegions
+            b'S', b'Q', // VR 
+            0x00, 0x00, // reserved
+            0xff, 0xff, 0xff, 0xff, // length: UNDEFINED
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: undefined
+            0x18, 0x00, 0x12, 0x60, b'U', b'S', 0x02, 0x00, 0x01, 0x00, // (0018, 6012) RegionSpatialformat, len = 2, value = 1
+            0x18, 0x00, 0x14, 0x60, b'U', b'S', 0x02, 0x00, 0x02, 0x00, // (0018, 6012) RegionDataType, len = 2, value = 2
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: undefined
+            0x18, 0x00, 0x12, 0x60, b'U', b'S', 0x02, 0x00, 0x04, 0x00, // (0018, 6012) RegionSpatialformat, len = 2, value = 4
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            0xfe, 0xff, 0xdd, 0xe0, 0x00, 0x00, 0x00, 0x00, // sequence end
+            0x20, 0x00, 0x00, 0x40, b'L', b'T', 0x04, 0x00, // (0020,4000) ImageComments, len = 4  
+            b'T', b'E', b'S', b'T', // value = "TEST"
+        ];
+
+        #[rustfmt::skip]
+        static GROUND_TRUTH_NO_CHANGE: &[u8] = &[
             0x18, 0x00, 0x11, 0x60, // sequence tag: (0018,6011) SequenceOfUltrasoundRegions
             b'S', b'Q', // VR 
             0x00, 0x00, // reserved
@@ -548,8 +705,16 @@ mod tests {
             0x20, 0x00, 0x00, 0x40, b'L', b'T', 0x04, 0x00, // (0020,4000) ImageComments, len = 4  
             b'T', b'E', b'S', b'T', // value = "TEST"
         ];
+        let no_change = DataSetWriterOptions {
+            explicit_length_sq_item_strategy: ExplicitLengthSqItemStrategy::NoChange,
+        };
 
-        validate_dataset_writer(tokens, GROUND_TRUTH);
+        validate_dataset_writer(tokens.clone(), GROUND_TRUTH_NO_CHANGE, no_change);
+        validate_dataset_writer(
+            tokens,
+            GROUND_TRUTH_LENGTH_UNDEFINED,
+            DataSetWriterOptions::default(),
+        );
     }
 
     #[test]
@@ -571,7 +736,35 @@ mod tests {
         ];
 
         #[rustfmt::skip]
-        static GROUND_TRUTH: &[u8] = &[
+        static GROUND_TRUTH_LENGTH_UNDEFINED: &[u8] = &[
+            0xe0, 0x7f, 0x10, 0x00, // (7FE0, 0010) PixelData
+            b'O', b'B', // VR 
+            0x00, 0x00, // reserved
+            0xff, 0xff, 0xff, 0xff, // length: undefined
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: UNDEFINED
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            0xfe, 0xff, 0x00, 0xe0, // item start tag
+            0xff, 0xff, 0xff, 0xff, // item length: UNDEFINED
+            // Compressed Fragment
+            0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+            0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+            0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+            0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+            0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, // item end
+            // End of pixel data
+            0xfe, 0xff, 0xdd, 0xe0, // sequence end tag
+            0x00, 0x00, 0x00, 0x00,
+            // -- 68 -- padding
+            0xfc, 0xff, 0xfc, 0xff, // (fffc,fffc) DataSetTrailingPadding
+            b'O', b'B', // VR
+            0x00, 0x00, // reserved
+            0x08, 0x00, 0x00, 0x00, // length: 8
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        #[rustfmt::skip]
+        static GROUND_TRUTH_NO_CHANGE: &[u8] = &[
             0xe0, 0x7f, 0x10, 0x00, // (7FE0, 0010) PixelData
             b'O', b'B', // VR 
             0x00, 0x00, // reserved
@@ -597,7 +790,14 @@ mod tests {
             0x08, 0x00, 0x00, 0x00, // length: 8
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
-
-        validate_dataset_writer(tokens, GROUND_TRUTH);
+        let no_change = DataSetWriterOptions {
+            explicit_length_sq_item_strategy: ExplicitLengthSqItemStrategy::NoChange,
+        };
+        validate_dataset_writer(tokens.clone(), GROUND_TRUTH_NO_CHANGE, no_change);
+        validate_dataset_writer(
+            tokens,
+            GROUND_TRUTH_LENGTH_UNDEFINED,
+            DataSetWriterOptions::default(),
+        );
     }
 }

--- a/parser/src/dataset/write.rs
+++ b/parser/src/dataset/write.rs
@@ -141,7 +141,9 @@ pub struct DataSetWriter<W, E, T = SpecificCharacterSet> {
     seq_tokens: Vec<SeqToken>,
     last_de: Option<DataElementHeader>,
     options: DataSetWriterOptions,
+    #[allow(dead_code)]
     in_mem_printer: StatefulEncoder<Vec<u8>, E, T>,
+    #[allow(dead_code)]
     in_mem_buffer: Vec<u8>,
 }
 

--- a/parser/src/stateful/encode.rs
+++ b/parser/src/stateful/encode.rs
@@ -50,6 +50,7 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+
 /// Also called a printer, this encoder type provides a stateful mid-level
 /// abstraction for writing DICOM content. Unlike `Encode`,
 /// the stateful encoder knows how to write text values and keeps track
@@ -66,8 +67,12 @@ pub struct StatefulEncoder<W, E, T = SpecificCharacterSet> {
 
 pub type DynStatefulEncoder<'w> = StatefulEncoder<Box<dyn Write + 'w>, DynEncoder<'w, dyn Write>>;
 
-impl<W, E, T> StatefulEncoder<W, E, T> {
+impl<W, E, T> StatefulEncoder<W, E, T>
+where
+    E: Clone,
+{
     pub fn new(to: W, encoder: E, text: T) -> Self {
+
         StatefulEncoder {
             to,
             encoder,
@@ -75,6 +80,10 @@ impl<W, E, T> StatefulEncoder<W, E, T> {
             bytes_written: 0,
             buffer: Vec::with_capacity(128),
         }
+    }
+
+    pub fn text_codec(&self) -> &T {
+        &self.text
     }
 }
 
@@ -87,6 +96,7 @@ impl<'s> DynStatefulEncoder<'s> {
         let encoder = ts
             .encoder()
             .context(UnsupportedTransferSyntaxSnafu { ts: ts.uid() })?;
+
         Ok(StatefulEncoder::new(to, encoder, charset))
     }
 }
@@ -431,6 +441,7 @@ mod tests {
         encode::{explicit_le::ExplicitVRLittleEndianEncoder, EncoderFor},
         text::{SpecificCharacterSet, TextCodec},
     };
+    use std::rc::Rc;
 
     use super::StatefulEncoder;
 
@@ -448,7 +459,7 @@ mod tests {
         {
             let mut encoder = StatefulEncoder::new(
                 &mut out,
-                EncoderFor::new(ExplicitVRLittleEndianEncoder::default()),
+                Rc::new(EncoderFor::new(ExplicitVRLittleEndianEncoder::default())),
                 SpecificCharacterSet::default(),
             );
 
@@ -483,7 +494,7 @@ mod tests {
         {
             let mut encoder = StatefulEncoder::new(
                 &mut out,
-                EncoderFor::new(ExplicitVRLittleEndianEncoder::default()),
+                Rc::new(EncoderFor::new(ExplicitVRLittleEndianEncoder::default())),
                 SpecificCharacterSet::default(),
             );
 
@@ -519,7 +530,7 @@ mod tests {
         {
             let mut encoder = StatefulEncoder::new(
                 &mut out,
-                EncoderFor::new(ExplicitVRLittleEndianEncoder::default()),
+                Rc::new(EncoderFor::new(ExplicitVRLittleEndianEncoder::default())),
                 SpecificCharacterSet::default(),
             );
 
@@ -550,7 +561,7 @@ mod tests {
         {
             let mut encoder = StatefulEncoder::new(
                 &mut out,
-                EncoderFor::new(ExplicitVRLittleEndianEncoder::default()),
+                Rc::new(EncoderFor::new(ExplicitVRLittleEndianEncoder::default())),
                 SpecificCharacterSet::default(),
             );
 
@@ -577,7 +588,7 @@ mod tests {
         {
             let mut encoder = StatefulEncoder::new(
                 &mut out,
-                EncoderFor::new(ExplicitVRLittleEndianEncoder::default()),
+                Rc::new(EncoderFor::new(ExplicitVRLittleEndianEncoder::default())),
                 SpecificCharacterSet::default(),
             );
 
@@ -642,7 +653,7 @@ mod tests {
 
         let mut encoder = StatefulEncoder::new(
             &mut sink,
-            EncoderFor::new(ExplicitVRLittleEndianEncoder::default()),
+            Rc::new(EncoderFor::new(ExplicitVRLittleEndianEncoder::default())),
             SpecificCharacterSet::default(),
         );
 

--- a/scpproxy/src/main.rs
+++ b/scpproxy/src/main.rs
@@ -25,7 +25,8 @@ enum Error {
     #[snafu(display("Could not send message"))]
     SendMessage {
         backtrace: Backtrace,
-        source: std::sync::mpsc::SendError<ThreadMessage>,
+        #[snafu(source(from(std::sync::mpsc::SendError<ThreadMessage>, Box::from)))]
+        source: Box<std::sync::mpsc::SendError<ThreadMessage>>,
     },
     #[snafu(display("Could not receive message"))]
     ReceiveMessage {

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -761,10 +761,10 @@ impl<'a> ClientAssociationOptions<'a> {
             }
             Pdu::AssociationRJ(association_rj) => RejectedSnafu { association_rj }.fail(),
             pdu @ Pdu::AbortRQ { .. }
-            | pdu @ Pdu::ReleaseRQ { .. }
+            | pdu @ Pdu::ReleaseRQ
             | pdu @ Pdu::AssociationRQ { .. }
             | pdu @ Pdu::PData { .. }
-            | pdu @ Pdu::ReleaseRP { .. } => {
+            | pdu @ Pdu::ReleaseRP => {
                 // abort connection
                 let _ = write_pdu(
                     &mut buffer,
@@ -1086,7 +1086,7 @@ where
             | pdu @ Pdu::AssociationRJ { .. }
             | pdu @ Pdu::AssociationRQ { .. }
             | pdu @ Pdu::PData { .. }
-            | pdu @ Pdu::ReleaseRQ { .. } => return UnexpectedResponseSnafu { pdu }.fail(),
+            | pdu @ Pdu::ReleaseRQ => return UnexpectedResponseSnafu { pdu }.fail(),
             pdu @ Pdu::Unknown { .. } => return UnknownResponseSnafu { pdu }.fail(),
         }
         Ok(())
@@ -1380,10 +1380,10 @@ pub mod non_blocking {
                 }
                 Pdu::AssociationRJ(association_rj) => RejectedSnafu { association_rj }.fail(),
                 pdu @ Pdu::AbortRQ { .. }
-                | pdu @ Pdu::ReleaseRQ { .. }
+                | pdu @ Pdu::ReleaseRQ
                 | pdu @ Pdu::AssociationRQ { .. }
                 | pdu @ Pdu::PData { .. }
-                | pdu @ Pdu::ReleaseRP { .. } => {
+                | pdu @ Pdu::ReleaseRP => {
                     // abort connection
                     let _ = write_pdu(
                         &mut buffer,
@@ -1602,7 +1602,7 @@ pub mod non_blocking {
                 | pdu @ Pdu::AssociationRJ { .. }
                 | pdu @ Pdu::AssociationRQ { .. }
                 | pdu @ Pdu::PData { .. }
-                | pdu @ Pdu::ReleaseRQ { .. } => return UnexpectedResponseSnafu { pdu }.fail(),
+                | pdu @ Pdu::ReleaseRQ => return UnexpectedResponseSnafu { pdu }.fail(),
                 pdu @ Pdu::Unknown { .. } => return UnknownResponseSnafu { pdu }.fail(),
             }
             Ok(())


### PR DESCRIPTION
This is what I came up with:
Put the DynEncoder in a Rc instead of a Box, so the DataSetWriter can share a single encoder between 
two different StatefulEncoder instanes.
One is the original with target W
Second is `in_mem_printer` with target Vec<u8>

Needed to make the T: Clone to be able to clone the text_codec and put in the the second StatefulEncoder

This code doesn't do anything new, but the DataSetWriter now has the means to encode items to a temporary buffer.

