### PR TITLE
Return the abstract syntax in the presentation_contexts() method

### DIFF
--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -156,11 +156,22 @@ pub struct PresentationContextProposed {
     pub transfer_syntaxes: Vec<String>,
 }
 
+/// Message component for the result of the presentation context negotiation.
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
 pub struct PresentationContextResult {
     pub id: u8,
     pub reason: PresentationContextResultReason,
     pub transfer_syntax: String,
+}
+
+/// Result of the presentation context negotiation, including the
+/// abstract syntax that corresponds to each presentation context.
+#[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
+pub struct PresentationContextNegotiated {
+    pub id: u8,
+    pub reason: PresentationContextResultReason,
+    pub transfer_syntax: String,
+    pub abstract_syntax: String,
 }
 
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]

--- a/ul/tests/association_echo.rs
+++ b/ul/tests/association_echo.rs
@@ -1,6 +1,6 @@
 use dicom_ul::{
     association::client::ClientAssociationOptions,
-    pdu::{Pdu, PresentationContextResult, PresentationContextResultReason},
+    pdu::{Pdu, PresentationContextNegotiated, PresentationContextResultReason},
 };
 
 use std::net::SocketAddr;
@@ -33,15 +33,17 @@ fn spawn_scp() -> Result<(std::thread::JoinHandle<Result<()>>, SocketAddr)> {
         assert_eq!(
             association.presentation_contexts(),
             &[
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 1,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                    abstract_syntax: VERIFICATION_SOP_CLASS.to_string(),
                 },
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 3,
                     reason: PresentationContextResultReason::AbstractSyntaxNotSupported,
                     transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                    abstract_syntax: DIGITAL_MG_STORAGE_SOP_CLASS.to_string(),
                 }
             ],
         );
@@ -72,15 +74,17 @@ async fn spawn_scp_async() -> Result<(tokio::task::JoinHandle<Result<()>>, Socke
         assert_eq!(
             association.presentation_contexts(),
             &[
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 1,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                    abstract_syntax: VERIFICATION_SOP_CLASS.to_string(),
                 },
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 3,
                     reason: PresentationContextResultReason::AbstractSyntaxNotSupported,
                     transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                    abstract_syntax: DIGITAL_MG_STORAGE_SOP_CLASS.to_string(),
                 }
             ],
         );

--- a/ul/tests/association_promiscuous.rs
+++ b/ul/tests/association_promiscuous.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use dicom_ul::association::client::Error::NoAcceptedPresentationContexts;
 use dicom_ul::pdu::PresentationContextResultReason::Acceptance;
-use dicom_ul::pdu::{PresentationContextResult, PresentationContextResultReason, UserVariableItem};
+use dicom_ul::pdu::{PresentationContextNegotiated, PresentationContextResultReason, UserVariableItem};
 use dicom_ul::{
     ClientAssociationOptions, Pdu, ServerAssociationOptions, IMPLEMENTATION_CLASS_UID,
     IMPLEMENTATION_VERSION_NAME,
@@ -14,6 +14,7 @@ const SCU_AE_TITLE: &str = "STORE-SCU";
 const SCP_AE_TITLE: &str = "STORE-SCP";
 
 const IMPLICIT_VR_LE: &str = "1.2.840.10008.1.2";
+const MR_IMAGE_STORAGE: &str = "1.2.840.10008.5.1.4.1.1.4";
 const MR_IMAGE_STORAGE_RAW: &str = "1.2.840.10008.5.1.4.1.1.4\0";
 const ULTRASOUND_IMAGE_STORAGE_RAW: &str = "1.2.840.10008.5.1.4.1.1.6.1\0";
 
@@ -37,10 +38,11 @@ fn spawn_scp(
         let mut association = options.establish(stream)?;
         assert_eq!(
             association.presentation_contexts(),
-            &[PresentationContextResult {
+            &[PresentationContextNegotiated {
                 id: 1,
                 reason: PresentationContextResultReason::Acceptance,
                 transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                abstract_syntax: MR_IMAGE_STORAGE.to_string(),
             }]
         );
 
@@ -75,10 +77,11 @@ async fn spawn_scp_async(
         let mut association = options.establish_async(stream).await?;
         assert_eq!(
             association.presentation_contexts(),
-            &[PresentationContextResult {
+            &[PresentationContextNegotiated {
                 id: 1,
                 reason: PresentationContextResultReason::Acceptance,
                 transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                abstract_syntax: MR_IMAGE_STORAGE.to_string(),
             }]
         );
 
@@ -114,10 +117,11 @@ fn scu_scp_association_promiscuous_enabled() {
     );
     assert_eq!(
         association.presentation_contexts(),
-        &[PresentationContextResult {
+        &[PresentationContextNegotiated {
             id: 1,
             reason: Acceptance,
-            transfer_syntax: IMPLICIT_VR_LE.to_string()
+            transfer_syntax: IMPLICIT_VR_LE.to_string(),
+            abstract_syntax: MR_IMAGE_STORAGE.to_string(),
         }]
     );
     assert_eq!(association.acceptor_max_pdu_length(), 16384);
@@ -159,10 +163,11 @@ async fn scu_scp_association_promiscuous_enabled_async() {
     );
     assert_eq!(
         association.presentation_contexts(),
-        &[PresentationContextResult {
+        &[PresentationContextNegotiated {
             id: 1,
             reason: Acceptance,
-            transfer_syntax: IMPLICIT_VR_LE.to_string()
+            transfer_syntax: IMPLICIT_VR_LE.to_string(),
+            abstract_syntax: MR_IMAGE_STORAGE.to_string(),
         }]
     );
     assert_eq!(association.acceptor_max_pdu_length(), 16384);

--- a/ul/tests/association_store.rs
+++ b/ul/tests/association_store.rs
@@ -1,6 +1,6 @@
 use dicom_ul::{
     association::client::ClientAssociationOptions,
-    pdu::{Pdu, PresentationContextResult, PresentationContextResultReason},
+    pdu::{Pdu, PresentationContextNegotiated, PresentationContextResultReason},
 };
 use std::net::SocketAddr;
 
@@ -36,15 +36,17 @@ fn spawn_scp() -> Result<(std::thread::JoinHandle<Result<()>>, SocketAddr)> {
         assert_eq!(
             association.presentation_contexts(),
             &[
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 1,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                    abstract_syntax: MR_IMAGE_STORAGE.to_string(),
                 },
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 3,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: JPEG_BASELINE.to_string(),
+                    abstract_syntax: DIGITAL_MG_STORAGE_SOP_CLASS.to_string(),
                 }
             ],
         );
@@ -76,15 +78,17 @@ async fn spawn_scp_async() -> Result<(tokio::task::JoinHandle<Result<()>>, Socke
         assert_eq!(
             association.presentation_contexts(),
             &[
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 1,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                    abstract_syntax: MR_IMAGE_STORAGE.to_string(),
                 },
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 3,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: JPEG_BASELINE.to_string(),
+                    abstract_syntax: DIGITAL_MG_STORAGE_SOP_CLASS.to_string(),
                 }
             ],
         );

--- a/ul/tests/association_store_uncompressed.rs
+++ b/ul/tests/association_store_uncompressed.rs
@@ -3,7 +3,7 @@
 
 use dicom_ul::{
     association::client::ClientAssociationOptions,
-    pdu::{Pdu, PresentationContextResult, PresentationContextResultReason},
+    pdu::{Pdu, PresentationContextNegotiated, PresentationContextResultReason},
 };
 use std::net::SocketAddr;
 
@@ -42,17 +42,19 @@ fn spawn_scp() -> Result<(std::thread::JoinHandle<Result<()>>, SocketAddr)> {
         assert_eq!(
             association.presentation_contexts(),
             &[
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 1,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                    abstract_syntax: MR_IMAGE_STORAGE.to_string(),
                 },
                 // should always pick Explicit VR LE
                 // because JPEG baseline was not explicitly enabled in SCP
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 3,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: EXPLICIT_VR_LE.to_string(),
+                    abstract_syntax: DIGITAL_MG_STORAGE_SOP_CLASS.to_string(),
                 }
             ],
         );
@@ -86,17 +88,19 @@ async fn spawn_scp_async() -> Result<(tokio::task::JoinHandle<Result<()>>, Socke
         assert_eq!(
             association.presentation_contexts(),
             &[
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 1,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                    abstract_syntax: MR_IMAGE_STORAGE.to_string(),
                 },
                 // should always pick Explicit VR LE
                 // because JPEG baseline was not explicitly enabled in SCP
-                PresentationContextResult {
+                PresentationContextNegotiated {
                     id: 3,
                     reason: PresentationContextResultReason::Acceptance,
                     transfer_syntax: EXPLICIT_VR_LE.to_string(),
+                    abstract_syntax: DIGITAL_MG_STORAGE_SOP_CLASS.to_string(),
                 }
             ],
         );


### PR DESCRIPTION
This is finally a fix for #683 that I'm comfortable with. The only problem is that it's a breaking change.

The return type of presentation_contexts() is now `&[PresentationContextNegotiated]`, and includes the abstract syntax that was negotiated on each PC. The PresentationContextResult struct remains for protocol handling. This avoids kludges such as using None for the field during internal handling, or adding another separate vector to relate abstract syntax and PC ID.

A broken (or rogue) server may return PC IDs that are not in the list of PCs proposed by the client. These are now filtered out, as it would be impossible to assign an abstract syntax to them.

This adds a description in the docs to PresentationContextResult, while on it.