### PR TITLE
MAIN: Don't use all rustls default features

### DIFF
--- a/ul/Cargo.toml
+++ b/ul/Cargo.toml
@@ -18,7 +18,6 @@ cfg-if = "1.0.3"
 dicom-encoding = { path = "../encoding/", version = "0.9" }
 dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.9", default-features = false }
 snafu = "0.8"
-tokio-rustls = {version = "0.26.2", optional = true }
 tracing = "0.1.34"
 
 [dependencies.tokio]


### PR DESCRIPTION
* This disables ring and aws-lc-rs  in the `ul` library which allows users of the library to choose their own cryptoprovider
* The binaries (storescu/storescp/etc) still use aws-lc-rs as default since the `app-common` package specifies rustls with default features.


Fixes #719 