### PR TITLE
Fix misinterpretation of AE address as plain socket address in some cases

### DIFF
--- a/storescu/src/main.rs
+++ b/storescu/src/main.rs
@@ -398,7 +398,7 @@ fn run(app: App) -> Result<(), Error> {
         store_sync::inner(scu, dicom_files, &progress_bar, fail_first, verbose, never_transcode, ignore_sop_class)?;
 
     } else {
-        let scu = scu_options.establish(&addr).map_err(Box::from).context(ScuSnafu)?;
+        let scu = scu_options.establish_with(&addr).map_err(Box::from).context(ScuSnafu)?;
         store_sync::inner(scu, dicom_files, &progress_bar, fail_first, verbose, never_transcode, ignore_sop_class)?;
     }
     Ok(())
@@ -505,7 +505,7 @@ async fn run_async() -> Result<(), Error> {
                 .await
             } else {
                 let scu = scu_options
-                    .establish_async(&addr)
+                    .establish_with_async(&addr)
                     .await
                     .map_err(Box::from)
                     .context(ScuSnafu)?;

--- a/ul/tests/association.rs
+++ b/ul/tests/association.rs
@@ -207,7 +207,7 @@ async fn test_tls_connection_async() -> Result<()> {
         .tls_config((*server_tls_config).clone());
     
     // Spawn server task
-    let server_handle = tokio::spawn(async move {
+    let server_handle: tokio::task::JoinHandle<Result<_>> = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync + 'static>)?;
         let mut association = server_options.establish_tls_async(stream).await.map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync + 'static>)?;
         


### PR DESCRIPTION
Should resolve #721.

### Summary

- [ul] add a simple test for `establish_with` method
- [storescu] Fix misinterpretation of AE address as plain socket address in some cases
   - always use `establish_with` and respective variants when using an address which might also include the AE title (syntax `{AETITLE}@{HOST}:{PORT}`)
