### PR TITLE
Fix confusion between buffer size and variable field size

### DIFF
--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -13,22 +13,28 @@ pub use reader::read_pdu;
 use snafu::{Backtrace, Snafu};
 pub use writer::{write_pdu, WriteChunkError};
 
-/// The default maximum PDU size
-pub const DEFAULT_MAX_PDU: u32 = 16_384;
-
-/// The minimum PDU size,
-/// as specified by the standard
-pub const MINIMUM_PDU_SIZE: u32 = 4_096;
-
-/// A generous PDU size for internal use.
-/// Prefer to initialize buffers no larger than this size
-pub(crate) const LARGE_PDU_SIZE: u32 = 262_144;
-
 /// The length of the PDU header in bytes,
 /// comprising the PDU type (1 byte),
 /// reserved byte (1 byte),
 /// and PDU length (4 bytes).
 pub const PDU_HEADER_SIZE: u32 = 6;
+
+/// The length of a PDV header + message control header in bytes,
+/// comprising the PDV length (4 bytes),
+/// presentation context ID (1 byte),
+/// and the flags that precede the data (1 byte).
+pub const PDV_HEADER_SIZE: u32 = 6;
+
+/// The default maximum PDU size
+pub const DEFAULT_MAX_PDU: u32 = 16_384 - PDU_HEADER_SIZE;
+
+/// The minimum PDU size,
+/// as specified by the standard
+pub const MINIMUM_PDU_SIZE: u32 = 4_096 - PDU_HEADER_SIZE;
+
+/// A generous PDU size for internal use.
+/// Prefer to initialize buffers no larger than this size
+pub(crate) const LARGE_PDU_SIZE: u32 = 262_144 - PDU_HEADER_SIZE;
 
 #[derive(Debug, Snafu)]
 #[non_exhaustive]

--- a/ul/tests/association_echo.rs
+++ b/ul/tests/association_echo.rs
@@ -11,7 +11,6 @@ use std::net::SocketAddr;
 // Check rather arbitrary maximum PDU lengths, also different for server and client
 const HI_PDU_LEN: usize = 7890;
 const LO_PDU_LEN: usize = 5678;
-const PDU_HDR_LEN: usize = 6;
 const PDV_HDR_LEN: usize = 6;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>;
@@ -89,14 +88,11 @@ fn spawn_scp(
             other => panic!("Unexpected packet type: {:?}", other),
         };
         assert_eq!(data.len(), 1);
-        assert_eq!(
-            data[0].data.len(),
-            max_server_pdu_len - PDU_HDR_LEN - PDV_HDR_LEN
-        );
+        assert_eq!(data[0].data.len(), max_server_pdu_len - PDV_HDR_LEN);
 
         // Create a bogus payload which fills the PDU to the max.
         // Take into account the PDU and PDV header lengths for that purpose.
-        let filler_len = max_client_pdu_len - PDU_HDR_LEN - PDV_HDR_LEN;
+        let filler_len = max_client_pdu_len - PDV_HDR_LEN;
         let mut packet = bogus_packet(filler_len);
 
         // send one bogus response
@@ -173,14 +169,11 @@ async fn spawn_scp_async(
             other => panic!("Unexpected packet type: {:?}", other),
         };
         assert_eq!(data.len(), 1);
-        assert_eq!(
-            data[0].data.len(),
-            max_server_pdu_len - PDU_HDR_LEN - PDV_HDR_LEN
-        );
+        assert_eq!(data[0].data.len(), max_server_pdu_len - PDV_HDR_LEN);
 
         // Create a bogus payload which fills the PDU to the max.
         // Take into account the PDU and PDV header lengths for that purpose.
-        let filler_len = max_client_pdu_len - PDU_HDR_LEN - PDV_HDR_LEN;
+        let filler_len = max_client_pdu_len - PDV_HDR_LEN;
         let mut packet = bogus_packet(filler_len);
 
         // send one bogus response
@@ -248,7 +241,7 @@ fn run_scu_scp_association_test(max_is_client: bool) {
 
     // Create a bogus payload which fills the PDU to the max.
     // Take into account the PDU and PDV header lengths for that purpose.
-    let filler_len = max_server_pdu_len - PDU_HDR_LEN - PDV_HDR_LEN;
+    let filler_len = max_server_pdu_len - PDV_HDR_LEN;
     let mut packet = bogus_packet(filler_len);
 
     association.send(&packet).expect("failed sending packet");
@@ -321,7 +314,7 @@ async fn run_scu_scp_association_test_async(max_is_client: bool) {
 
     // Create a bogus payload which fills the PDU to the max.
     // Take into account the PDU and PDV header lengths for that purpose.
-    let filler_len = max_server_pdu_len - PDU_HDR_LEN - PDV_HDR_LEN;
+    let filler_len = max_server_pdu_len - PDV_HDR_LEN;
     let mut packet = bogus_packet(filler_len);
 
     association

--- a/ul/tests/association_promiscuous.rs
+++ b/ul/tests/association_promiscuous.rs
@@ -4,6 +4,7 @@ use dicom_ul::association::Error::NoAcceptedPresentationContexts;
 use dicom_ul::pdu::PresentationContextResultReason::Acceptance;
 use dicom_ul::pdu::{
     PresentationContextNegotiated, PresentationContextResultReason, UserVariableItem,
+    DEFAULT_MAX_PDU,
 };
 use dicom_ul::{
     ClientAssociationOptions, Pdu, ServerAssociationOptions, IMPLEMENTATION_CLASS_UID,
@@ -112,7 +113,7 @@ fn scu_scp_association_promiscuous_enabled() {
     assert_eq!(
         association.user_variables(),
         &[
-            UserVariableItem::MaxLength(16384),
+            UserVariableItem::MaxLength(DEFAULT_MAX_PDU),
             UserVariableItem::ImplementationClassUID(IMPLEMENTATION_CLASS_UID.to_string()),
             UserVariableItem::ImplementationVersionName(IMPLEMENTATION_VERSION_NAME.to_string())
         ]
@@ -126,8 +127,8 @@ fn scu_scp_association_promiscuous_enabled() {
             abstract_syntax: MR_IMAGE_STORAGE.to_string(),
         }]
     );
-    assert_eq!(association.acceptor_max_pdu_length(), 16384);
-    assert_eq!(association.requestor_max_pdu_length(), 16384);
+    assert_eq!(association.acceptor_max_pdu_length(), DEFAULT_MAX_PDU);
+    assert_eq!(association.requestor_max_pdu_length(), DEFAULT_MAX_PDU);
     assert_eq!(association.read_timeout(), None);
     assert_eq!(association.write_timeout(), None);
 
@@ -158,7 +159,7 @@ async fn scu_scp_association_promiscuous_enabled_async() {
     assert_eq!(
         association.user_variables(),
         &[
-            UserVariableItem::MaxLength(16384),
+            UserVariableItem::MaxLength(DEFAULT_MAX_PDU),
             UserVariableItem::ImplementationClassUID(IMPLEMENTATION_CLASS_UID.to_string()),
             UserVariableItem::ImplementationVersionName(IMPLEMENTATION_VERSION_NAME.to_string())
         ]
@@ -172,8 +173,8 @@ async fn scu_scp_association_promiscuous_enabled_async() {
             abstract_syntax: MR_IMAGE_STORAGE.to_string(),
         }]
     );
-    assert_eq!(association.acceptor_max_pdu_length(), 16384);
-    assert_eq!(association.requestor_max_pdu_length(), 16384);
+    assert_eq!(association.acceptor_max_pdu_length(), DEFAULT_MAX_PDU);
+    assert_eq!(association.requestor_max_pdu_length(), DEFAULT_MAX_PDU);
     assert_eq!(association.read_timeout(), None);
     assert_eq!(association.write_timeout(), None);
 


### PR DESCRIPTION
The code is using max_pdu_size as both a limit for the variable field of the PDU (i.e. excluding the PDU header) and as a limit for the PDU as a whole (i.e. including the PDU header). The latter is wrong and affects send() and receive() in both server and client. As a consequence:

- A compliant client or server that doesn't use this library could send a well-formed PDU that would be rejected by the peer.
- A compliant server or client that uses this library could attempt to send a perfectly valid PDU and be wrongfully stopped by the library.

In the belief that the std library might allocate more than necessary when crossing a size that is a power of 2, I've reduced the constants `DEFAULT_MAX_PDU`, `MINIMUM_PDU_SIZE` and `LARGE_PDU_SIZE` by 6 (the size of the PDU header) so that the full PDU fits within a buffer with a length that is a power of two.