### PR TITLE
Revise association maximum PDU length handling

### DIFF
--- a/findscu/src/main.rs
+++ b/findscu/src/main.rs
@@ -48,7 +48,7 @@ struct App {
     #[arg(
         long = "max-pdu-length",
         default_value = "16384",
-        value_parser(clap::value_parser!(u32).range(4096..=131_072))
+        value_parser(clap::value_parser!(u32).range(4096..))
     )]
     max_pdu_length: u32,
 

--- a/scpproxy/src/main.rs
+++ b/scpproxy/src/main.rs
@@ -278,7 +278,7 @@ fn command() -> Command {
                 .help("Maximum PDU length")
                 .short('m')
                 .long("max-pdu-length")
-                .value_parser(value_parser!(u32).range(4096..=131_072))
+                .value_parser(value_parser!(u32).range(4096..))
                 .default_value("16384"),
         )
 }

--- a/storescp/src/main.rs
+++ b/storescp/src/main.rs
@@ -40,7 +40,7 @@ struct App {
         short = 'm',
         long = "max-pdu-length",
         default_value = "16384",
-        value_parser(clap::value_parser!(u32).range(4096..=131_072))
+        value_parser(clap::value_parser!(u32).range(4096..))
     )]
     max_pdu_length: u32,
     /// Output directory for incoming objects

--- a/storescu/src/main.rs
+++ b/storescu/src/main.rs
@@ -49,7 +49,7 @@ struct App {
     #[arg(
         long = "max-pdu-length",
         default_value = "16384",
-        value_parser(clap::value_parser!(u32).range(4096..=131_072))
+        value_parser(clap::value_parser!(u32).range(4096..))
     )]
     max_pdu_length: u32,
     /// fail if not all DICOM files can be transferred

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -20,9 +20,9 @@ pub const DEFAULT_MAX_PDU: u32 = 16_384;
 /// as specified by the standard
 pub const MINIMUM_PDU_SIZE: u32 = 4_096;
 
-/// The maximum PDU size,
-/// as specified by the standard
-pub const MAXIMUM_PDU_SIZE: u32 = 131_072;
+/// A generous PDU size for internal use.
+/// Prefer to initialize buffers no larger than this size
+pub(crate) const LARGE_PDU_SIZE: u32 = 262_144;
 
 /// The length of the PDU header in bytes,
 /// comprising the PDU type (1 byte),
@@ -65,7 +65,7 @@ pub enum WriteError {
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
 pub enum ReadError {
-    #[snafu(display("Invalid max PDU length {}", max_pdu_length))]
+    #[snafu(display("Max PDU length {max_pdu_length} is not acceptable"))]
     InvalidMaxPdu {
         max_pdu_length: u32,
         backtrace: Backtrace,

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -9,22 +9,6 @@ pub type Error = crate::pdu::ReadError;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// The default maximum PDU size
-#[deprecated(since = "0.8.0", note = "Use dicom_ul::pdu::DEFAULT_MAX_PDU instead")]
-pub const DEFAULT_MAX_PDU: u32 = crate::pdu::DEFAULT_MAX_PDU;
-
-/// The minimum PDU size,
-/// as specified by the standard
-#[deprecated(since = "0.8.0", note = "Use dicom_ul::pdu::MINIMUM_PDU_SIZE instead")]
-pub const MINIMUM_PDU_SIZE: u32 = crate::pdu::MINIMUM_PDU_SIZE;
-
-/// The length of the PDU header in bytes,
-/// comprising the PDU type (1 byte),
-/// reserved byte (1 byte),
-/// and PDU length (4 bytes).
-#[deprecated(since = "0.8.0", note = "Use dicom_ul::pdu::PDU_HEADER_SIZE instead")]
-pub const PDU_HEADER_SIZE: u32 = crate::pdu::PDU_HEADER_SIZE;
-
 /// Read a PDU from the given byte buffer.
 pub fn read_pdu(mut buf: impl Buf, max_pdu_length: u32, strict: bool) -> Result<Option<Pdu>> {
     ensure!(


### PR DESCRIPTION
### Summary

- remove constant `MAXIMUM_PDU_LENGTH` and lift any limits to this property (affects also `findscu`, `scpproxy`, `storescp`, and `storescu`), enabling compatible AEs to exchange larger PDUs
- allocate write buffers at association start with capacity `DEFAULT_PDU_LENGTH`
- adjust more initial capacity allocations so that they are capped by an internal constant `LARGE_PDU_SIZE`, or value 2621444, following the local max PDU length most of the time.
- fix the mixup of max PDU length admitted by `ClientAssociation::receive` (sync and async versions), should make #686 obsolete
- remove deprecated constant aliases in `reader` module
