### PR TITLE
Fix bit_allocation 1 for decode_pixel_data

### DIFF
--- a/object/src/collector.rs
+++ b/object/src/collector.rs
@@ -991,7 +991,7 @@ where
         &mut self,
         mut pred: impl FnMut(
             &LazyDataToken<
-                &mut StatefulDecoder<Box<(dyn DecodeFrom<BufReader<S>> + 'static)>, BufReader<S>>,
+                &mut StatefulDecoder<Box<dyn DecodeFrom<BufReader<S>> + 'static>, BufReader<S>>,
             >,
         ) -> bool,
     ) -> Result<bool> {

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -2278,7 +2278,7 @@ where
                     frame_data
                         .iter()
                         .flat_map(|&byte| (0..8).map(move |bit| ((byte >> bit) & 1) * 255))
-                        .take(frame_pixels)
+                        .take(frame_pixels * number_of_frames as usize)
                         .collect()
                 } else {
                     data.to_vec()

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -3123,7 +3123,6 @@ mod tests {
 
         let test_file =
             dicom_test_files::path("pydicom/liver.dcm").expect("test DICOM file should exist");
-        println!("Parsing pixel data for {}", test_file.display());
         let obj = dicom_object::open_file(test_file).unwrap();
         let pixel_data = obj.decode_pixel_data().unwrap();
         let output_dir = Path::new("../target/dicom_test_files/_out/test_1bit_image_decoding");

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -3130,7 +3130,7 @@ mod tests {
         let output_dir = Path::new("../target/dicom_test_files/_out/test_1bit_image_decoding");
         std::fs::create_dir_all(output_dir).unwrap();
 
-        assert_eq!(pixel_data.number_of_frames(), 1, "expected 1 frame only");
+        assert_eq!(pixel_data.number_of_frames(), 3, "expected 3 frames");
 
         let image = pixel_data.to_dynamic_image(0).unwrap();
         let image_path = output_dir.join(format!(

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -2275,7 +2275,6 @@ where
             DicomValue::Sequence(..) => InvalidPixelDataSnafu.fail()?,
         };
 
-        println!("asdf data.len() {:?}", decoded_pixel_data.len());
         Ok(DecodedPixelData {
             data: Cow::from(decoded_pixel_data),
             cols: cols.into(),

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -3107,23 +3107,25 @@ mod tests {
             dicom_test_files::path("pydicom/liver.dcm").expect("test DICOM file should exist");
         println!("Parsing pixel data for {}", test_file.display());
         let obj = dicom_object::open_file(test_file).unwrap();
-        let pixel_data = obj.decode_pixel_data_frame(0).unwrap();
         let output_dir = Path::new("../target/dicom_test_files/_out/test_1bit_image_decoding");
         std::fs::create_dir_all(output_dir).unwrap();
+        for idx in 0..=2 {
+            let pixel_data = obj.decode_pixel_data_frame(idx).unwrap();
 
-        assert_eq!(pixel_data.number_of_frames(), 1, "expected 1 frame only");
+            assert_eq!(pixel_data.number_of_frames(), 1, "expected 1 frame only");
 
-        let image = pixel_data.to_dynamic_image(0).unwrap();
-        let image_path = output_dir.join(format!(
-            "{}-{}-frame0.png",
-            Path::new("pydicom/liver.dcm")
-                .file_stem()
-                .unwrap()
-                .to_str()
-                .unwrap(),
-            0,
-        ));
-        image.save(image_path).unwrap();
+            let image = pixel_data.to_dynamic_image(0).unwrap();
+            let image_path = output_dir.join(format!(
+                "{}-frame-{}.png",
+                Path::new("pydicom/liver.dcm")
+                    .file_stem()
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+                idx
+            ));
+            image.save(image_path).unwrap();
+        }
     }
 
     #[cfg(feature = "image")]

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -3093,6 +3093,36 @@ mod tests {
 
     #[cfg(feature = "image")]
     #[test]
+    fn test_1bit_image_decoding_data() {
+        use crate::PixelDecoder as _;
+        use std::path::Path;
+
+        let test_file =
+            dicom_test_files::path("pydicom/liver.dcm").expect("test DICOM file should exist");
+        let obj = dicom_object::open_file(test_file).unwrap();
+        let pixel_data = obj.decode_pixel_data().unwrap();
+        let output_dir = Path::new("../target/dicom_test_files/_out/test_1bit_image_decoding");
+        std::fs::create_dir_all(output_dir).unwrap();
+
+        assert_eq!(pixel_data.number_of_frames(), 3, "expected 3 frames");
+
+        for idx in 0..=2 {
+            let image = pixel_data.to_dynamic_image(idx).unwrap();
+            let image_path = output_dir.join(format!(
+                "{}-image-{}.png",
+                Path::new("pydicom/liver.dcm")
+                    .file_stem()
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+                idx,
+            ));
+            image.save(image_path).unwrap();
+        }
+    }
+
+    #[cfg(feature = "image")]
+    #[test]
     fn test_1bit_image_decoding_data_frame() {
         use crate::PixelDecoder as _;
         use std::path::Path;
@@ -3118,36 +3148,6 @@ mod tests {
                     .to_str()
                     .unwrap(),
                 idx
-            ));
-            image.save(image_path).unwrap();
-        }
-    }
-
-    #[cfg(feature = "image")]
-    #[test]
-    fn test_1bit_image_decoding_data() {
-        use crate::PixelDecoder as _;
-        use std::path::Path;
-
-        let test_file =
-            dicom_test_files::path("pydicom/liver.dcm").expect("test DICOM file should exist");
-        let obj = dicom_object::open_file(test_file).unwrap();
-        let pixel_data = obj.decode_pixel_data().unwrap();
-        let output_dir = Path::new("../target/dicom_test_files/_out/test_1bit_image_decoding");
-        std::fs::create_dir_all(output_dir).unwrap();
-
-        assert_eq!(pixel_data.number_of_frames(), 3, "expected 3 frames");
-
-        for idx in 0..=2 {
-            let image = pixel_data.to_dynamic_image(idx).unwrap();
-            let image_path = output_dir.join(format!(
-                "{}-image-{}.png",
-                Path::new("pydicom/liver.dcm")
-                    .file_stem()
-                    .unwrap()
-                    .to_str()
-                    .unwrap(),
-                idx,
             ));
             image.save(image_path).unwrap();
         }

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -2262,18 +2262,12 @@ where
                     // Expand 1-bit samples to 0/255 bytes for all frames
                     let frame_pixels = (rows as usize) * (cols as usize);
                     let frame_samples = frame_pixels * (samples_per_pixel as usize);
-                    let frame_size = if bits_allocated == 1 {
-                        frame_samples / 8
-                    } else {
-                        frame_samples * ((bits_allocated as usize + 7) / 8)
-                    };
+                    let frame_size = frame_samples / 8;
                     let frame_size_all = frame_size * (number_of_frames as usize);
 
-                let frame_data = data.get(0..frame_size_all).context(
-                    FrameOutOfRangeSnafu {
+                    let frame_data = data.get(0..frame_size_all).context(FrameOutOfRangeSnafu {
                         frame_number: frame_size_all as u32,
-                    },
-                )?;
+                    })?;
                     // Map every bit in each byte to a separate byte of either 0 or 255
                     frame_data
                         .iter()

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -3101,10 +3101,11 @@ mod tests {
             dicom_test_files::path("pydicom/liver.dcm").expect("test DICOM file should exist");
         let obj = dicom_object::open_file(test_file).unwrap();
         let pixel_data = obj.decode_pixel_data().unwrap();
-        let output_dir = Path::new("../target/dicom_test_files/_out/test_1bit_image_decoding");
-        std::fs::create_dir_all(output_dir).unwrap();
 
         assert_eq!(pixel_data.number_of_frames(), 3, "expected 3 frames");
+
+        let output_dir = Path::new("../target/dicom_test_files/_out/test_1bit_image_decoding");
+        std::fs::create_dir_all(output_dir).unwrap();
 
         for idx in 0..=2 {
             let image = pixel_data.to_dynamic_image(idx).unwrap();

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -3143,16 +3143,18 @@ mod tests {
 
         assert_eq!(pixel_data.number_of_frames(), 3, "expected 3 frames");
 
-        let image = pixel_data.to_dynamic_image(0).unwrap();
-        let image_path = output_dir.join(format!(
-            "{}-{}.png",
-            Path::new("pydicom/liver.dcm")
-                .file_stem()
-                .unwrap()
-                .to_str()
-                .unwrap(),
-            0,
-        ));
-        image.save(image_path).unwrap();
+        for idx in 0..=2 {
+            let image = pixel_data.to_dynamic_image(idx).unwrap();
+            let image_path = output_dir.join(format!(
+                "{}-image-{}.png",
+                Path::new("pydicom/liver.dcm")
+                    .file_stem()
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+                idx,
+            ));
+            image.save(image_path).unwrap();
+        }
     }
 }

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -3109,6 +3109,7 @@ mod tests {
         let obj = dicom_object::open_file(test_file).unwrap();
         let output_dir = Path::new("../target/dicom_test_files/_out/test_1bit_image_decoding");
         std::fs::create_dir_all(output_dir).unwrap();
+
         for idx in 0..=2 {
             let pixel_data = obj.decode_pixel_data_frame(idx).unwrap();
 


### PR DESCRIPTION
https://github.com/Enet4/dicom-rs/pull/654 only implemented bit_allocation == 1 for decode_pixel_data_frame(index) but missed it for decode_pixel_data().

1. Added the code to decode_pixel_data() for data with bit_allocation == 1
2. Added a test for decode_pixel_data()  for data with bit_allocation == 1

BTW: Is decode_pixel_data() the same as decode_pixel_data(0)?