### PR TITLE
[encoding] Remove PartialEq derive on TransferSyntaxFactory

### DIFF
--- a/encoding/src/transfer_syntax/mod.rs
+++ b/encoding/src/transfer_syntax/mod.rs
@@ -82,8 +82,7 @@ pub struct TransferSyntax<D = DynDataRWAdapter, R = DynPixelDataReader, W = DynP
 /// will usually not interact with it directly.
 /// In order to register a new transfer syntax,
 /// see the macro [`submit_transfer_syntax`](crate::submit_transfer_syntax).
-#[allow(unpredictable_function_pointer_comparisons)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone)]
 pub struct TransferSyntaxFactory(pub fn() -> TransferSyntax);
 
 #[cfg(feature = "inventory-registry")]


### PR DESCRIPTION
The derived `PartialEq` implementation is not meaningful because of the inner function pointer.