### PR TITLE
[pixeldata] add option to prevent inversion for monochrome1

### DIFF
--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -354,8 +354,6 @@ impl ConvertOptions {
     }
 
     /// Set the photometric interpretation option.
-    ///
-    /// This is equivalent to `self.with_photometric_interpretation(photometric_interpretation)`.
     pub fn with_photometric_interpretation(
         mut self,
         photometric_interpretation: PhotometricInterpretationOption,


### PR DESCRIPTION
- add photometric interpretation option to control behaviour
- default behaviour is kept as it currently is