### PR TITLE
Add DicomTime::millisecond

### DIFF
--- a/core/src/value/partial.rs
+++ b/core/src/value/partial.rs
@@ -480,13 +480,17 @@ impl DicomTime {
             },
         }
     }
-    /** Retrieves the fraction of a second and it's precision from a time as a reference */
-    pub(crate) fn fraction_and_precision(&self) -> Option<(&u32, &u8)> {
+
+    /// Retrieves the fraction of a second and its precision from a time as a reference.
+    ///
+    /// Returns a pair containing
+    /// the duration and the precision of that duration.
+    pub(crate) fn fraction_and_precision(&self) -> Option<(u32, u8)> {
         match self {
             DicomTime(DicomTimeImpl::Hour(_)) => None,
             DicomTime(DicomTimeImpl::Minute(_, _)) => None,
             DicomTime(DicomTimeImpl::Second(_, _, _)) => None,
-            DicomTime(DicomTimeImpl::Fraction(_, _, _, f, fp)) => Some((f, fp)),
+            DicomTime(DicomTimeImpl::Fraction(_, _, _, f, fp)) => Some((*f, *fp)),
         }
     }
     /**
@@ -1215,7 +1219,7 @@ mod tests {
         let dicom_time = dicom_date_time.time().unwrap();
         assert_eq!(
             dicom_time.fraction_and_precision(),
-            Some((&0, &6)),
+            Some((0, 6)),
         );
         assert_eq!(
             dicom_date_time.to_encoded(),

--- a/core/src/value/partial.rs
+++ b/core/src/value/partial.rs
@@ -496,7 +496,7 @@ impl DicomTime {
         })
     }
 
-    /// Retrieves the fraction of a second and its precision from a time as a reference.
+    /// Retrieves the fraction of a second and its precision.
     ///
     /// Returns a pair containing
     /// the duration and the precision of that duration.

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -503,7 +503,7 @@ impl PrimitiveValue {
             DateComponent::Second => 6,
             DateComponent::Fraction => match time.fraction_and_precision() {
                 None => panic!("DicomTime has fraction precision but no fraction can be retrieved"),
-                Some((_, fp)) => 7 + *fp as usize, // 1 is for the '.'
+                Some((_, fp)) => 7 + fp as usize, // 1 is for the '.'
             },
             _ => panic!("Impossible precision for a Dicomtime"),
         }

--- a/core/src/value/range.rs
+++ b/core/src/value/range.rs
@@ -259,7 +259,7 @@ impl AsRange for DicomTime {
     type Range = TimeRange;
 
     fn is_precise(&self) -> bool {
-        matches!(self.fraction_and_precision(), Some((_fr_, precision)) if precision == &6)
+        matches!(self.fraction_and_precision(), Some((_fr_, precision)) if precision == 6)
     }
 
     fn earliest(&self) -> Result<Self::PreciseValue> {
@@ -269,7 +269,7 @@ impl AsRange for DicomTime {
             self.second().unwrap_or(&0),
             match self.fraction_and_precision() {
                 None => 0,
-                Some((f, fp)) => *f * u32::pow(10, 6 - <u32>::from(*fp)),
+                Some((f, fp)) => f * u32::pow(10, 6 - <u32>::from(fp)),
             },
         );
 
@@ -290,7 +290,7 @@ impl AsRange for DicomTime {
             match self.fraction_and_precision() {
                 None => 999_999,
                 Some((f, fp)) => {
-                    (*f * u32::pow(10, 6 - u32::from(*fp))) + (u32::pow(10, 6 - u32::from(*fp))) - 1
+                    (f * u32::pow(10, 6 - u32::from(fp))) + (u32::pow(10, 6 - u32::from(fp))) - 1
                 }
             },
         );


### PR DESCRIPTION
This is a non-breaking addition to `dicom_core` to mitigate #663 until a better resolution is made.

### Summary

- [core] change `DicomTime::fraction_and_precision` to return non-references
- [core] add `DicomTime::millisecond`, which returns the number of milliseconds of the fraction of a second, if the fraction is precise to the millisecond or more.
