### PR TITLE
[pixeldata] Use another error variant to report length mismatch of VOI LUT

### DIFF
--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -246,16 +246,6 @@ pub enum InnerError {
         ww_vm: u32,
         backtrace: Backtrace,
     },
-    #[snafu(display(
-        "Value multiplicity of VOI LUT must match the number of frames. Expected `{:?}`, found `{:?}`",
-        nr_frames,
-        vm
-    ))]
-    LengthMismatchVoiLut {
-        vm: u32,
-        nr_frames: u32,
-        backtrace: Backtrace,
-    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -671,7 +661,7 @@ impl DecodedPixelData<'_> {
                         Ok(Some(inner.as_slice()))
                     } else {
                         if self.enforce_frame_fg_vm_match {
-                            LengthMismatchVoiLutSnafu {
+                            LengthMismatchVoiLutFunctionSnafu {
                                 vm: *len as u32,
                                 nr_frames: self.number_of_frames(),
                             }


### PR DESCRIPTION
This reverts the breaking change cause by the extra error variant introduced in #599. The inner error type was exposed by mistake and is not non-exhaustive (1658270).

This allows us to proceed with delivering DICOM-rs 0.8.2.