### PR TITLE
[ul] Implement generic Extended Negotiation

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -16,8 +16,8 @@ use std::{
 use crate::association::AsyncAssociation;
 use crate::{
     association::{
-        encode_pdu, private::SyncAssociationSealed, read_pdu_from_wire, Association,
-        NegotiatedOptions, SocketOptions, SyncAssociation,
+        encode_pdu, extended_negotiation_filter_impl, private::SyncAssociationSealed,
+        read_pdu_from_wire, Association, NegotiatedOptions, SocketOptions, SyncAssociation,
     },
     pdu::{
         write_pdu, AbortRQSource, AssociationAC, AssociationRQ, Pdu, PresentationContextNegotiated,
@@ -263,6 +263,8 @@ pub struct ClientAssociationOptions<'a> {
     saml_assertion: Option<Cow<'a, str>>,
     /// User identity JWT
     jwt: Option<Cow<'a, str>>,
+    /// Extended Negotiation info
+    extended_negotiation: Vec<(Cow<'a, str>, Vec<u8>)>,
     /// Socket options for TCP connections
     socket_options: SocketOptions,
     /// TLS configuration to use for the connection
@@ -292,6 +294,7 @@ impl Default for ClientAssociationOptions<'_> {
             kerberos_service_ticket: None,
             saml_assertion: None,
             jwt: None,
+            extended_negotiation: Vec::new(),
             socket_options: SocketOptions {
                 read_timeout: None,
                 write_timeout: None,
@@ -496,6 +499,22 @@ impl<'a> ClientAssociationOptions<'a> {
         self
     }
 
+    /// Add an Extended Negotiation SOP Class UID and raw data.
+    /// The data must be a byte slice with the information
+    /// required by the standard for the given SOP Class. This is
+    /// kind of a low-level function, intended to support all
+    /// possible current and future use cases for this feature,
+    /// so it's the caller's responsibility to fill in this field
+    /// correctly.
+    pub fn with_extended_negotiation<T>(mut self, sop_class: T, scai: &[u8]) -> Self
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        self.extended_negotiation
+            .push((sop_class.into(), scai.to_vec()));
+        self
+    }
+
     /// Set the TLS configuration to use for the connection
     #[cfg(feature = "sync-tls")]
     pub fn tls_config(mut self, config: impl Into<std::sync::Arc<rustls::ClientConfig>>) -> Self {
@@ -686,6 +705,7 @@ impl<'a> ClientAssociationOptions<'a> {
             kerberos_service_ticket,
             saml_assertion,
             jwt,
+            extended_negotiation,
             ..
         } = self;
         // fail if no presentation contexts were provided: they represent intent,
@@ -729,6 +749,12 @@ impl<'a> ClientAssociationOptions<'a> {
             UserVariableItem::ImplementationClassUID(IMPLEMENTATION_CLASS_UID.to_string()),
             UserVariableItem::ImplementationVersionName(IMPLEMENTATION_VERSION_NAME.to_string()),
         ];
+        for sub_item in extended_negotiation {
+            user_variables.push(UserVariableItem::SopClassExtendedNegotiationSubItem(
+                sub_item.0.to_string(),
+                sub_item.1.clone(),
+            ));
+        }
 
         if let Some(user_identity) = Self::determine_user_identity(
             username.as_deref(),
@@ -1031,6 +1057,14 @@ where
 
     fn user_variables(&self) -> &[UserVariableItem] {
         &self.user_variables
+    }
+
+    /// Given a SOP Class UID, obtain the bytes matching
+    /// that UID with the result from the negotiation, or
+    /// None if that SOP Class UID was rejected or not
+    /// proposed.
+    fn extended_negotiation_for(&self, sop_class_uid: &str) -> Option<&[u8]> {
+        extended_negotiation_filter_impl(&self.user_variables, sop_class_uid)
     }
 }
 
@@ -1550,6 +1584,14 @@ impl<S> Association for AsyncClientAssociation<S> {
 
     fn user_variables(&self) -> &[UserVariableItem] {
         &self.user_variables
+    }
+
+    /// Given a SOP Class UID, obtain the bytes matching
+    /// that UID with the result from the negotiation, or
+    /// None if that SOP Class UID was rejected or not
+    /// proposed.
+    fn extended_negotiation_for(&self, sop_class_uid: &str) -> Option<&[u8]> {
+        extended_negotiation_filter_impl(&self.user_variables, sop_class_uid)
     }
 }
 

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -499,19 +499,20 @@ impl<'a> ClientAssociationOptions<'a> {
         self
     }
 
-    /// Add an Extended Negotiation SOP Class UID and raw data.
-    /// The data must be a byte slice with the information
+    /// Add an Extended Negotiation SOP Class UID and raw data. SCAI
+    /// stands for Service-class-application-information as defined in
+    /// PS3.7. The data must be a byte slice or vector with the information
     /// required by the standard for the given SOP Class. This is
     /// kind of a low-level function, intended to support all
     /// possible current and future use cases for this feature,
     /// so it's the caller's responsibility to fill in this field
     /// correctly.
-    pub fn with_extended_negotiation<T>(mut self, sop_class: T, scai: &[u8]) -> Self
+    pub fn with_extended_negotiation<T>(mut self, sop_class: T, scai: impl Into<Vec<u8>>) -> Self
     where
         T: Into<Cow<'a, str>>,
     {
         self.extended_negotiation
-            .push((sop_class.into(), scai.to_vec()));
+            .push((sop_class.into(), scai.into()));
         self
     }
 

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -234,6 +234,19 @@ impl CloseSocket for rustls::StreamOwned<rustls::ServerConnection, std::net::Tcp
     }
 }
 
+// Local function to not repeat the same code in every implementation
+pub(crate) fn extended_negotiation_filter_impl<'a>(
+    user_vars: &'a [UserVariableItem],
+    sop_class_uid: &str,
+) -> Option<&'a [u8]> {
+    user_vars.iter().find_map(|uv| match uv {
+        UserVariableItem::SopClassExtendedNegotiationSubItem(uid, data) if uid == sop_class_uid => {
+            Some(data.as_slice())
+        }
+        _ => None,
+    })
+}
+
 /// Trait that represents common properties of an association
 pub trait Association {
     /// Obtain the remote DICOM node's application entity title.
@@ -273,6 +286,12 @@ pub trait Association {
     /// It usually contains the maximum PDU length,
     /// the implementation class UID, and the implementation version name.
     fn user_variables(&self) -> &[UserVariableItem];
+
+    /// Retrieve the bytes associated to a specific SOP Class
+    /// that was negotiated with extended negotiation.
+    ///
+    /// Returns None if that SOP class was rejected or not requested.
+    fn extended_negotiation_for(&self, sop_class_uid: &str) -> Option<&[u8]>;
 }
 
 mod private {

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -290,7 +290,7 @@ pub trait Association {
     /// Retrieve the bytes associated to a specific SOP Class
     /// that was negotiated with extended negotiation.
     ///
-    /// Returns None if that SOP class was rejected or not requested.
+    /// Returns `None` if that SOP class was rejected or not requested.
     fn extended_negotiation_for(&self, sop_class_uid: &str) -> Option<&[u8]>;
 }
 

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -106,7 +106,7 @@ pub trait Negotiation {
     /// User-provided extended negotiation. The result of
     /// the negotiation must be returned as either None, if
     /// extended negotiation is not supported by the
-    /// application for the given SOP Class, or Some(Vec<u8>)
+    /// application for the given SOP Class, or `Some(Vec<u8>)`
     /// with the result of the negotiation, if the SOP Class is
     /// supported and negotiation is successful. The meaning
     /// is SOP Class-specific and typically index-specific. For
@@ -115,12 +115,14 @@ pub trait Negotiation {
     /// the first byte in the output should be 1 if the first
     /// input byte is 1 (client requests relational queries)
     /// and the server supports relational queries, and 0
-    /// otherwise,and so on. For reference, see Table C.5-2 in
-    /// PS3.4 of the Standard:
-    /// https://dicom.nema.org/medical/dicom/2025d/output/chtml/part04/sect_C.5.html#table_C.5-2
+    /// otherwise, and so on.
+    /// For reference, see
+    /// [Table C.5-2 in PS3.4 of the Standard][1].
+    ///
+    /// [1]: https://dicom.nema.org/medical/dicom/2025d/output/chtml/part04/sect_C.5.html#table_C.5-2
     ///
     /// The default action is to not perform extended negotiation
-    /// (returns None for all SOP Classes, therefore no Extended
+    /// (returns `None` for all SOP Classes, therefore no Extended
     /// Negotiation items are included in the A-ASSOCIATE-AC
     /// response).
     ///

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -13,7 +13,7 @@ use crate::association::private::SyncAssociationSealed;
 use crate::association::{
     AbortedSnafu, Association, CloseSocket, MissingAbstractSyntaxSnafu, RejectedSnafu,
     SendPduSnafu, SocketOptions, SyncAssociation, UnexpectedPduSnafu, UnknownPduSnafu,
-    WireSendSnafu, encode_pdu, read_pdu_from_wire,
+    WireSendSnafu, encode_pdu, extended_negotiation_filter_impl, read_pdu_from_wire,
 };
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
@@ -100,6 +100,101 @@ impl AccessControl for AcceptCalledAeTitle {
         }
     }
 }
+
+/// Interface for negotiation of certain aspects of the association.
+pub trait Negotiation {
+    /// User-provided extended negotiation. The result of
+    /// the negotiation must be returned as either None, if
+    /// extended negotiation is not supported by the
+    /// application for the given SOP Class, or Some(Vec<u8>)
+    /// with the result of the negotiation, if the SOP Class is
+    /// supported and negotiation is successful. The meaning
+    /// is SOP Class-specific and typically index-specific. For
+    /// example, for the SOP Class 1.2.840.10008.5.1.4.1.2.2.1
+    /// (Study Root Query/Retrieve Information Model - FIND),
+    /// the first byte in the output should be 1 if the first
+    /// input byte is 1 (client requests relational queries)
+    /// and the server supports relational queries, and 0
+    /// otherwise,and so on. For reference, see Table C.5-2 in
+    /// PS3.4 of the Standard:
+    /// https://dicom.nema.org/medical/dicom/2025d/output/chtml/part04/sect_C.5.html#table_C.5-2
+    ///
+    /// The default action is to not perform extended negotiation
+    /// (returns None for all SOP Classes, therefore no Extended
+    /// Negotiation items are included in the A-ASSOCIATE-AC
+    /// response).
+    ///
+    /// This is an example of a server that supports combined
+    /// date/time matching and empty value matching for the
+    /// SOP Class "Study Root Query/Retrieve Information Model - FIND":
+    /// ```no_run
+    /// # use dicom_ul::association::server::{Negotiation, ServerAssociationOptions};
+    /// # use dicom_ul::association::Association;
+    /// # use std::net::TcpListener;
+    /// const STUDY_ROOT_QR_IM_FIND: &str = "1.2.840.10008.5.1.4.1.2.2.1";
+    /// struct FindOptions;
+    ///
+    /// impl Negotiation for FindOptions {
+    ///     fn extended_negotiation(
+    ///         &self,
+    ///         sop_class_uid: &str,
+    ///         input: &[u8],
+    ///     ) -> Option<Vec<u8>> {
+    ///         // Only this SOP Class is supported, so ditch the rest
+    ///         if sop_class_uid != STUDY_ROOT_QR_IM_FIND {
+    ///             return None;
+    ///         }
+    ///         // Truncate to at most 7 elements and store in a new vector
+    ///         let mut result = input[..input.len().min(7)].to_vec();
+    ///         for index in 1..=result.len() {
+    ///             match index {
+    ///                 // Combined date-time matching (second byte of field) and
+    ///                 // Empty value matching (sixth byte) are both supported.
+    ///                 // Remember that the DICOM standard specifies 1-based
+    ///                 // byte positions, but Rust indices are 0-based.
+    ///                 2 | 6 => (),
+    ///                 // Indicate lack of support for the rest of features.
+    ///                 _ => { result[index - 1] = 0; }
+    ///             }
+    ///         }
+    ///         Some(result)
+    ///     }
+    /// }
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let tcp_listener: TcpListener = unimplemented!();
+    /// let find_options = FindOptions;
+    ///
+    /// let scp_options = ServerAssociationOptions::new()
+    ///     .with_negotiation(find_options);
+    ///
+    /// let (stream, _address) = tcp_listener.accept()?;
+    /// let assoc = scp_options.establish(stream)?;
+    ///
+    /// // Association is established; read the flags that were negotiated
+    /// let mut combined_date_time = false;
+    /// let mut empty_value_matching = false;
+    ///
+    /// if let Some(values) = assoc.extended_negotiation_for(STUDY_ROOT_QR_IM_FIND) {
+    ///     // 2nd byte position (index 1) is the combined date/time matching option.
+    ///     // If it is zero or absent, consider it disabled.
+    ///     combined_date_time = values.get(2 - 1).copied().unwrap_or(0) != 0;
+    ///     // 6th byte position (index 5) is the empty value matching option
+    ///     empty_value_matching = values.get(6 - 1).copied().unwrap_or(0) != 0;
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn extended_negotiation(&self, _sop_class_uid: &str, _input: &[u8]) -> Option<Vec<u8>> {
+        None
+    }
+}
+
+/// An Extended Negotiation rule that ignores all SOP Classes
+#[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
+pub struct DefaultNegotiation;
+
+impl Negotiation for DefaultNegotiation {}
 
 /// A DICOM association builder for an acceptor DICOM node,
 /// often taking the role of a service class provider (SCP).
@@ -281,7 +376,7 @@ impl AccessControl for AcceptCalledAeTitle {
 /// For an association with the async API,
 /// call `establish_tls_async` instead of `establish_tls`.
 #[derive(Debug, Clone)]
-pub struct ServerAssociationOptions<'a, A> {
+pub struct ServerAssociationOptions<'a, A, N> {
     /// the application entity access control policy
     ae_access_control: A,
     /// the AE title of this DICOM node
@@ -300,6 +395,8 @@ pub struct ServerAssociationOptions<'a, A> {
     strict: bool,
     /// whether to accept unknown abstract syntaxes
     promiscuous: bool,
+    /// extended negotiation handler
+    negotiation: N,
     /// Options for the underlying TCP socket
     socket_options: SocketOptions,
     /// TLS configuration for the underlying TCP socket
@@ -307,7 +404,7 @@ pub struct ServerAssociationOptions<'a, A> {
     tls_config: Option<std::sync::Arc<rustls::ServerConfig>>,
 }
 
-impl Default for ServerAssociationOptions<'_, AcceptAny> {
+impl Default for ServerAssociationOptions<'_, AcceptAny, DefaultNegotiation> {
     fn default() -> Self {
         ServerAssociationOptions {
             ae_access_control: AcceptAny,
@@ -319,6 +416,7 @@ impl Default for ServerAssociationOptions<'_, AcceptAny> {
             max_pdu_length: DEFAULT_MAX_PDU,
             strict: true,
             promiscuous: false,
+            negotiation: DefaultNegotiation,
             socket_options: SocketOptions::default(),
             #[cfg(feature = "sync-tls")]
             tls_config: None,
@@ -326,22 +424,23 @@ impl Default for ServerAssociationOptions<'_, AcceptAny> {
     }
 }
 
-impl ServerAssociationOptions<'_, AcceptAny> {
+impl ServerAssociationOptions<'_, AcceptAny, DefaultNegotiation> {
     /// Create a new set of options for establishing an association.
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl<'a, A> ServerAssociationOptions<'a, A>
+impl<'a, A, N> ServerAssociationOptions<'a, A, N>
 where
     A: AccessControl,
+    N: Negotiation,
 {
     /// Change the access control policy to accept any association
     /// regardless of the specified AE titles.
     ///
     /// This is the default behavior when the options are first created.
-    pub fn accept_any(self) -> ServerAssociationOptions<'a, AcceptAny> {
+    pub fn accept_any(self) -> ServerAssociationOptions<'a, AcceptAny, N> {
         self.ae_access_control(AcceptAny)
     }
 
@@ -350,7 +449,7 @@ where
     ///
     /// The default is to accept any requesting node
     /// regardless of the specified AE titles.
-    pub fn accept_called_ae_title(self) -> ServerAssociationOptions<'a, AcceptCalledAeTitle> {
+    pub fn accept_called_ae_title(self) -> ServerAssociationOptions<'a, AcceptCalledAeTitle, N> {
         self.ae_access_control(AcceptCalledAeTitle)
     }
 
@@ -358,7 +457,7 @@ where
     ///
     /// The default is to accept any requesting node
     /// regardless of the specified AE titles.
-    pub fn ae_access_control<P>(self, access_control: P) -> ServerAssociationOptions<'a, P>
+    pub fn ae_access_control<P>(self, access_control: P) -> ServerAssociationOptions<'a, P, N>
     where
         P: AccessControl,
     {
@@ -372,6 +471,7 @@ where
             strict,
             promiscuous,
             ae_access_control: _,
+            negotiation,
             socket_options,
             #[cfg(feature = "sync-tls")]
             tls_config,
@@ -387,6 +487,7 @@ where
             max_pdu_length,
             strict,
             promiscuous,
+            negotiation,
             socket_options,
             #[cfg(feature = "sync-tls")]
             tls_config,
@@ -469,6 +570,44 @@ where
                 connection_timeout: self.socket_options.connection_timeout,
             },
             ..self
+        }
+    }
+
+    /// Set the extended negotiation handler
+    pub fn with_negotiation<NN>(self, negotiation: NN) -> ServerAssociationOptions<'a, A, NN>
+    where
+        NN: Negotiation,
+    {
+        let ServerAssociationOptions {
+            ae_access_control,
+            ae_title,
+            application_context_name,
+            abstract_syntax_uids,
+            transfer_syntax_uids,
+            protocol_version,
+            max_pdu_length,
+            strict,
+            promiscuous,
+            negotiation: _,
+            socket_options,
+            #[cfg(feature = "sync-tls")]
+            tls_config,
+        } = self;
+
+        ServerAssociationOptions {
+            ae_access_control,
+            ae_title,
+            application_context_name,
+            abstract_syntax_uids,
+            transfer_syntax_uids,
+            protocol_version,
+            max_pdu_length,
+            strict,
+            promiscuous,
+            negotiation,
+            socket_options,
+            #[cfg(feature = "sync-tls")]
+            tls_config,
         }
     }
 
@@ -600,6 +739,34 @@ where
                     })
                     .collect();
 
+                let mut new_user_variables = vec![
+                    UserVariableItem::MaxLength(self.max_pdu_length),
+                    UserVariableItem::ImplementationClassUID(IMPLEMENTATION_CLASS_UID.to_string()),
+                    UserVariableItem::ImplementationVersionName(
+                        IMPLEMENTATION_VERSION_NAME.to_string(),
+                    ),
+                ];
+                // Extended negotiation is performed here: add only the variables
+                // for which the user-supplied negotiation function returns Some(x).
+                for item in user_variables.iter() {
+                    if let UserVariableItem::SopClassExtendedNegotiationSubItem(
+                        sop_class_uid,
+                        scai,
+                    ) = item
+                    {
+                        if let Some(extended_negotiation_result) =
+                            self.negotiation.extended_negotiation(sop_class_uid, scai)
+                        {
+                            new_user_variables.push(
+                                UserVariableItem::SopClassExtendedNegotiationSubItem(
+                                    sop_class_uid.clone(),
+                                    extended_negotiation_result,
+                                ),
+                            );
+                        }
+                    }
+                }
+
                 let pdu = Pdu::AssociationAC(AssociationAC {
                     protocol_version: self.protocol_version,
                     application_context_name,
@@ -613,21 +780,13 @@ where
                         .collect(),
                     calling_ae_title: calling_ae_title.clone(),
                     called_ae_title: called_ae_title.clone(),
-                    user_variables: vec![
-                        UserVariableItem::MaxLength(self.max_pdu_length),
-                        UserVariableItem::ImplementationClassUID(
-                            IMPLEMENTATION_CLASS_UID.to_string(),
-                        ),
-                        UserVariableItem::ImplementationVersionName(
-                            IMPLEMENTATION_VERSION_NAME.to_string(),
-                        ),
-                    ],
+                    user_variables: new_user_variables.clone(),
                 });
                 Ok((
                     pdu,
                     NegotiatedOptions {
                         peer_max_pdu_length: requestor_max_pdu_length,
-                        user_variables,
+                        user_variables: new_user_variables,
                         presentation_contexts: presentation_contexts_negotiated,
                         peer_ae_title: calling_ae_title,
                     },
@@ -984,6 +1143,13 @@ where
     fn user_variables(&self) -> &[UserVariableItem] {
         &self.user_variables
     }
+
+    /// Given a SOP Class UID, obtain a slice of bytes
+    /// with the extended negotiation result for that
+    /// SOP Class, if it exists.
+    fn extended_negotiation_for(&self, sop_class_uid: &str) -> Option<&[u8]> {
+        extended_negotiation_filter_impl(&self.user_variables, sop_class_uid)
+    }
 }
 
 impl<S> SyncAssociationSealed<S> for ServerAssociation<S>
@@ -1092,9 +1258,10 @@ where
 }
 
 #[cfg(feature = "async")]
-impl<A> ServerAssociationOptions<'_, A>
+impl<A, N> ServerAssociationOptions<'_, A, N>
 where
     A: AccessControl,
+    N: Negotiation,
 {
     /// Negotiate an association with the given TCP stream.
     pub async fn establish_async(
@@ -1331,6 +1498,13 @@ where
     fn user_variables(&self) -> &[UserVariableItem] {
         &self.user_variables
     }
+
+    /// Given a SOP Class UID, obtain a slice of bytes
+    /// with the extended negotiation result for that
+    /// SOP Class, if it exists.
+    fn extended_negotiation_for(&self, sop_class_uid: &str) -> Option<&[u8]> {
+        extended_negotiation_filter_impl(&self.user_variables, sop_class_uid)
+    }
 }
 
 #[cfg(feature = "async")]
@@ -1525,9 +1699,10 @@ mod tests {
         );
     }
 
-    impl<'a, A> ServerAssociationOptions<'a, A>
+    impl<'a, A, N> ServerAssociationOptions<'a, A, N>
     where
         A: AccessControl,
+        N: Negotiation,
     {
         // Broken implementation of server establish which sends an extra pdu during establish
         pub(crate) fn establish_with_extra_pdus(

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -115,9 +115,11 @@ pub trait Negotiation {
     /// the first byte in the output should be 1 if the first
     /// input byte is 1 (client requests relational queries)
     /// and the server supports relational queries, and 0
-    /// otherwise, and so on.
-    /// For reference, see
-    /// [Table C.5-2 in PS3.4 of the Standard][1].
+    /// otherwise, and so on, according to
+    /// [Table C.5-2 in PS3.4 of the Standard][1]. That link
+    /// applies to the SOP class of this example; see the
+    /// appropriate section of the standard for each SOP class
+    /// you intend to support.
     ///
     /// [1]: https://dicom.nema.org/medical/dicom/2025d/output/chtml/part04/sect_C.5.html#table_C.5-2
     ///
@@ -125,6 +127,12 @@ pub trait Negotiation {
     /// (returns `None` for all SOP Classes, therefore no Extended
     /// Negotiation items are included in the A-ASSOCIATE-AC
     /// response).
+    ///
+    /// When implementing an extended_negotiation method, never
+    /// return more bytes than the version of the standard you
+    /// support specifies. If you're using the input array as a
+    /// basis, truncate or slice it accordingly before returning
+    /// it.
     ///
     /// This is an example of a server that supports combined
     /// date/time matching and empty value matching for the
@@ -134,6 +142,7 @@ pub trait Negotiation {
     /// # use dicom_ul::association::Association;
     /// # use std::net::TcpListener;
     /// const STUDY_ROOT_QR_IM_FIND: &str = "1.2.840.10008.5.1.4.1.2.2.1";
+    ///
     /// struct FindOptions;
     ///
     /// impl Negotiation for FindOptions {
@@ -146,7 +155,8 @@ pub trait Negotiation {
     ///         if sop_class_uid != STUDY_ROOT_QR_IM_FIND {
     ///             return None;
     ///         }
-    ///         // Truncate to at most 7 elements and store in a new vector
+    ///         // Truncate to at most 7 elements (those supported by the 2025d
+    ///         // version of the standard) and store in a new vector.
     ///         let mut result = input[..input.len().min(7)].to_vec();
     ///         for index in 1..=result.len() {
     ///             match index {
@@ -192,7 +202,8 @@ pub trait Negotiation {
     }
 }
 
-/// An Extended Negotiation rule that ignores all SOP Classes
+/// A Negotiation rule that causes the server to omit the negotiation in the response, thus forcing
+/// default values for all kinds of negotiations supported, for all SOP classes.
 #[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
 pub struct DefaultNegotiation;
 

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -197,7 +197,8 @@ pub trait Negotiation {
     /// # Ok(())
     /// # }
     /// ```
-    fn extended_negotiation(&self, _sop_class_uid: &str, _input: &[u8]) -> Option<Vec<u8>> {
+    #[allow(unused_variables)]
+    fn extended_negotiation(&self, sop_class_uid: &str, input: &[u8]) -> Option<Vec<u8>> {
         None
     }
 }

--- a/ul/tests/association_echo.rs
+++ b/ul/tests/association_echo.rs
@@ -1,7 +1,11 @@
 #[cfg(feature = "async")]
 use dicom_ul::association::AsyncServerAssociation;
 use dicom_ul::{
-    association::{client::ClientAssociationOptions, server::ServerAssociationOptions, Error},
+    association::{
+        client::ClientAssociationOptions,
+        server::{Negotiation, ServerAssociationOptions},
+        Association, Error,
+    },
     pdu::{
         PDataValue, PDataValueType, Pdu, PresentationContextNegotiated,
         PresentationContextResultReason,
@@ -54,11 +58,28 @@ fn spawn_scp(
 )> {
     let listener = std::net::TcpListener::bind("localhost:0")?;
     let addr = listener.local_addr()?;
+
+    struct TestNegotiation;
+    impl Negotiation for TestNegotiation {
+        fn extended_negotiation(&self, sop_class_uid: &str, scai: &[u8]) -> Option<Vec<u8>> {
+            let mut result = scai.to_vec();
+            if sop_class_uid == "1.2.3.4" || sop_class_uid == "1.2.3.5" {
+                result[1] = 0;
+                result[2] = 0;
+                Some(result)
+            } else {
+                None
+            }
+        }
+    }
+    let test_negotiation = TestNegotiation;
+
     let scp = ServerAssociationOptions::new()
         .accept_called_ae_title()
         .ae_title(SCP_AE_TITLE)
         .max_pdu_length(max_server_pdu_len as u32)
-        .with_abstract_syntax(VERIFICATION_SOP_CLASS);
+        .with_abstract_syntax(VERIFICATION_SOP_CLASS)
+        .with_negotiation(test_negotiation);
 
     let h = std::thread::spawn(move || -> Result<_> {
         let (stream, _addr) = listener.accept()?;
@@ -89,6 +110,22 @@ fn spawn_scp(
         assert_eq!(
             association.acceptor_max_pdu_length(),
             max_server_pdu_len as u32
+        );
+        assert_eq!(
+            association.extended_negotiation_for("1.2.3.4"), // accepted, items 1 and 2 set to 0
+            Some([1, 0, 0, 0].as_slice())
+        );
+        assert_eq!(
+            association.extended_negotiation_for("1.2.3.5"), // same as 1.2.3.4
+            Some([0, 0, 0, 1].as_slice())
+        );
+        assert_eq!(
+            association.extended_negotiation_for("1.2.3.6"), // rejected
+            None
+        );
+        assert_eq!(
+            association.extended_negotiation_for("1.2.3.7"), // not offered by client
+            None
         );
 
         // handle one bogus payload
@@ -318,6 +355,9 @@ fn run_scu_scp_association_test(max_is_client: bool) {
             DIGITAL_MG_STORAGE_SOP_CLASS,
             vec![IMPLICIT_VR_LE, EXPLICIT_VR_LE, JPEG_BASELINE],
         )
+        .with_extended_negotiation("1.2.3.4", &[1, 1, 0, 0])
+        .with_extended_negotiation("1.2.3.5", &[0, 1, 1, 1])
+        .with_extended_negotiation("1.2.3.6", &[1, 1, 1, 1])
         .max_pdu_length(max_client_pdu_len as u32)
         .establish(scp_addr)
         .unwrap();
@@ -329,6 +369,22 @@ fn run_scu_scp_association_test(max_is_client: bool) {
     assert_eq!(
         association.acceptor_max_pdu_length(),
         max_server_pdu_len as u32
+    );
+    assert_eq!(
+        association.extended_negotiation_for("1.2.3.4"), // accepted, items 1 and 2 set to 0
+        Some([1, 0, 0, 0].as_slice())
+    );
+    assert_eq!(
+        association.extended_negotiation_for("1.2.3.5"), // same as 1.2.3.4
+        Some([0, 0, 0, 1].as_slice())
+    );
+    assert_eq!(
+        association.extended_negotiation_for("1.2.3.6"), // rejected
+        None
+    );
+    assert_eq!(
+        association.extended_negotiation_for("1.2.3.7"), // not offered by client
+        None
     );
 
     // Create a bogus payload which fills the PDU to the max.


### PR DESCRIPTION
Add a `Negotiation` trait which contains, for the moment, the `extended_negotiation` method. In future it can also help implement Role Selection negotiation (#731) and possibly other currently unimplemented features like Common Extended Negotiation. Note I'm also interested in #731 and will probably submit a patch if this one is merged, as it will depend on said trait.

This is a case where the client and the server differ substantially. The `Negotiation` trait is only for the server; the client just adds pairs SOP Class / Byte array. After the association succeeds, they both have the same set of pairs, which they can look up to determine which extended options are active, through the new method `extended_negotiation_for(sop_class_uid: &str)` or by walking the `user_variables()`.

Everything is quite low-level, to cover for all current and hopefully future versions of the standard. It's easy to send invalid bytes, for instance.

I'm not quite sure if this is a breaking change. It did not break anything in our application, which is a server. The addition of a new generic concerned me a bit.

Edit: Forgot to mention, this obviously depends on #727, otherwise the bytestream is not correct.