### PR TITLE
Add into_text_value() to PrimitiveValues

### DIFF
--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -771,8 +771,12 @@ impl PrimitiveValue {
     ///
     /// # Behavior
     ///
-    /// - All variants are converted to `PrimitiveValue::Str`
-    ///   using their string representation (via [`to_raw_str()`])
+    /// - All possible variants are converted to `PrimitiveValue::Str`
+    ///   using their string representation (via [`to_raw_str()`]):
+    ///   In the case of `Strs`,
+    ///   the strings are first joined together with a backslash ('\\').
+    ///   All other type variants are first converted to a string,
+    ///   then joined together with a backslash.
     ///
     /// # When to use `into_text_value()`
     ///


### PR DESCRIPTION
Implements: [ISSUE-88](https://github.com/Enet4/dicom-rs/issues/88)

This adds `into_text_value()` for `PrimitiveValue` as well as an `impl From<Cow<'_, str>> for PrimitiveValue` per the suggestion in the issue above.

Assumptions to check:
- All variants should be converted to `PrimitiveValue::Str` (including `Empty` and `Strs`)
- use `to_raw_str()` instead of `to_str()` to preserve the most information (no trimming of extra spaces, etc)
- both `into_text_value()` and `impl From<Cow<'_, str>> for PrimitiveValue` are useful for convenience/completeness, even though `into_text_value()` is just `PrimitiveValue::from(self.to_raw_str())`

Other things to check:
- I didn't write test cases for all variants, figuring it become redundant with the `to_raw_str()` tests. Let me know if I should.
- double check the correctness of the documentation. I tried to follow the pattern but I'm new to the project and might have mis-typed