### PR TITLE
[partial] Improve fraction retrieval for DicomTime with precision checks 

### DIFF
--- a/core/src/value/partial.rs
+++ b/core/src/value/partial.rs
@@ -811,10 +811,6 @@ impl DicomDateTime {
     pub fn has_time_zone(&self) -> bool {
         self.time_zone.is_some()
     }
-
-    /** Retrieves a reference to the internal offset value */
-    #[deprecated(since = "0.7.0", note = "Use `time_zone` instead")]
-    pub fn offset(&self) {}
 }
 
 impl TryFrom<&DateTime<FixedOffset>> for DicomDateTime {

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -2686,11 +2686,6 @@ impl PrimitiveValue {
         }
     }
 
-    #[deprecated(since = "0.7.0", note = "Use `to_datetime` instead")]
-    pub fn to_chrono_datetime(&self) {}
-    #[deprecated(since = "0.7.0", note = "Use `to_multi_datetime` instead")]
-    pub fn to_multi_chrono_datetime(&self) {}
-
     /// Retrieve a single `DicomDateTime` from this value.
     ///
     /// If the value is already represented as a date-time, it is converted into DicomDateTime.

--- a/core/src/value/range.rs
+++ b/core/src/value/range.rs
@@ -419,11 +419,6 @@ impl DicomDateTime {
     pub fn to_precise_datetime(&self) -> Result<PreciseDateTime> {
         self.exact()
     }
-
-    #[deprecated(since = "0.7.0", note = "Use `to_precise_date_time()`")]
-    pub fn to_chrono_datetime(self) -> Result<DateTime<FixedOffset>> {
-        ToPreciseDateTimeSnafu.fail()
-    }
 }
 
 /// Represents a date range as two [`Option<chrono::NaiveDate>`] values.


### PR DESCRIPTION
Hi,
i picked #662 and implemented a solution where leading zeros are not omitted and the value representation of the Date time remains correct. I also added 2 more tests for my change. First time adding to Open Source, hope this helps.

I am not sure if `Option<&u32>` is the right choice as return type, or if i should create a new error variant if a mismatch between frac and frac_precision occurs.



