### PR TITLE
Update ndarray and rstest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,21 +2222,20 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,14 +1710,16 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.15.6"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
  "rawpointer",
 ]
 
@@ -1955,6 +1957,15 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -26,7 +26,7 @@ snafu = "0.8"
 byteorder = "1.4.3"
 gdcm-rs = { version = "0.6", optional = true }
 rayon = { version = "1.5.0", optional = true }
-ndarray = { version = "0.15.1", optional = true }
+ndarray = { version = "0.16.1", optional = true }
 num-traits = "0.2.12"
 tracing = "0.1.34"
 

--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -46,7 +46,7 @@ version = "0.3.17"
 optional = true
 
 [dev-dependencies]
-rstest = "0.25"
+rstest = "0.26.1"
 dicom-test-files = "0.3"
 
 [features]

--- a/ul/Cargo.toml
+++ b/ul/Cargo.toml
@@ -33,7 +33,7 @@ features = [
 [dev-dependencies]
 dicom-dictionary-std = { path = "../dictionary-std" }
 matches = "0.1.8"
-rstest = "0.25"
+rstest = "0.26.1"
 tokio = { version = "^1.38", features = ["io-util", "macros", "net", "rt", "rt-multi-thread"] }
 dicom-core = { path = '../core' }
 dicom-object = { path = '../object' }


### PR DESCRIPTION
(it's a breaking change because `ndarray` is part of the public API)

- [pixeldata] (change) Update ndarray to 0.16.1
- Update rstest to 0.26.1
