### PR TITLE
Remove drop traits

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -1039,15 +1039,6 @@ where S: CloseSocket + std::io::Read + std::io::Write{
     }
 }
 
-/// Automatically release the association and shut down the connection.
-impl<S> Drop for ClientAssociation<S>
-where S: CloseSocket + std::io::Read + std::io::Write,
-{
-    fn drop(&mut self) {
-        let _ = SyncAssociationSealed::release(self);
-    }
-}
-
 #[cfg(feature = "async")]
 /// Initiate simple TCP connection to the given address
 pub async fn async_connection<T>(
@@ -1408,19 +1399,6 @@ where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send{
     fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
         let Self { socket, read_buffer, .. } = self;
         (socket, read_buffer)
-    }
-}
-
-#[cfg(feature = "async")]
-impl<S> Drop for AsyncClientAssociation<S>
-where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
-{
-    fn drop(&mut self) {
-        tokio::task::block_in_place(move || {
-            tokio::runtime::Handle::current().block_on(async move {
-                let _ = crate::association::private::AsyncAssociationSealed::release(self).await;
-            })
-        });
     }
 }
 

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -865,13 +865,6 @@ where S: std::io::Read + std::io::Write + CloseSocket,{
 
 }
 
-impl<S> Drop for ServerAssociation<S> 
-where S: std::io::Read + std::io::Write + CloseSocket{
-    fn drop(&mut self) {
-        let _ = SyncAssociationSealed::abort(self);
-    }
-}
-
 /// Check that a transfer syntax repository
 /// supports the given transfer syntax,
 /// meaning that it can parse and decode DICOM data sets.
@@ -1145,18 +1138,6 @@ where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send{
     fn get_mut(&mut self) -> (&mut S, &mut bytes::BytesMut) {
         let Self { socket, read_buffer, .. } = self; 
         (socket, read_buffer)
-    }
-}
-
-#[cfg(feature = "async")]
-impl<S> Drop for AsyncServerAssociation<S> 
-where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send{
-    fn drop(&mut self) {
-        tokio::task::block_in_place(move || {
-            tokio::runtime::Handle::current().block_on(async move {
-                let _ = crate::association::private::AsyncAssociationSealed::abort(self).await;
-            })
-        });
     }
 }
 

--- a/ul/src/association/tests.rs
+++ b/ul/src/association/tests.rs
@@ -379,12 +379,12 @@ mod successive_pdus_during_client_association {
             server_addr.into()
         ).await.unwrap();
         // Initiate abort server-side
-        let _ = server_handle.await.unwrap().abort().await; // FIXME: result is Err(ConnectionClosed)
+        server_handle.await.unwrap().abort().await.unwrap();
 
         // Client should be able to receive the release request that was sent consecutively
         let received_pdu = association.receive().await.expect("Could not receive abort PDU");
         assert_eq!(received_pdu, Pdu::AbortRQ { source: AbortRQSource::ServiceProvider(AbortRQServiceProviderReason::ReasonNotSpecified) });
-        
+
         // Client cannot receive the PDU that was sent during association
         // Clean shutdown
         drop(association);

--- a/ul/src/association/tests.rs
+++ b/ul/src/association/tests.rs
@@ -730,7 +730,7 @@ mod successive_pdus_during_server_association {
             // Server misses the echo request entirely
             let received_pdu = association.receive().await.unwrap();
             assert_eq!(received_pdu, Pdu::ReleaseRQ);
-            association.abort().await.unwrap();
+            association.send(&Pdu::ReleaseRP).await.unwrap();
         });
 
         // Give server time to start
@@ -750,7 +750,7 @@ mod successive_pdus_during_server_association {
             .unwrap();
 
         // Clean shutdown
-        let _ = association.release().await;
+        association.release().await.unwrap();
         server_handle.await.unwrap();
     }
 }

--- a/ul/src/association/tests.rs
+++ b/ul/src/association/tests.rs
@@ -552,6 +552,7 @@ mod successive_pdus_during_server_association {
             // Server misses the echo request entirely
             let received_pdu = association.receive().unwrap();
             assert_eq!(received_pdu, Pdu::ReleaseRQ);
+            association.send(&Pdu::ReleaseRP).unwrap();
         });
 
         // Give server time to start
@@ -570,7 +571,7 @@ mod successive_pdus_during_server_association {
             .unwrap();
 
         // Clean shutdown
-        let _ = association.release(); // FIXME: attempting to unwrap fails ??
+        association.release().unwrap();
         server_handle.join().unwrap();
     }
 


### PR DESCRIPTION
Implements point 1 of https://github.com/Enet4/dicom-rs/issues/714#issuecomment-3664462480. There was a unit test that seemed to rely on packets being sent upon dropping the association object, so I had to fix those too. However I'm not very clear on what's going on exactly, as the functions they use seem to return `Err(ConnectionClosed)` in some instances, which doesn't seem to affect the test.

If all is OK, I will remove the FIXME's.