### PR TITLE
[ul] Fix docs regarding renaming of feature `tls` to `sync-tls`

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -140,20 +140,18 @@ fn tls_connection<T>(
 /// 
 /// ### Sync TLS
 /// 
-/// * Make sure you include the `tls` feature in your `Cargo.toml`
+/// * Make sure you include the `sync-tls` feature in your `Cargo.toml`
 /// 
 /// ### Async TLS
 /// 
 /// * Make sure you include the `async-tls` feature in your `Cargo.toml`
 /// 
-/// > **⚠️ Warning:** Just including the `async` and `tls` features will _not_ work!
-/// 
 /// ### Example
-/// ```
+/// ```no_compile
 /// # use dicom_ul::association::client::ClientAssociationOptions;
 /// # use std::time::Duration;
 /// # use std::sync::Arc;
-/// # #[cfg(feature = "tls")]
+/// # #[cfg(feature = "sync-tls")]
 /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// use rustls::{
 ///     ClientConfig, RootCertStore,

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -209,13 +209,11 @@ impl AccessControl for AcceptCalledAeTitle {
 /// 
 /// ### Sync TLS
 /// 
-/// * Make sure you include the `tls` feature in your `Cargo.toml`
+/// * Make sure you include the `sync-tls` feature in your `Cargo.toml`
 /// 
 /// ### Async TLS
 /// 
 /// * Make sure you include the `async-tls` feature in your `Cargo.toml`
-/// 
-/// > **⚠️ Warning:** Just including the `async` and `tls` features will _not_ work!
 /// 
 /// ### Example
 /// ```no_compile
@@ -223,7 +221,7 @@ impl AccessControl for AcceptCalledAeTitle {
 /// # use dicom_ul::association::client::ClientAssociationOptions;
 /// # use std::time::Duration;
 /// # use std::sync::Arc;
-/// # #[cfg(feature = "tls")]
+/// # #[cfg(feature = "sync-tls")]
 /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// use rustls::{
 ///     ClientConfig, RootCertStore,


### PR DESCRIPTION
I presume that the warning about not being sufficient to include "tls" and "async" is no longer necessary, given that after being renamed, it no longer makes sense to include "sync-tls" and "async", so I've removed them.

At the same time it adds no_compile to the doc example, that otherwise errors out because of missing .crt files.

Fixes #726.

Edit: It appears that features `sync-tls` and `async-tls` (or at least the former) are not being tested in CI, as otherwise the compile error would have been apparent. @Enet4 