### PR TITLE
Fix LazyDataSetReader handling of encapsulated pixel data sequence header

### DIFF
--- a/object/src/collector.rs
+++ b/object/src/collector.rs
@@ -1764,9 +1764,9 @@ mod tests {
             .is_none());
     }
 
-    // read dicom up to the pixel data, then read it to the end
+    // test loading portions of a DICOM in steps with the collector API
     #[test]
-    fn test_deferred_dicom_read() {
+    fn test_lazy_dicom_read() {
         let file_path_buf = dicom_test_files::path("WG04/J2KR/MG1_J2KR")
             .expect("should be able to retrieve test file");
 
@@ -1786,7 +1786,7 @@ mod tests {
             .expect("should be able to read up to the PixelData element");
 
         // read the rest of the dicom
-        // NOTE: this doesn't include the offset table currently -- is this intended behavior?
+        // NOTE: this doesn't include the offset table currently
         collector
             .read_dataset_to_end(&mut obj)
             .expect("should be able to read the rest of the DICOM");

--- a/parser/src/dataset/lazy_read.rs
+++ b/parser/src/dataset/lazy_read.rs
@@ -330,6 +330,7 @@ where
                 DataToken::ItemStart { len } => LazyDataToken::ItemStart { len },
                 DataToken::ItemEnd => LazyDataToken::ItemEnd,
                 DataToken::SequenceEnd => LazyDataToken::SequenceEnd,
+                DataToken::PixelSequenceStart => LazyDataToken::PixelSequenceStart,
                 _ => unreachable!("peeked token should not be a value token"),
             };
             return Some(Ok(token));

--- a/parser/src/dataset/lazy_read.rs
+++ b/parser/src/dataset/lazy_read.rs
@@ -624,6 +624,9 @@ where
                     LazyDataToken::SequenceEnd => {
                         self.peek = Some(DataToken::SequenceEnd);
                     }
+                    LazyDataToken::PixelSequenceStart => {
+                        self.peek = Some(DataToken::PixelSequenceStart);
+                    }
                     _ => {
                         self.hard_break = true;
                         return PeekSnafu {


### PR DESCRIPTION
This PR resolves the error described in #742 and adds a test to demonstrate this behavior.

In short: the collector API for lazy DICOM reading errors when encountering encapsulated pixel data where the PixelSequence element [7FE0,0010] is a sequence header. This behavior was primarily tested on FFDM/DBT/S2D mammograms from several datasets. The included test references a mammogram from the `dicom_test_files` crate.

Error Behavior:
I implemented the collector API like this based on the docs:
```rust
let mut collector = DicomCollector::open_file(filename)
	.expect("should be able to open the test file with the collector");

let _fmi = collector.read_file_meta();

// read the dicom up to the pixel data
let mut obj = InMemDicomObject::new_empty();
collector
	.read_dataset_up_to_pixeldata(&mut obj)
	.expect("should be able to read up to the PixelData element");

// do other things ---

// read the rest of the dicom
collector
	.read_dataset_to_end(&mut obj)
	.expect("should be able to read the rest of the DICOM");
```

On execution, the `collector.read_dataset_up_to_pixeldata` line throws this error:
```
Error(ReadToken { source: Peek { 
	bytes_read: ... , 
	backtrace: Backtrace [
		...
		{ fn: "dicom_parser::dataset::lazy_read::LazyDataSetReader<S>::peek", file: "[...]/dicom-parser-0.9.0/src/dataset/lazy_read.rs", line: 631 },
		{ fn: "dicom_object::collector::DicomCollector<std::io::buffered::bufreader::BufReader<S>,D,R>::collect_elements", file: "[...]/dicom-object-0.9.0/src/collector.rs", line: 1090 },
		{ fn: "dicom_object::collector::DicomCollector<std::io::buffered::bufreader::BufReader<S>,D,R>::collect_to_object", file: "[...]/dicom-object-0.9.0/src/collector.rs", line: 1075 },
		{ fn: "dicom_object::collector::DicomCollector<std::io::buffered::bufreader::BufReader<S>,D,R>::read_dataset_up_to", file: "[...]/dicom-object-0.9.0/src/collector.rs", line: 821 },
		{ fn: "dicom_object::collector::DicomCollector<std::io::buffered::bufreader::BufReader<S>,D,R>::read_dataset_up_to_pixeldata", file: "[...]/dicom-object-0.9.0/src/collector.rs", line: 836 },
		...
	] 
} })
```

The backtrace indicated that line 631 of `lazy_read.rs` was responsible. Specifically the `LazyDataSetReader::peek` method when `match self.advance()` was triggering a hard break. I found this happened when self.advance() returned a LazyDataToken::PixelSequenceStart for an encapsulated pixel sequence header. 

https://github.com/Enet4/dicom-rs/blob/840790a0c9fafe2cc46001b8f850e899787dc8dc/parser/src/dataset/lazy_read.rs#L595-L637

I added an entry to the match statement to catch the LazyDataToken::PixelSequenceStart:
```rust
LazyDataToken::PixelSequenceStart => {
	self.peek = Some(DataToken::PixelSequenceStart);
}
```

And now got a new error from the match statement at the start of the `LazyDataSetReader::advance` method.

https://github.com/Enet4/dicom-rs/blob/840790a0c9fafe2cc46001b8f850e899787dc8dc/parser/src/dataset/lazy_read.rs#L315-L336

I confirmed this was erroring when the token was a DataToken::PixelSequenceStart and added a case to handle it:
```rust
DataToken::PixelSequenceStart => LazyDataToken::PixelSequenceStart
```

I confirmed the token was now correctly matching against the statement on line 442 here:

https://github.com/Enet4/dicom-rs/blob/840790a0c9fafe2cc46001b8f850e899787dc8dc/parser/src/dataset/lazy_read.rs#L441-L447

Finally, I added a minimal test case in `dicom_object/collector.rs` to test this behavior on a DICOM from the `dicom_test_files` crate. Before applying the fix, this test fails when `collector.read_dataset_up_to_pixeldata()` is called. After applying the fix, the test successfully reads up to the pixel data, then reads the remainder of the file with `collector.read_dataset_to_end()`. I ran `cargo test` and confirmed that all existing tests pass.