### PR TITLE
[ul] Run `cargo fmt` on some files

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -12,25 +12,23 @@ use std::{
     time::Duration,
 };
 
-use crate::{
-    AeAddr, IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME, association::{
-        Association, NegotiatedOptions, SocketOptions, SyncAssociation, encode_pdu,
-        private::SyncAssociationSealed, read_pdu_from_wire,
-    }, pdu::{
-        AbortRQSource, AssociationAC, AssociationRQ, DEFAULT_MAX_PDU, LARGE_PDU_SIZE,
-        PDU_HEADER_SIZE, Pdu, PresentationContextNegotiated, PresentationContextProposed,
-        PresentationContextResultReason, UserIdentity, UserIdentityType, UserVariableItem,
-        write_pdu,
-    }
-};
 #[cfg(feature = "async")]
 use crate::association::AsyncAssociation;
+use crate::{
+    association::{
+        encode_pdu, private::SyncAssociationSealed, read_pdu_from_wire, Association,
+        NegotiatedOptions, SocketOptions, SyncAssociation,
+    },
+    pdu::{
+        write_pdu, AbortRQSource, AssociationAC, AssociationRQ, Pdu, PresentationContextNegotiated,
+        PresentationContextProposed, PresentationContextResultReason, UserIdentity,
+        UserIdentityType, UserVariableItem, DEFAULT_MAX_PDU, LARGE_PDU_SIZE, PDU_HEADER_SIZE,
+    },
+    AeAddr, IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
+};
 use snafu::{ensure, ResultExt};
 
-use super::{
-    uid::trim_uid,
-    Result,
-};
+use super::{uid::trim_uid, Result};
 
 // stray module from 0.9.0, remove in 0.10.0
 #[deprecated(since = "0.9.1")]
@@ -44,15 +42,16 @@ pub type AsyncTlsStream = tokio_rustls::client::TlsStream<tokio::net::TcpStream>
 pub use crate::association::CloseSocket;
 
 /// Helper function to establish a TCP client connection
-fn tcp_connection<T>(
-    ae_address: &AeAddr<T>,
-    opts: &SocketOptions,
-) -> Result<TcpStream> where T: ToSocketAddrs
+fn tcp_connection<T>(ae_address: &AeAddr<T>, opts: &SocketOptions) -> Result<TcpStream>
+where
+    T: ToSocketAddrs,
 {
     // NOTE: TcpStream::connect_timeout needs a single SocketAddr, whereas TcpStream::connect can
-    // take multiple 
+    // take multiple
     let conn_result: Result<TcpStream> = if let Some(timeout) = opts.connection_timeout {
-        let addresses = ae_address.to_socket_addrs().context(super::ToAddressSnafu)?;
+        let addresses = ae_address
+            .to_socket_addrs()
+            .context(super::ToAddressSnafu)?;
         let mut result = Result::Err(std::io::Error::from(std::io::ErrorKind::AddrNotAvailable));
         for address in addresses {
             result = TcpStream::connect_timeout(&address, timeout);
@@ -74,7 +73,6 @@ fn tcp_connection<T>(
         .context(super::SetWriteTimeoutSnafu)?;
 
     Ok(socket)
-
 }
 
 /// Helper function to establish a TLS client connection
@@ -84,16 +82,19 @@ fn tls_connection<T>(
     server_name: &str,
     opts: &SocketOptions,
     tls_config: std::sync::Arc<rustls::ClientConfig>,
-) -> Result<TlsStream> where T: ToSocketAddrs{
+) -> Result<TlsStream>
+where
+    T: ToSocketAddrs,
+{
     use std::convert::TryFrom;
 
-    let socket =  tcp_connection(ae_address, opts)?;
+    let socket = tcp_connection(ae_address, opts)?;
     let server_name = rustls::pki_types::ServerName::try_from(server_name.to_string())
         .context(super::InvalidServerNameSnafu)?;
-    
+
     let conn = rustls::ClientConnection::new(tls_config.clone(), server_name)
         .context(super::TlsConnectionSnafu)?;
-        
+
     Ok(rustls::StreamOwned::new(conn, socket))
 }
 
@@ -129,7 +130,7 @@ fn tls_connection<T>(
 /// ```
 ///
 /// ### Asynchronous API
-/// 
+///
 /// Include the `async` feature in your `Cargo.toml`
 ///
 /// ```no_run
@@ -147,22 +148,22 @@ fn tls_connection<T>(
 /// # Ok(())
 /// # }
 /// ```
-/// 
+///
 /// ## TLS Support
-/// 
+///
 /// Enabling one of the Cargo features `sync-tls` or `async-tls`
 /// unlocks the methods for configuring TLS.
 /// Call `tls_config` and `server_name`
 /// to establish the association over a secure transport connection.
 ///
 /// ### TLS in synchronous API
-/// 
+///
 /// Include the `sync-tls` feature in your `Cargo.toml`.
-/// 
+///
 /// ### TLS in asynchronous API
-/// 
+///
 /// Include the `async-tls` feature in your `Cargo.toml`.
-/// 
+///
 /// ### Example
 ///
 /// ```no_run
@@ -515,8 +516,7 @@ impl<'a> ClientAssociationOptions<'a> {
     pub fn establish<A: ToSocketAddrs>(
         self,
         address: A,
-    ) -> Result<ClientAssociation<std::net::TcpStream>> 
-    {
+    ) -> Result<ClientAssociation<std::net::TcpStream>> {
         let addr = AeAddr::new_socket_addr(address);
         let socket = tcp_connection(&addr, &self.socket_options)?;
         self.establish_impl(addr, socket)
@@ -527,17 +527,17 @@ impl<'a> ClientAssociationOptions<'a> {
     /// negotiating the presentation contexts in the process.
     #[cfg(feature = "sync-tls")]
     pub fn establish_tls<A: ToSocketAddrs>(
-        self, address: A
+        self,
+        address: A,
     ) -> Result<ClientAssociation<TlsStream>> {
         match (&self.tls_config, &self.server_name) {
             (Some(tls_config), Some(server_name)) => {
                 let addr = AeAddr::new_socket_addr(address);
-                let socket = tls_connection(
-                    &addr, server_name, &self.socket_options, tls_config.clone()
-                )?;
+                let socket =
+                    tls_connection(&addr, server_name, &self.socket_options, tls_config.clone())?;
                 self.establish_impl(addr, socket)
-            },
-            _ => super::TlsConfigMissingSnafu.fail()?
+            }
+            _ => super::TlsConfigMissingSnafu.fail()?,
         }
     }
 
@@ -565,23 +565,19 @@ impl<'a> ClientAssociationOptions<'a> {
     /// # }
     /// ```
     #[allow(unreachable_patterns)]
-    pub fn establish_with(
-        self,
-        ae_address: &str,
-    ) -> Result<ClientAssociation<TcpStream>> {
+    pub fn establish_with(self, ae_address: &str) -> Result<ClientAssociation<TcpStream>> {
         match ae_address.try_into() {
             Ok(ae_address) => {
                 let socket = tcp_connection(&ae_address, &self.socket_options)?;
                 self.establish_impl(ae_address, socket)
-            },
+            }
             Err(_) => {
                 let addr = AeAddr::new_socket_addr(ae_address);
                 let socket = tcp_connection(&addr, &self.socket_options)?;
                 self.establish_impl(addr, socket)
-            },
+            }
         }
     }
-
 
     /// Initiate TLS connection to the given address
     /// and request a new DICOM association,
@@ -608,30 +604,30 @@ impl<'a> ClientAssociationOptions<'a> {
     /// ```
     #[allow(unreachable_patterns)]
     #[cfg(feature = "sync-tls")]
-    pub fn establish_with_tls(
-        self,
-        ae_address: &str,
-    ) -> Result<ClientAssociation<TlsStream>> {
+    pub fn establish_with_tls(self, ae_address: &str) -> Result<ClientAssociation<TlsStream>> {
         match (&self.tls_config, &self.server_name) {
-            (Some(tls_config), Some(server_name)) => {
-                match ae_address.try_into() {
-                    Ok(ae_address) => {
-                        let socket = tls_connection(
-                            &ae_address, server_name, &self.socket_options, tls_config.clone()
-                        )?;
-                        self.establish_impl(ae_address, socket)
-                    },
-                    Err(_) => {
-                        let addr = AeAddr::new_socket_addr(ae_address);
-                        let socket = tls_connection(
-                            &addr, server_name, &self.socket_options, tls_config.clone()
-                        )?;
-                        self.establish_impl(addr, socket)
-                    },
+            (Some(tls_config), Some(server_name)) => match ae_address.try_into() {
+                Ok(ae_address) => {
+                    let socket = tls_connection(
+                        &ae_address,
+                        server_name,
+                        &self.socket_options,
+                        tls_config.clone(),
+                    )?;
+                    self.establish_impl(ae_address, socket)
                 }
-
+                Err(_) => {
+                    let addr = AeAddr::new_socket_addr(ae_address);
+                    let socket = tls_connection(
+                        &addr,
+                        server_name,
+                        &self.socket_options,
+                        tls_config.clone(),
+                    )?;
+                    self.establish_impl(addr, socket)
+                }
             },
-            _ => super::TlsConfigMissingSnafu.fail()?
+            _ => super::TlsConfigMissingSnafu.fail()?,
         }
     }
 
@@ -826,13 +822,15 @@ impl<'a> ClientAssociationOptions<'a> {
                     peer_ae_title: called_ae_title,
                 })
             }
-            Pdu::AssociationRJ(association_rj) => crate::association::RejectedSnafu { association_rj }.fail(),
+            Pdu::AssociationRJ(association_rj) => {
+                crate::association::RejectedSnafu { association_rj }.fail()
+            }
             pdu @ Pdu::AbortRQ { .. }
             | pdu @ Pdu::ReleaseRQ
             | pdu @ Pdu::AssociationRQ { .. }
             | pdu @ Pdu::PData { .. }
             | pdu @ Pdu::ReleaseRP => crate::association::UnexpectedPduSnafu { pdu }.fail(),
-            pdu @ Pdu::Unknown { .. } => crate::association::UnknownPduSnafu { pdu }.fail()
+            pdu @ Pdu::Unknown { .. } => crate::association::UnknownPduSnafu { pdu }.fail(),
         }
     }
 
@@ -840,7 +838,7 @@ impl<'a> ClientAssociationOptions<'a> {
     fn establish_impl<T, S>(
         self,
         ae_address: AeAddr<T>,
-        mut socket: S
+        mut socket: S,
     ) -> Result<ClientAssociation<S>>
     where
         T: ToSocketAddrs,
@@ -870,8 +868,13 @@ impl<'a> ClientAssociationOptions<'a> {
                 let _ = socket.write_all(&buffer);
                 buffer.clear();
                 Err(e)
-            },
-            Ok(NegotiatedOptions{presentation_contexts, peer_max_pdu_length, user_variables, peer_ae_title}) => {
+            }
+            Ok(NegotiatedOptions {
+                presentation_contexts,
+                peer_max_pdu_length,
+                user_variables,
+                peer_ae_title,
+            }) => {
                 Ok(ClientAssociation {
                     presentation_contexts,
                     requestor_max_pdu_length: self.max_pdu_length,
@@ -991,7 +994,8 @@ pub struct ClientAssociation<S> {
 }
 
 impl<S> Association for ClientAssociation<S>
-where S: CloseSocket + std::io::Read + std::io::Write,
+where
+    S: CloseSocket + std::io::Read + std::io::Write,
 {
     fn peer_ae_title(&self) -> &str {
         &self.peer_ae_title
@@ -1031,7 +1035,8 @@ where S: CloseSocket + std::io::Read + std::io::Write,
 }
 
 impl<S> ClientAssociation<S>
-where S: CloseSocket + std::io::Read + std::io::Write,
+where
+    S: CloseSocket + std::io::Read + std::io::Write,
 {
     /// Retrieve read timeout for the association
     pub fn read_timeout(&self) -> Option<Duration> {
@@ -1071,7 +1076,8 @@ where S: CloseSocket + std::io::Read + std::io::Write,
 
 // compatibility filler, remove in 0.10.0
 impl<S> ClientAssociation<S>
-where S: CloseSocket + std::io::Read + std::io::Write,
+where
+    S: CloseSocket + std::io::Read + std::io::Write,
 {
     /// Send a PDU message to the other intervenient.
     pub fn send(&mut self, pdu: &Pdu) -> Result<()> {
@@ -1139,17 +1145,30 @@ where S: CloseSocket + std::io::Read + std::io::Write,
 }
 
 impl<S> SyncAssociationSealed<S> for ClientAssociation<S>
-where S: CloseSocket + std::io::Read + std::io::Write{
+where
+    S: CloseSocket + std::io::Read + std::io::Write,
+{
     /// Send a PDU message to the other intervenient.
     fn send(&mut self, pdu: &Pdu) -> Result<()> {
         self.write_buffer.clear();
-        encode_pdu(&mut self.write_buffer, pdu, self.acceptor_max_pdu_length + PDU_HEADER_SIZE)?;
-        self.socket.write_all(&self.write_buffer).context(super::WireSendSnafu)
+        encode_pdu(
+            &mut self.write_buffer,
+            pdu,
+            self.acceptor_max_pdu_length + PDU_HEADER_SIZE,
+        )?;
+        self.socket
+            .write_all(&self.write_buffer)
+            .context(super::WireSendSnafu)
     }
 
     /// Read a PDU message from the other intervenient.
     fn receive(&mut self) -> Result<Pdu> {
-        read_pdu_from_wire(&mut self.socket, &mut self.read_buffer, self.requestor_max_pdu_length, self.strict)
+        read_pdu_from_wire(
+            &mut self.socket,
+            &mut self.read_buffer,
+            self.requestor_max_pdu_length,
+            self.strict,
+        )
     }
 
     fn close(&mut self) -> std::io::Result<()> {
@@ -1158,13 +1177,19 @@ where S: CloseSocket + std::io::Read + std::io::Write{
 }
 
 impl<S> SyncAssociation<S> for ClientAssociation<S>
-where S: CloseSocket + std::io::Read + std::io::Write{
+where
+    S: CloseSocket + std::io::Read + std::io::Write,
+{
     fn inner_stream(&mut self) -> &mut S {
         &mut self.socket
     }
 
     fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
-        let Self { socket, read_buffer, .. } = self;
+        let Self {
+            socket,
+            read_buffer,
+            ..
+        } = self;
         (socket, read_buffer)
     }
 }
@@ -1188,12 +1213,16 @@ impl Release for ClientAssociation<std::net::TcpStream> {
 pub(crate) async fn async_connection<T>(
     ae_address: &AeAddr<T>,
     opts: &SocketOptions,
-) -> Result<tokio::net::TcpStream> where T: tokio::net::ToSocketAddrs{
+) -> Result<tokio::net::TcpStream>
+where
+    T: tokio::net::ToSocketAddrs,
+{
     super::timeout(opts.connection_timeout, async {
         tokio::net::TcpStream::connect(ae_address.socket_addr())
             .await
             .context(crate::association::ConnectSnafu)
-    }).await
+    })
+    .await
 }
 
 /// Initiate TLS connection to the given address
@@ -1207,8 +1236,8 @@ pub(crate) async fn async_tls_connection<T>(
 where
     T: tokio::net::ToSocketAddrs,
 {
-    use std::convert::TryFrom;
     use rustls::pki_types::ServerName;
+    use std::convert::TryFrom;
 
     let tcp_stream = async_connection(ae_address, opts).await?;
     let connector = tokio_rustls::TlsConnector::from(tls_config);
@@ -1269,7 +1298,7 @@ impl<'a> ClientAssociationOptions<'a> {
     async fn establish_impl_async<T, S>(
         self,
         ae_address: AeAddr<T>,
-        mut socket: S
+        mut socket: S,
     ) -> Result<AsyncClientAssociation<S>>
     where
         T: tokio::net::ToSocketAddrs,
@@ -1280,14 +1309,15 @@ impl<'a> ClientAssociationOptions<'a> {
         let mut write_buffer: Vec<u8> = Vec::with_capacity(DEFAULT_MAX_PDU as usize);
 
         // send request
-        write_pdu(&mut write_buffer, &a_associate)
-            .context(crate::association::SendPduSnafu)?;
+        write_pdu(&mut write_buffer, &a_associate).context(crate::association::SendPduSnafu)?;
         super::timeout(self.socket_options.write_timeout, async {
-            socket.write_all(&write_buffer)
+            socket
+                .write_all(&write_buffer)
                 .await
                 .context(crate::association::WireSendSnafu)?;
             Ok(())
-        }).await?;
+        })
+        .await?;
         write_buffer.clear();
 
         // read buffer is prepared according to the requestor's max pdu length
@@ -1295,7 +1325,13 @@ impl<'a> ClientAssociationOptions<'a> {
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
         let resp = super::timeout(self.socket_options.read_timeout, async {
-            super::read_pdu_from_wire_async(&mut socket, &mut read_buffer, self.max_pdu_length, self.strict).await
+            super::read_pdu_from_wire_async(
+                &mut socket,
+                &mut read_buffer,
+                self.max_pdu_length,
+                self.strict,
+            )
+            .await
         })
         .await?;
         let negotiated_options = self.process_a_association_resp(resp, &pc_proposed);
@@ -1308,13 +1344,19 @@ impl<'a> ClientAssociationOptions<'a> {
                         source: AbortRQSource::ServiceUser,
                     },
                 );
-                socket.write_all(&write_buffer)
+                socket
+                    .write_all(&write_buffer)
                     .await
                     .context(crate::association::WireSendSnafu)?;
                 write_buffer.clear();
                 Err(e)
-            },
-            Ok(NegotiatedOptions{presentation_contexts, peer_max_pdu_length, user_variables, peer_ae_title}) => {
+            }
+            Ok(NegotiatedOptions {
+                presentation_contexts,
+                peer_max_pdu_length,
+                user_variables,
+                peer_ae_title,
+            }) => {
                 Ok(AsyncClientAssociation {
                     presentation_contexts,
                     requestor_max_pdu_length: self.max_pdu_length,
@@ -1327,7 +1369,7 @@ impl<'a> ClientAssociationOptions<'a> {
                     read_timeout: self.socket_options.read_timeout,
                     write_timeout: self.socket_options.write_timeout,
                     user_variables,
-                    peer_ae_title
+                    peer_ae_title,
                 })
             }
         }
@@ -1342,8 +1384,7 @@ impl<'a> ClientAssociationOptions<'a> {
     ) -> Result<AsyncClientAssociation<tokio::net::TcpStream>> {
         let addr = AeAddr::new_socket_addr(address);
         let socket = async_connection(&addr, &self.socket_options).await?;
-        self.establish_impl_async(addr, socket)
-            .await
+        self.establish_impl_async(addr, socket).await
     }
 
     /// Initiate the TCP connection to the given address
@@ -1358,12 +1399,15 @@ impl<'a> ClientAssociationOptions<'a> {
             (Some(tls_config), Some(server_name)) => {
                 let addr = AeAddr::new_socket_addr(address);
                 let socket = async_tls_connection(
-                    &addr, server_name, &self.socket_options, tls_config.clone()
-                ).await?;
-                self.establish_impl_async(addr, socket)
-                    .await
-            },
-            _ => crate::association::TlsConfigMissingSnafu.fail()?
+                    &addr,
+                    server_name,
+                    &self.socket_options,
+                    tls_config.clone(),
+                )
+                .await?;
+                self.establish_impl_async(addr, socket).await
+            }
+            _ => crate::association::TlsConfigMissingSnafu.fail()?,
         }
     }
 
@@ -1401,12 +1445,11 @@ impl<'a> ClientAssociationOptions<'a> {
             Ok(ae_address) => {
                 let socket = async_connection(&ae_address, &self.socket_options).await?;
                 self.establish_impl_async(ae_address, socket).await
-            },
+            }
             Err(_) => {
                 let addr = AeAddr::new_socket_addr(ae_address);
                 let socket = async_connection(&addr, &self.socket_options).await?;
-                self.establish_impl_async(addr, socket)
-                    .await
+                self.establish_impl_async(addr, socket).await
             }
         }
     }
@@ -1443,25 +1486,30 @@ impl<'a> ClientAssociationOptions<'a> {
         ae_address: &str,
     ) -> Result<AsyncClientAssociation<AsyncTlsStream>> {
         match (&self.tls_config, &self.server_name) {
-            (Some(tls_config), Some(server_name)) => {
-                match ae_address.try_into() {
-                    Ok(ae_address) => {
-                        let socket = async_tls_connection(
-                            &ae_address, server_name, &self.socket_options, tls_config.clone()
-                        ).await?;
-                        self.establish_impl_async(ae_address, socket).await
-                    },
-                    Err(_) => {
-                        let addr = AeAddr::new_socket_addr(ae_address);
-                        let socket = async_tls_connection(
-                            &addr, server_name, &self.socket_options, tls_config.clone()
-                        ).await?;
-                        self.establish_impl_async(addr, socket).await
-                    },
+            (Some(tls_config), Some(server_name)) => match ae_address.try_into() {
+                Ok(ae_address) => {
+                    let socket = async_tls_connection(
+                        &ae_address,
+                        server_name,
+                        &self.socket_options,
+                        tls_config.clone(),
+                    )
+                    .await?;
+                    self.establish_impl_async(ae_address, socket).await
                 }
-
+                Err(_) => {
+                    let addr = AeAddr::new_socket_addr(ae_address);
+                    let socket = async_tls_connection(
+                        &addr,
+                        server_name,
+                        &self.socket_options,
+                        tls_config.clone(),
+                    )
+                    .await?;
+                    self.establish_impl_async(addr, socket).await
+                }
             },
-            _ => crate::association::TlsConfigMissingSnafu.fail()?
+            _ => crate::association::TlsConfigMissingSnafu.fail()?,
         }
     }
 }
@@ -1546,9 +1594,9 @@ impl<S> AsyncClientAssociation<S> {
 // compatibility filler, remove in 0.10.0
 #[cfg(feature = "async")]
 impl<S> AsyncClientAssociation<S>
-where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
 {
-
     /// Obtain access to the inner stream
     /// connected to the association acceptor.
     ///
@@ -1616,13 +1664,18 @@ where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
 
 #[cfg(feature = "async")]
 impl<S> super::private::AsyncAssociationSealed<S> for AsyncClientAssociation<S>
-where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
 {
     async fn send(&mut self, msg: &Pdu) -> Result<()> {
         use tokio::io::AsyncWriteExt;
 
         self.write_buffer.clear();
-        encode_pdu(&mut self.write_buffer, msg, self.acceptor_max_pdu_length + PDU_HEADER_SIZE)?;
+        encode_pdu(
+            &mut self.write_buffer,
+            msg,
+            self.acceptor_max_pdu_length + PDU_HEADER_SIZE,
+        )?;
         super::timeout(self.write_timeout, async {
             self.socket
                 .write_all(&self.write_buffer)
@@ -1639,8 +1692,9 @@ where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
                 &mut self.socket,
                 &mut self.read_buffer,
                 self.requestor_max_pdu_length,
-                self.strict
-            ).await
+                self.strict,
+            )
+            .await
         })
         .await
     }
@@ -1653,14 +1707,19 @@ where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
 
 #[cfg(feature = "async")]
 impl<S> AsyncAssociation<S> for AsyncClientAssociation<S>
-where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send{
-
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
+{
     fn inner_stream(&mut self) -> &mut S {
         &mut self.socket
     }
 
     fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
-        let Self { socket, read_buffer, .. } = self;
+        let Self {
+            socket,
+            read_buffer,
+            ..
+        } = self;
         (socket, read_buffer)
     }
 }
@@ -1671,7 +1730,6 @@ mod tests {
     #[cfg(feature = "async")]
     use crate::association::read_pdu_from_wire_async;
     use std::io::Write;
-
 
     impl<'a> ClientAssociationOptions<'a> {
         pub(crate) fn establish_with_extra_pdus<T>(
@@ -1691,7 +1749,9 @@ mod tests {
             for pdu in extra_pdus {
                 write_pdu(&mut write_buffer, &pdu).context(crate::association::SendPduSnafu)?;
             }
-            socket.write_all(&write_buffer).context(crate::association::WireSendSnafu)?;
+            socket
+                .write_all(&write_buffer)
+                .context(crate::association::WireSendSnafu)?;
             write_buffer.clear();
 
             let mut read_buffer = BytesMut::with_capacity(
@@ -1707,7 +1767,7 @@ mod tests {
                 presentation_contexts,
                 peer_max_pdu_length,
                 user_variables,
-                peer_ae_title
+                peer_ae_title,
             } = self
                 .process_a_association_resp(resp, &pc_proposed)
                 .expect("Failed to process a associate response");
@@ -1723,7 +1783,7 @@ mod tests {
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
                 user_variables,
-                peer_ae_title
+                peer_ae_title,
             })
         }
 
@@ -1747,7 +1807,10 @@ mod tests {
             for pdu in extra_pdus {
                 write_pdu(&mut buffer, &pdu).context(crate::association::SendPduSnafu)?;
             }
-            socket.write_all(&buffer).await.context(crate::association::WireSendSnafu)?;
+            socket
+                .write_all(&buffer)
+                .await
+                .context(crate::association::WireSendSnafu)?;
             buffer.clear();
 
             let mut buf = BytesMut::with_capacity(
@@ -1760,7 +1823,7 @@ mod tests {
                 presentation_contexts,
                 peer_max_pdu_length,
                 user_variables,
-                peer_ae_title
+                peer_ae_title,
             } = self
                 .process_a_association_resp(resp, &pc_proposed)
                 .expect("Failed to process a associate response");
@@ -1776,7 +1839,7 @@ mod tests {
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
                 user_variables,
-                peer_ae_title
+                peer_ae_title,
             })
         }
 
@@ -1793,7 +1856,9 @@ mod tests {
             let mut buffer: Vec<u8> = Vec::with_capacity(DEFAULT_MAX_PDU as usize);
             // send request
             write_pdu(&mut buffer, &a_associate).context(crate::association::SendPduSnafu)?;
-            socket.write_all(&buffer).context(crate::association::WireSendSnafu)?;
+            socket
+                .write_all(&buffer)
+                .context(crate::association::WireSendSnafu)?;
             buffer.clear();
 
             let mut buf = BytesMut::with_capacity(
@@ -1804,7 +1869,7 @@ mod tests {
                 presentation_contexts,
                 peer_max_pdu_length,
                 user_variables,
-                peer_ae_title
+                peer_ae_title,
             } = self
                 .process_a_association_resp(resp, &pc_proposed)
                 .expect("Failed to process a associate response");
@@ -1821,7 +1886,7 @@ mod tests {
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
                 user_variables,
-                peer_ae_title
+                peer_ae_title,
             })
         }
 
@@ -1841,7 +1906,10 @@ mod tests {
             let mut buffer: Vec<u8> = Vec::with_capacity(DEFAULT_MAX_PDU as usize);
             // send request
             write_pdu(&mut buffer, &a_associate).context(crate::association::SendPduSnafu)?;
-            socket.write_all(&buffer).await.context(crate::association::WireSendSnafu)?;
+            socket
+                .write_all(&buffer)
+                .await
+                .context(crate::association::WireSendSnafu)?;
             buffer.clear();
 
             let mut buf = BytesMut::with_capacity(
@@ -1854,7 +1922,7 @@ mod tests {
                 presentation_contexts,
                 peer_max_pdu_length,
                 user_variables,
-                peer_ae_title
+                peer_ae_title,
             } = self
                 .process_a_association_resp(resp, &pc_proposed)
                 .expect("Failed to process a associate response");
@@ -1871,7 +1939,7 @@ mod tests {
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
                 user_variables,
-                peer_ae_title
+                peer_ae_title,
             })
         }
     }

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -27,22 +27,26 @@ pub(crate) mod pdata;
 
 use std::{
     backtrace::Backtrace,
-    io::{BufRead, BufReader, Cursor, Read}, time::Duration,
+    io::{BufRead, BufReader, Cursor, Read},
+    time::Duration,
 };
 
 use bytes::{Buf, BytesMut};
-pub use pdata::{PDataReader, PDataWriter};
-pub use client::{ClientAssociation, ClientAssociationOptions};
-pub use server::{ServerAssociation, ServerAssociationOptions};
-#[cfg(feature = "async")]
-pub use pdata::non_blocking::AsyncPDataWriter;
 #[cfg(feature = "async")]
 pub use client::AsyncClientAssociation;
+pub use client::{ClientAssociation, ClientAssociationOptions};
+#[cfg(feature = "async")]
+pub use pdata::non_blocking::AsyncPDataWriter;
+pub use pdata::{PDataReader, PDataWriter};
 #[cfg(feature = "async")]
 pub use server::AsyncServerAssociation;
+pub use server::{ServerAssociation, ServerAssociationOptions};
 use snafu::{ensure, ResultExt, Snafu};
 
-use crate::{Pdu, pdu::{self, AssociationRJ, PresentationContextNegotiated, ReadPduSnafu, UserVariableItem}, write_pdu};
+use crate::{
+    pdu::{self, AssociationRJ, PresentationContextNegotiated, ReadPduSnafu, UserVariableItem},
+    write_pdu, Pdu,
+};
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -148,7 +152,7 @@ pub enum Error {
     #[snafu(display("failed close connection: {}", source))]
     Close {
         source: std::io::Error,
-        backtrace: Backtrace
+        backtrace: Backtrace,
     },
 
     #[snafu(display(
@@ -169,21 +173,21 @@ pub enum Error {
     /// Invalid server name for TLS
     #[cfg(feature = "sync-tls")]
     #[snafu(display("Invalid server name for TLS connection"))]
-    InvalidServerName { 
+    InvalidServerName {
         source: rustls::pki_types::InvalidDnsNameError,
-        backtrace: Backtrace 
+        backtrace: Backtrace,
     },
 
     /// Failed to establish TLS connection
     #[cfg(feature = "sync-tls")]
     #[snafu(display("Failed to establish TLS connection: {:?}", source))]
-    TlsConnection { 
+    TlsConnection {
         source: rustls::Error,
-        backtrace: Backtrace 
+        backtrace: Backtrace,
     },
 }
 /// Struct to hold negotiated options after association is accepted
-pub(crate) struct NegotiatedOptions{
+pub(crate) struct NegotiatedOptions {
     /// Maximum PDU length the peer can handle
     peer_max_pdu_length: u32,
     /// User variables accepted by the peer
@@ -191,7 +195,7 @@ pub(crate) struct NegotiatedOptions{
     /// Presentation contexts accepted by the peer
     presentation_contexts: Vec<PresentationContextNegotiated>,
     /// The peer's AE title
-    peer_ae_title: String
+    peer_ae_title: String,
 }
 
 /// Socket configuration for associations
@@ -217,14 +221,14 @@ impl CloseSocket for std::net::TcpStream {
 }
 
 #[cfg(feature = "sync-tls")]
-impl CloseSocket for rustls::StreamOwned<rustls::ClientConnection, std::net::TcpStream>{
+impl CloseSocket for rustls::StreamOwned<rustls::ClientConnection, std::net::TcpStream> {
     fn close(&mut self) -> std::io::Result<()> {
         self.get_mut().shutdown(std::net::Shutdown::Both)
     }
 }
 
 #[cfg(feature = "sync-tls")]
-impl CloseSocket for rustls::StreamOwned<rustls::ServerConnection, std::net::TcpStream>{
+impl CloseSocket for rustls::StreamOwned<rustls::ServerConnection, std::net::TcpStream> {
     fn close(&mut self) -> std::io::Result<()> {
         self.get_mut().shutdown(std::net::Shutdown::Both)
     }
@@ -272,23 +276,25 @@ pub trait Association {
 }
 
 mod private {
-    use crate::{Pdu, pdu::{AbortRQServiceProviderReason, AbortRQSource}};
-    use snafu::{ResultExt};
+    use crate::{
+        pdu::{AbortRQServiceProviderReason, AbortRQSource},
+        Pdu,
+    };
+    use snafu::ResultExt;
 
     /// Private trait which exposes "unsafe" methods that should not be called by the user
-    /// 
-    /// `close` and `release` _should_ take ownership, and in the public interface, they 
-    /// do. However, in order to implement `Drop` we need to expose a version of these 
+    ///
+    /// `close` and `release` _should_ take ownership, and in the public interface, they
+    /// do. However, in order to implement `Drop` we need to expose a version of these
     /// methods that don't take ownership.
-    /// 
+    ///
     /// `send` and `receive` implementations are needed in order to provide
     /// the implementation for `release`
     pub trait SyncAssociationSealed<S: std::io::Read + std::io::Write + super::CloseSocket> {
-
         fn close(&mut self) -> std::io::Result<()>;
         fn send(&mut self, pdu: &Pdu) -> super::Result<()>;
         fn receive(&mut self) -> super::Result<Pdu>;
-        fn release(&mut self) -> super::Result<()>{
+        fn release(&mut self) -> super::Result<()> {
             let pdu = Pdu::ReleaseRQ;
             self.send(&pdu)?;
             let pdu = self.receive()?;
@@ -303,12 +309,14 @@ mod private {
                 | pdu @ Pdu::ReleaseRQ => return super::UnexpectedPduSnafu { pdu }.fail(),
                 pdu @ Pdu::Unknown { .. } => return super::UnknownPduSnafu { pdu }.fail(),
             }
-            self.close()
-                .context(super::CloseSnafu)?;
+            self.close().context(super::CloseSnafu)?;
             Ok(())
         }
 
-        fn abort(&mut self) -> super::Result<()> where Self: Sized {
+        fn abort(&mut self) -> super::Result<()>
+        where
+            Self: Sized,
+        {
             let pdu = Pdu::AbortRQ {
                 source: AbortRQSource::ServiceProvider(
                     AbortRQServiceProviderReason::ReasonNotSpecified,
@@ -321,23 +329,31 @@ mod private {
     }
 
     /// Private trait which exposes "unsafe" methods that should not be called by the user
-    /// 
-    /// `close` and `release` _should_ take ownership, and in the public interface, they 
-    /// do. However, in order to implement `Drop` we need to expose a version of these 
+    ///
+    /// `close` and `release` _should_ take ownership, and in the public interface, they
+    /// do. However, in order to implement `Drop` we need to expose a version of these
     /// methods that don't take ownership.
-    /// 
+    ///
     /// `send` and `receive` implementations are needed in order to provide
     /// the implementation for `release`
     #[cfg(feature = "async")]
     pub trait AsyncAssociationSealed<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin> {
         fn close(&mut self) -> impl std::future::Future<Output = std::io::Result<()>> + Send
-            where Self: Send;
-        fn send(&mut self, pdu: &Pdu) -> impl std::future::Future<Output=super::Result<()>> + Send 
-            where Self: Send;
-        fn receive(&mut self) -> impl std::future::Future<Output = super::Result<Pdu>> + Send 
-            where Self: Send;
-        fn release(&mut self) -> impl std::future::Future<Output=super::Result<()>> + Send
-            where Self: Send {
+        where
+            Self: Send;
+        fn send(
+            &mut self,
+            pdu: &Pdu,
+        ) -> impl std::future::Future<Output = super::Result<()>> + Send
+        where
+            Self: Send;
+        fn receive(&mut self) -> impl std::future::Future<Output = super::Result<Pdu>> + Send
+        where
+            Self: Send;
+        fn release(&mut self) -> impl std::future::Future<Output = super::Result<()>> + Send
+        where
+            Self: Send,
+        {
             async move {
                 let pdu = Pdu::ReleaseRQ;
                 self.send(&pdu).await?;
@@ -353,15 +369,15 @@ mod private {
                     | pdu @ Pdu::ReleaseRQ => return super::UnexpectedPduSnafu { pdu }.fail(),
                     pdu @ Pdu::Unknown { .. } => return super::UnknownPduSnafu { pdu }.fail(),
                 }
-                self.close()
-                    .await
-                    .context(super::CloseSnafu)?;
+                self.close().await.context(super::CloseSnafu)?;
                 Ok(())
             }
         }
 
-        fn abort(&mut self) -> impl std::future::Future<Output = super::Result<()>> + Send 
-        where Self: Sized + Send {
+        fn abort(&mut self) -> impl std::future::Future<Output = super::Result<()>> + Send
+        where
+            Self: Sized + Send,
+        {
             let pdu = Pdu::AbortRQ {
                 source: AbortRQSource::ServiceProvider(
                     AbortRQServiceProviderReason::ReasonNotSpecified,
@@ -377,8 +393,9 @@ mod private {
 }
 
 /// Trait that represents methods that can be made on a synchronous association.
-pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>: private::SyncAssociationSealed<S> + Association {
-
+pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>:
+    private::SyncAssociationSealed<S> + Association
+{
     /// Obtain access to the inner stream
     /// connected to the association acceptor.
     ///
@@ -394,19 +411,22 @@ pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>: priv
     fn get_mut(&mut self) -> (&mut S, &mut BytesMut);
 
     /// Send a PDU message to the other intervenient.
-    fn send(&mut self, pdu: &Pdu) -> Result<()>{
+    fn send(&mut self, pdu: &Pdu) -> Result<()> {
         private::SyncAssociationSealed::send(self, pdu)
     }
 
     /// Read a PDU message from the other intervenient.
-    fn receive(&mut self) -> Result<Pdu>{
+    fn receive(&mut self) -> Result<Pdu> {
         private::SyncAssociationSealed::receive(self)
     }
 
     /// Send a provider initiated abort message
     /// and shut down the TCP connection,
     /// terminating the association.
-    fn abort(mut self) -> Result<()> where Self: Sized {
+    fn abort(mut self) -> Result<()>
+    where
+        Self: Sized,
+    {
         private::SyncAssociationSealed::abort(&mut self)
     }
 
@@ -419,7 +439,10 @@ pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>: priv
     /// implementers of this trait no longer call this method on [`Drop`],
     /// so remember to call `release` explicitly
     /// at the end of all DIMSE transactions.
-    fn release(mut self) -> Result<()> where Self: Sized {
+    fn release(mut self) -> Result<()>
+    where
+        Self: Sized,
+    {
         private::SyncAssociationSealed::release(&mut self)
     }
 
@@ -428,13 +451,9 @@ pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>: priv
     ///
     /// Returns a writer which automatically
     /// splits the inner data into separate PDUs if necessary.
-    fn send_pdata(&mut self, presentation_context_id: u8) -> PDataWriter<&mut S>{
+    fn send_pdata(&mut self, presentation_context_id: u8) -> PDataWriter<&mut S> {
         let max_pdu_length = self.peer_max_pdu_length();
-        PDataWriter::new(
-            self.inner_stream(),
-            presentation_context_id,
-            max_pdu_length,
-        )
+        PDataWriter::new(self.inner_stream(), presentation_context_id, max_pdu_length)
     }
 
     /// Prepare a P-Data reader for receiving
@@ -442,21 +461,18 @@ pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>: priv
     ///
     /// Returns a reader which automatically
     /// receives more data PDUs once the bytes collected are consumed.
-    fn receive_pdata(&mut self) -> PDataReader<'_, &mut S>{
+    fn receive_pdata(&mut self) -> PDataReader<'_, &mut S> {
         let max_pdu_length = self.local_max_pdu_length();
         let (socket, read_buffer) = self.get_mut();
-        PDataReader::new(
-            socket,
-            max_pdu_length,
-            read_buffer,
-        )
+        PDataReader::new(socket, max_pdu_length, read_buffer)
     }
 }
 
 #[cfg(feature = "async")]
 /// Trait that represents methods that can be made on an asynchronous association.
-pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>: private::AsyncAssociationSealed<S> + Association {
-
+pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>:
+    private::AsyncAssociationSealed<S> + Association
+{
     /// Obtain access to the inner stream
     /// connected to the association acceptor.
     ///
@@ -472,29 +488,29 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     fn get_mut(&mut self) -> (&mut S, &mut BytesMut);
 
     /// Send a PDU message to the other intervenient.
-    fn send(&mut self, pdu: &Pdu) -> impl std::future::Future<Output = Result<()>> + Send 
-    where Self: Send {
-        async move{ 
-            private::AsyncAssociationSealed::send(self, pdu).await
-        }
+    fn send(&mut self, pdu: &Pdu) -> impl std::future::Future<Output = Result<()>> + Send
+    where
+        Self: Send,
+    {
+        async move { private::AsyncAssociationSealed::send(self, pdu).await }
     }
 
     /// Read a PDU message from the other intervenient.
     fn receive(&mut self) -> impl std::future::Future<Output = Result<Pdu>> + Send
-    where Self: Send {
-        async move {
-            private::AsyncAssociationSealed::receive(self).await
-        }
+    where
+        Self: Send,
+    {
+        async move { private::AsyncAssociationSealed::receive(self).await }
     }
 
     /// Send a provider initiated abort message
     /// and shut down the TCP connection,
     /// terminating the association.
-    fn abort(mut self) -> impl std::future::Future<Output = Result<()>> + Send 
-    where Self: Sized + Send {
-        async move {
-            private::AsyncAssociationSealed::abort(&mut self).await
-        }
+    fn abort(mut self) -> impl std::future::Future<Output = Result<()>> + Send
+    where
+        Self: Sized + Send,
+    {
+        async move { private::AsyncAssociationSealed::abort(&mut self).await }
     }
 
     /// Iniate a graceful release of the association.
@@ -506,11 +522,11 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     /// do not try to release the association on [`Drop`],
     /// so remember to call `release` explicitly
     /// at the end of all DIMSE transactions.
-    fn release(mut self) -> impl std::future::Future<Output = Result<()>> + Send 
-    where Self: Sized + Send {
-        async move {
-            private::AsyncAssociationSealed::release(&mut self).await
-        }
+    fn release(mut self) -> impl std::future::Future<Output = Result<()>> + Send
+    where
+        Self: Sized + Send,
+    {
+        async move { private::AsyncAssociationSealed::release(&mut self).await }
     }
 
     /// Prepare a P-Data writer for sending
@@ -518,13 +534,9 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     ///
     /// Returns a writer which automatically
     /// splits the inner data into separate PDUs if necessary.
-    fn send_pdata(&mut self, presentation_context_id: u8) -> AsyncPDataWriter<&mut S>{
+    fn send_pdata(&mut self, presentation_context_id: u8) -> AsyncPDataWriter<&mut S> {
         let max_pdu_length = self.peer_max_pdu_length();
-        AsyncPDataWriter::new(
-            self.inner_stream(),
-            presentation_context_id,
-            max_pdu_length,
-        )
+        AsyncPDataWriter::new(self.inner_stream(), presentation_context_id, max_pdu_length)
     }
 
     /// Prepare a P-Data reader for receiving
@@ -532,14 +544,10 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     ///
     /// Returns a reader which automatically
     /// receives more data PDUs once the bytes collected are consumed.
-    fn receive_pdata(&mut self) -> PDataReader<'_, &mut S>{
+    fn receive_pdata(&mut self) -> PDataReader<'_, &mut S> {
         let max_pdu_length = self.local_max_pdu_length();
         let (socket, read_buffer) = self.get_mut();
-        PDataReader::new(
-            socket,
-            max_pdu_length,
-            read_buffer,
-        )
+        PDataReader::new(socket, max_pdu_length, read_buffer)
     }
 }
 
@@ -561,7 +569,7 @@ async fn timeout<T>(
 
 /// Encode a PDU into the provided buffer
 pub(crate) fn encode_pdu(buffer: &mut Vec<u8>, pdu: &Pdu, peer_max_pdu_length: u32) -> Result<()> {
-    write_pdu( buffer, pdu).context(SendPduSnafu)?;
+    write_pdu(buffer, pdu).context(SendPduSnafu)?;
     if buffer.len() > peer_max_pdu_length as usize {
         return SendTooLongPduSnafu {
             length: buffer.len(),

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -9,16 +9,15 @@ use std::borrow::Cow;
 use std::time::Duration;
 use std::{io::Write, net::TcpStream};
 
+use crate::association::private::SyncAssociationSealed;
+use crate::association::{
+    encode_pdu, read_pdu_from_wire, AbortedSnafu, Association, CloseSocket,
+    MissingAbstractSyntaxSnafu, RejectedSnafu, SendPduSnafu, SocketOptions, SyncAssociation,
+    UnexpectedPduSnafu, UnknownPduSnafu, WireSendSnafu,
+};
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use snafu::{ensure, ResultExt};
-use crate::association::private::SyncAssociationSealed;
-use crate::association::{
-    Association, CloseSocket, SocketOptions, SyncAssociation, encode_pdu,
-    read_pdu_from_wire, AbortedSnafu, MissingAbstractSyntaxSnafu, RejectedSnafu, SendPduSnafu,
-    UnexpectedPduSnafu,
-    UnknownPduSnafu, WireSendSnafu,
-};
 
 use crate::association::NegotiatedOptions;
 use crate::pdu::{PresentationContextNegotiated, LARGE_PDU_SIZE};
@@ -32,10 +31,7 @@ use crate::{
     IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
 };
 
-use super::{
-    uid::trim_uid,
-    Error, Result
-};
+use super::{uid::trim_uid, Error, Result};
 
 #[cfg(feature = "async")]
 use crate::association::AsyncAssociation;
@@ -115,7 +111,7 @@ impl AccessControl for AcceptCalledAeTitle {
 /// a value of this type can be reused for multiple connections.
 ///
 /// [`ClientAssociationOptions`]: crate::association::ClientAssociationOptions
-/// 
+///
 /// The SCP will by default accept all transfer syntaxes
 /// supported by the main [transfer syntax registry][1],
 /// unless one or more transfer syntaxes are explicitly indicated
@@ -160,7 +156,7 @@ impl AccessControl for AcceptCalledAeTitle {
 /// # Ok(())
 /// # }
 /// ```
-/// 
+///
 /// ### Asynchronous API
 ///
 /// Spawn an async task for each incoming association request.
@@ -211,9 +207,9 @@ impl AccessControl for AcceptCalledAeTitle {
 /// # #[cfg(not(feature = "async"))]
 /// fn main() {}
 /// ```
-/// 
+///
 /// ## TLS Support
-/// 
+///
 /// Enabling one of the Cargo features `sync-tls` or `async-tls`
 /// unlocks the methods for configuring TLS.
 /// Call `tls_config`
@@ -221,13 +217,13 @@ impl AccessControl for AcceptCalledAeTitle {
 /// over a secure transport connection.
 ///
 /// #### TLS in synchronous API
-/// 
+///
 /// Include the `sync-tls` feature in your `Cargo.toml`.
-/// 
+///
 /// #### TLS in asynchronous API
-/// 
+///
 /// Include the `async-tls` feature in your `Cargo.toml`.
-/// 
+///
 /// ### Example
 ///
 /// ```no_run
@@ -246,20 +242,20 @@ impl AccessControl for AcceptCalledAeTitle {
 /// // Loading certificates and keys for demonstration purposes
 /// let ca_cert = CertificateDer::from_pem_slice(std::fs::read("ssl/ca.crt")?.as_ref())
 ///     .expect("Failed to load client cert");
-/// 
+///
 /// // Server certificate and private key -- signed by CA
 /// let server_cert = CertificateDer::from_pem_slice(std::fs::read("ssl/server.crt")?.as_ref())
 ///     .expect("Failed to load server cert");
 ///
 /// let server_private_key = PrivateKeyDer::from_pem_slice(std::fs::read("ssl/server.key")?.as_ref())
 ///     .expect("Failed to load client private key");
-/// 
+///
 /// // Create a root cert store for the client which includes the server certificate
 /// let mut certs = RootCertStore::empty();
 /// certs.add_parsable_certificates(vec![ca_cert.clone()]);
 ///
 /// // Server configuration.
-/// // Creates a server config that requires client authentication (mutual TLS) using 
+/// // Creates a server config that requires client authentication (mutual TLS) using
 /// // webpki for certificate verification.
 /// let server_config = ServerConfig::builder()
 ///     .with_client_cert_verifier(
@@ -269,7 +265,7 @@ impl AccessControl for AcceptCalledAeTitle {
 ///     )
 ///     .with_single_cert(vec![server_cert.clone(), ca_cert.clone()], server_private_key)
 ///     .expect("Failed to create server TLS config");
-/// 
+///
 /// let (stream, _address) = tcp_listener.accept()?;
 ///
 /// let association: ServerAssociation<_> = ServerAssociationOptions::new()
@@ -378,7 +374,7 @@ where
             ae_access_control: _,
             socket_options,
             #[cfg(feature = "sync-tls")]
-            tls_config
+            tls_config,
         } = self;
 
         ServerAssociationOptions {
@@ -393,7 +389,7 @@ where
             promiscuous,
             socket_options,
             #[cfg(feature = "sync-tls")]
-            tls_config
+            tls_config,
         }
     }
 
@@ -627,13 +623,16 @@ where
                         ),
                     ],
                 });
-                Ok((pdu, NegotiatedOptions{
-                    peer_max_pdu_length: requestor_max_pdu_length,
-                    user_variables,
-                    presentation_contexts: presentation_contexts_negotiated,
-                    peer_ae_title: calling_ae_title
-                }))
-            },
+                Ok((
+                    pdu,
+                    NegotiatedOptions {
+                        peer_max_pdu_length: requestor_max_pdu_length,
+                        user_variables,
+                        presentation_contexts: presentation_contexts_negotiated,
+                        peer_ae_title: calling_ae_title,
+                    },
+                ))
+            }
             Pdu::ReleaseRQ => Err((Pdu::ReleaseRP, AbortedSnafu.build())),
             pdu @ Pdu::AssociationAC { .. }
             | pdu @ Pdu::AssociationRJ { .. }
@@ -659,8 +658,7 @@ where
     }
 
     /// Negotiate an association with the given TCP stream.
-    pub fn establish(&self, mut socket: TcpStream) -> Result<ServerAssociation<TcpStream>>
-    {
+    pub fn establish(&self, mut socket: TcpStream) -> Result<ServerAssociation<TcpStream>> {
         ensure!(
             !self.abstract_syntax_uids.is_empty() || self.promiscuous,
             MissingAbstractSyntaxSnafu
@@ -673,17 +671,29 @@ where
             .set_write_timeout(self.socket_options.write_timeout)
             .context(super::SetWriteTimeoutSnafu)?;
 
-
         let mut read_buffer = BytesMut::with_capacity(
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
-        let msg = read_pdu_from_wire(&mut socket, &mut read_buffer, self.max_pdu_length, self.strict)?;
+        let msg = read_pdu_from_wire(
+            &mut socket,
+            &mut read_buffer,
+            self.max_pdu_length,
+            self.strict,
+        )?;
         let mut write_buffer: Vec<u8> = Vec::with_capacity(self.max_pdu_length as usize);
         match self.process_a_association_rq(msg) {
-            Ok((pdu, NegotiatedOptions{ user_variables, presentation_contexts , peer_max_pdu_length, peer_ae_title })) => {
+            Ok((
+                pdu,
+                NegotiatedOptions {
+                    user_variables,
+                    presentation_contexts,
+                    peer_max_pdu_length,
+                    peer_ae_title,
+                },
+            )) => {
                 write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                 socket.write_all(&write_buffer).context(WireSendSnafu)?;
-                Ok(ServerAssociation { 
+                Ok(ServerAssociation {
                     presentation_contexts,
                     requestor_max_pdu_length: peer_max_pdu_length,
                     acceptor_max_pdu_length: self.max_pdu_length,
@@ -711,9 +721,10 @@ where
             !self.abstract_syntax_uids.is_empty() || self.promiscuous,
             MissingAbstractSyntaxSnafu
         );
-        let tls_config = self.tls_config.as_ref().ok_or_else(|| {
-            super::TlsConfigMissingSnafu {}.build()
-        })?;
+        let tls_config = self
+            .tls_config
+            .as_ref()
+            .ok_or_else(|| super::TlsConfigMissingSnafu {}.build())?;
 
         socket
             .set_read_timeout(self.socket_options.read_timeout)
@@ -722,20 +733,33 @@ where
             .set_write_timeout(self.socket_options.write_timeout)
             .context(super::SetWriteTimeoutSnafu)?;
 
-        let conn = rustls::ServerConnection::new(tls_config.clone())
-            .context(super::TlsConnectionSnafu)?;
+        let conn =
+            rustls::ServerConnection::new(tls_config.clone()).context(super::TlsConnectionSnafu)?;
         let mut tls_stream = rustls::StreamOwned::new(conn, socket);
         let mut read_buffer = BytesMut::with_capacity(
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
 
-        let msg = read_pdu_from_wire(&mut tls_stream, &mut read_buffer, self.max_pdu_length, self.strict)?;
+        let msg = read_pdu_from_wire(
+            &mut tls_stream,
+            &mut read_buffer,
+            self.max_pdu_length,
+            self.strict,
+        )?;
         let mut write_buffer: Vec<u8> = Vec::with_capacity(self.max_pdu_length as usize);
         match self.process_a_association_rq(msg) {
-            Ok((pdu, NegotiatedOptions{ user_variables, presentation_contexts , peer_max_pdu_length, peer_ae_title })) => {
+            Ok((
+                pdu,
+                NegotiatedOptions {
+                    user_variables,
+                    presentation_contexts,
+                    peer_max_pdu_length,
+                    peer_ae_title,
+                },
+            )) => {
                 write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                 tls_stream.write_all(&write_buffer).context(WireSendSnafu)?;
-                Ok(ServerAssociation { 
+                Ok(ServerAssociation {
                     presentation_contexts,
                     requestor_max_pdu_length: peer_max_pdu_length,
                     acceptor_max_pdu_length: self.max_pdu_length,
@@ -746,7 +770,7 @@ where
                     read_buffer,
                     user_variables,
                 })
-            },
+            }
             Err((pdu, err)) => {
                 // send the rejection/abort PDU
                 write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
@@ -837,14 +861,19 @@ impl<S> ServerAssociation<S> {
     }
 
     /// Obtain the remote DICOM node's application entity title.
-    #[deprecated(since = "0.9.1", note = "Call `peer_ae_title` from trait `Association`")]
+    #[deprecated(
+        since = "0.9.1",
+        note = "Call `peer_ae_title` from trait `Association`"
+    )]
     pub fn client_ae_title(&self) -> &str {
         &self.client_ae_title
     }
 }
 
 impl<S> ServerAssociation<S>
-where S: std::io::Read + std::io::Write + CloseSocket {
+where
+    S: std::io::Read + std::io::Write + CloseSocket,
+{
     /// Send a PDU message to the other intervenient.
     pub fn send(&mut self, msg: &Pdu) -> Result<()> {
         SyncAssociation::send(self, msg)
@@ -898,8 +927,9 @@ where S: std::io::Read + std::io::Write + CloseSocket {
 }
 
 impl<S> Association for ServerAssociation<S>
-where S: std::io::Read + std::io::Write + CloseSocket{
-
+where
+    S: std::io::Read + std::io::Write + CloseSocket,
+{
     /// Obtain a view of the negotiated presentation contexts.
     fn presentation_contexts(&self) -> &[PresentationContextNegotiated] {
         &self.presentation_contexts
@@ -944,33 +974,51 @@ where S: std::io::Read + std::io::Write + CloseSocket{
 }
 
 impl<S> SyncAssociationSealed<S> for ServerAssociation<S>
-    where S: std::io::Read + std::io::Write + CloseSocket {
+where
+    S: std::io::Read + std::io::Write + CloseSocket,
+{
     fn send(&mut self, pdu: &Pdu) -> Result<()> {
         self.write_buffer.clear();
-        encode_pdu(&mut self.write_buffer, pdu, self.requestor_max_pdu_length + PDU_HEADER_SIZE)?;
-        self.socket.write_all(&self.write_buffer).context(WireSendSnafu)
+        encode_pdu(
+            &mut self.write_buffer,
+            pdu,
+            self.requestor_max_pdu_length + PDU_HEADER_SIZE,
+        )?;
+        self.socket
+            .write_all(&self.write_buffer)
+            .context(WireSendSnafu)
     }
 
     fn receive(&mut self) -> Result<Pdu> {
-        read_pdu_from_wire(&mut self.socket, &mut self.read_buffer, self.acceptor_max_pdu_length, self.strict)
+        read_pdu_from_wire(
+            &mut self.socket,
+            &mut self.read_buffer,
+            self.acceptor_max_pdu_length,
+            self.strict,
+        )
     }
 
-    fn close(&mut self) -> std::io::Result<()>{
+    fn close(&mut self) -> std::io::Result<()> {
         self.socket.close()
     }
 }
 
 impl<S> SyncAssociation<S> for ServerAssociation<S>
-where S: std::io::Read + std::io::Write + CloseSocket,{
+where
+    S: std::io::Read + std::io::Write + CloseSocket,
+{
     fn inner_stream(&mut self) -> &mut S {
         &mut self.socket
     }
 
     fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
-        let Self { socket, read_buffer, .. } = self;
+        let Self {
+            socket,
+            read_buffer,
+            ..
+        } = self;
         (socket, read_buffer)
     }
-
 }
 
 /// Check that a transfer syntax repository
@@ -1030,14 +1078,16 @@ where
     it.into_iter().find(|ts| is_supported(ts.as_ref()))
 }
 
-
 #[cfg(feature = "async")]
 impl<A> ServerAssociationOptions<'_, A>
 where
     A: AccessControl,
 {
     /// Negotiate an association with the given TCP stream.
-    pub async fn establish_async(&self, mut socket: tokio::net::TcpStream) -> Result<AsyncServerAssociation<tokio::net::TcpStream>> {
+    pub async fn establish_async(
+        &self,
+        mut socket: tokio::net::TcpStream,
+    ) -> Result<AsyncServerAssociation<tokio::net::TcpStream>> {
         use tokio::io::AsyncWriteExt;
         ensure!(
             !self.abstract_syntax_uids.is_empty() || self.promiscuous,
@@ -1048,15 +1098,32 @@ where
             let mut read_buffer = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let pdu = super::read_pdu_from_wire_async(&mut socket, &mut read_buffer, self.max_pdu_length, self.strict).await?;
+            let pdu = super::read_pdu_from_wire_async(
+                &mut socket,
+                &mut read_buffer,
+                self.max_pdu_length,
+                self.strict,
+            )
+            .await?;
 
             let mut write_buffer: Vec<u8> =
                 Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
             match self.process_a_association_rq(pdu) {
-                Ok((pdu, NegotiatedOptions{ user_variables, presentation_contexts , peer_max_pdu_length, peer_ae_title})) => {
+                Ok((
+                    pdu,
+                    NegotiatedOptions {
+                        user_variables,
+                        presentation_contexts,
+                        peer_max_pdu_length,
+                        peer_ae_title,
+                    },
+                )) => {
                     write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                    socket.write_all(&write_buffer).await.context(WireSendSnafu)?;
-                    Ok(AsyncServerAssociation { 
+                    socket
+                        .write_all(&write_buffer)
+                        .await
+                        .context(WireSendSnafu)?;
+                    Ok(AsyncServerAssociation {
                         presentation_contexts,
                         requestor_max_pdu_length: peer_max_pdu_length,
                         acceptor_max_pdu_length: self.max_pdu_length,
@@ -1067,50 +1134,76 @@ where
                         read_buffer,
                         read_timeout: self.socket_options.read_timeout,
                         write_timeout: self.socket_options.write_timeout,
-                        user_variables
+                        user_variables,
                     })
-                },
+                }
                 Err((pdu, err)) => {
                     // send the rejection/abort PDU
                     write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                    socket.write_all(&write_buffer).await.context(WireSendSnafu)?;
+                    socket
+                        .write_all(&write_buffer)
+                        .await
+                        .context(WireSendSnafu)?;
                     Err(err)
                 }
             }
-
         };
         super::timeout(read_timeout, task).await
     }
 
     /// Negotiate an association with the given TCP stream.
     #[cfg(feature = "async-tls")]
-    pub async fn establish_tls_async(&self, socket: tokio::net::TcpStream) -> Result<AsyncServerAssociation<AsyncTlsStream>> {
-        use tokio_rustls::TlsAcceptor;
+    pub async fn establish_tls_async(
+        &self,
+        socket: tokio::net::TcpStream,
+    ) -> Result<AsyncServerAssociation<AsyncTlsStream>> {
         use tokio::io::AsyncWriteExt;
+        use tokio_rustls::TlsAcceptor;
 
         ensure!(
             !self.abstract_syntax_uids.is_empty() || self.promiscuous,
             MissingAbstractSyntaxSnafu
         );
-        let tls_config = self.tls_config.as_ref().ok_or_else(|| {
-            crate::association::TlsConfigMissingSnafu {}.build()
-        })?;
+        let tls_config = self
+            .tls_config
+            .as_ref()
+            .ok_or_else(|| crate::association::TlsConfigMissingSnafu {}.build())?;
         let acceptor = TlsAcceptor::from(tls_config.clone());
-        let mut socket = acceptor.accept(socket).await.context(crate::association::ConnectSnafu)?;
+        let mut socket = acceptor
+            .accept(socket)
+            .await
+            .context(crate::association::ConnectSnafu)?;
         let read_timeout = self.socket_options.read_timeout;
         let task = async {
             let mut read_buffer = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let pdu = super::read_pdu_from_wire_async(&mut socket, &mut read_buffer, self.max_pdu_length, self.strict).await?;
+            let pdu = super::read_pdu_from_wire_async(
+                &mut socket,
+                &mut read_buffer,
+                self.max_pdu_length,
+                self.strict,
+            )
+            .await?;
 
             let mut write_buffer: Vec<u8> =
                 Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
             match self.process_a_association_rq(pdu) {
-                Ok((pdu, NegotiatedOptions{ user_variables, presentation_contexts , peer_max_pdu_length, peer_ae_title})) => {
+                Ok((
+                    pdu,
+                    NegotiatedOptions {
+                        user_variables,
+                        presentation_contexts,
+                        peer_max_pdu_length,
+                        peer_ae_title,
+                    },
+                )) => {
                     write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                    socket.write_all(&write_buffer).await.context(WireSendSnafu)?;
-                    Ok(AsyncServerAssociation { 
+                    socket
+                        .write_all(&write_buffer)
+                        .await
+                        .context(WireSendSnafu)?;
+                    Ok(AsyncServerAssociation {
                         presentation_contexts,
                         requestor_max_pdu_length: peer_max_pdu_length,
                         acceptor_max_pdu_length: self.max_pdu_length,
@@ -1121,13 +1214,16 @@ where
                         read_buffer,
                         read_timeout: self.socket_options.read_timeout,
                         write_timeout: self.socket_options.write_timeout,
-                        user_variables
+                        user_variables,
                     })
-                },
+                }
                 Err((pdu, err)) => {
                     // send the rejection/abort PDU
                     write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                    socket.write_all(&write_buffer).await.context(WireSendSnafu)?;
+                    socket
+                        .write_all(&write_buffer)
+                        .await
+                        .context(WireSendSnafu)?;
                     Err(err)
                 }
             }
@@ -1175,9 +1271,10 @@ pub struct AsyncServerAssociation<S> {
 }
 
 #[cfg(feature = "async")]
-impl<S> Association for AsyncServerAssociation<S> 
-where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send{
-
+impl<S> Association for AsyncServerAssociation<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
+{
     /// Retrieve the maximum PDU length
     /// that the association acceptor is expecting to receive.
     fn acceptor_max_pdu_length(&self) -> u32 {
@@ -1219,30 +1316,39 @@ where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send{
 
 #[cfg(feature = "async")]
 impl<S> crate::association::private::AsyncAssociationSealed<S> for AsyncServerAssociation<S>
-where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send{
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
+{
     /// Send a PDU message to the other intervenient.
     async fn send(&mut self, msg: &Pdu) -> Result<()> {
         use tokio::io::AsyncWriteExt;
         self.write_buffer.clear();
         super::timeout(self.write_timeout, async {
-            encode_pdu(&mut self.write_buffer, msg, self.requestor_max_pdu_length + PDU_HEADER_SIZE)?;
+            encode_pdu(
+                &mut self.write_buffer,
+                msg,
+                self.requestor_max_pdu_length + PDU_HEADER_SIZE,
+            )?;
             self.socket
                 .write_all(&self.write_buffer)
                 .await
                 .context(WireSendSnafu)
-        }).await
+        })
+        .await
     }
 
     /// Read a PDU message from the other intervenient.
     async fn receive(&mut self) -> Result<Pdu> {
-        super::timeout(self.read_timeout,async {
+        super::timeout(self.read_timeout, async {
             super::read_pdu_from_wire_async(
                 &mut self.socket,
                 &mut self.read_buffer,
                 self.acceptor_max_pdu_length,
-                self.strict
-            ).await
-        }).await
+                self.strict,
+            )
+            .await
+        })
+        .await
     }
 
     async fn close(&mut self) -> std::io::Result<()> {
@@ -1253,13 +1359,19 @@ where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send{
 
 #[cfg(feature = "async")]
 impl<S> crate::association::AsyncAssociation<S> for AsyncServerAssociation<S>
-where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send{
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
+{
     fn inner_stream(&mut self) -> &mut S {
         &mut self.socket
     }
 
     fn get_mut(&mut self) -> (&mut S, &mut bytes::BytesMut) {
-        let Self { socket, read_buffer, .. } = self; 
+        let Self {
+            socket,
+            read_buffer,
+            ..
+        } = self;
         (socket, read_buffer)
     }
 }
@@ -1285,7 +1397,10 @@ impl<S> AsyncServerAssociation<S> {
     }
 
     /// Obtain the remote DICOM node's application entity title.
-    #[deprecated(since = "0.9.1", note = "Call `peer_ae_title` from trait `Association`")]
+    #[deprecated(
+        since = "0.9.1",
+        note = "Call `peer_ae_title` from trait `Association`"
+    )]
     pub fn client_ae_title(&self) -> &str {
         &self.client_ae_title
     }
@@ -1294,7 +1409,9 @@ impl<S> AsyncServerAssociation<S> {
 // compatibility filler, remove in 0.10.0
 #[cfg(feature = "async")]
 impl<S> AsyncServerAssociation<S>
-where S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send {
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
+{
     /// Send a PDU message to the other intervenient.
     pub async fn send(&mut self, msg: &Pdu) -> Result<()> {
         AsyncAssociation::send(self, msg).await
@@ -1405,8 +1522,14 @@ mod tests {
             )?;
             let (
                 pdu,
-                NegotiatedOptions{ user_variables, presentation_contexts , peer_max_pdu_length, peer_ae_title}
-            ) = self.process_a_association_rq(pdu)
+                NegotiatedOptions {
+                    user_variables,
+                    presentation_contexts,
+                    peer_max_pdu_length,
+                    peer_ae_title,
+                },
+            ) = self
+                .process_a_association_rq(pdu)
                 .expect("Could not parse association req");
 
             let mut write_buffer: Vec<u8> =
@@ -1453,8 +1576,14 @@ mod tests {
             .await?;
             let (
                 pdu,
-                NegotiatedOptions{ user_variables, presentation_contexts , peer_max_pdu_length, peer_ae_title}
-            ) = self.process_a_association_rq(pdu)
+                NegotiatedOptions {
+                    user_variables,
+                    presentation_contexts,
+                    peer_max_pdu_length,
+                    peer_ae_title,
+                },
+            ) = self
+                .process_a_association_rq(pdu)
                 .expect("Could not parse association req");
 
             let mut buffer: Vec<u8> = Vec::with_capacity(
@@ -1466,7 +1595,7 @@ mod tests {
             }
             socket.write_all(&buffer).await.context(WireSendSnafu)?;
 
-            Ok(AsyncServerAssociation { 
+            Ok(AsyncServerAssociation {
                 presentation_contexts,
                 requestor_max_pdu_length: peer_max_pdu_length,
                 acceptor_max_pdu_length: self.max_pdu_length,
@@ -1499,14 +1628,21 @@ mod tests {
             )?;
             let (
                 pdu,
-                NegotiatedOptions{user_variables, presentation_contexts , peer_max_pdu_length, peer_ae_title}
-            ) = self.process_a_association_rq(msg).expect("Could not parse association req");
+                NegotiatedOptions {
+                    user_variables,
+                    presentation_contexts,
+                    peer_max_pdu_length,
+                    peer_ae_title,
+                },
+            ) = self
+                .process_a_association_rq(msg)
+                .expect("Could not parse association req");
             let mut buffer: Vec<u8> = Vec::with_capacity(
                 (peer_max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
             write_pdu(&mut buffer, &pdu).context(SendPduSnafu)?;
             socket.write_all(&buffer).context(WireSendSnafu)?;
-            Ok(ServerAssociation { 
+            Ok(ServerAssociation {
                 presentation_contexts,
                 requestor_max_pdu_length: peer_max_pdu_length,
                 acceptor_max_pdu_length: self.max_pdu_length,
@@ -1517,7 +1653,7 @@ mod tests {
                 read_buffer: BytesMut::with_capacity(
                     (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
                 ),
-                user_variables
+                user_variables,
             })
         }
 
@@ -1543,14 +1679,21 @@ mod tests {
             .await?;
             let (
                 pdu,
-                NegotiatedOptions{user_variables, presentation_contexts , peer_max_pdu_length, peer_ae_title},
-            ) = self.process_a_association_rq(msg).expect("Could not parse association req");
+                NegotiatedOptions {
+                    user_variables,
+                    presentation_contexts,
+                    peer_max_pdu_length,
+                    peer_ae_title,
+                },
+            ) = self
+                .process_a_association_rq(msg)
+                .expect("Could not parse association req");
             let mut buffer: Vec<u8> = Vec::with_capacity(
                 (peer_max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
             write_pdu(&mut buffer, &pdu).context(SendPduSnafu)?;
             socket.write_all(&buffer).await.context(WireSendSnafu)?;
-            Ok(AsyncServerAssociation { 
+            Ok(AsyncServerAssociation {
                 presentation_contexts,
                 requestor_max_pdu_length: peer_max_pdu_length,
                 acceptor_max_pdu_length: self.max_pdu_length,
@@ -1563,7 +1706,7 @@ mod tests {
                 ),
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
-                user_variables
+                user_variables,
             })
         }
     }

--- a/ul/src/association/tests.rs
+++ b/ul/src/association/tests.rs
@@ -31,7 +31,10 @@ mod successive_pdus_during_client_association {
     use std::net::TcpListener;
 
     use super::*;
-    use crate::{ClientAssociationOptions, Pdu, pdu::{AbortRQServiceProviderReason, AbortRQSource, PDataValue, PDataValueType}};
+    use crate::{
+        pdu::{AbortRQServiceProviderReason, AbortRQSource, PDataValue, PDataValueType},
+        ClientAssociationOptions, Pdu,
+    };
 
     use crate::association::server::*;
 
@@ -123,8 +126,10 @@ mod successive_pdus_during_client_association {
                 .accept_any()
                 .with_abstract_syntax(VERIFICATION)
                 .ae_title("THIS-SCP");
-                
-            let association = server_options.establish_with_extra_pdus(stream, vec![server_pdu]).unwrap();
+
+            let association = server_options
+                .establish_with_extra_pdus(stream, vec![server_pdu])
+                .unwrap();
             association
         });
 
@@ -242,8 +247,11 @@ mod successive_pdus_during_client_association {
                 .accept_any()
                 .with_abstract_syntax(VERIFICATION)
                 .ae_title("THIS-SCP");
-                
-            let association = server_options.establish_with_extra_pdus_async(stream, vec![server_pdu]).await.unwrap();
+
+            let association = server_options
+                .establish_with_extra_pdus_async(stream, vec![server_pdu])
+                .await
+                .unwrap();
             association
         });
 
@@ -300,7 +308,9 @@ mod successive_pdus_during_client_association {
                 .with_abstract_syntax(VERIFICATION)
                 .ae_title("THIS-SCP");
 
-            let association = server_options.establish_with_extra_pdus(stream, vec![echo_pdu]).unwrap();
+            let association = server_options
+                .establish_with_extra_pdus(stream, vec![echo_pdu])
+                .unwrap();
             association
         });
         // Give server time to start
@@ -318,11 +328,18 @@ mod successive_pdus_during_client_association {
 
         // Initiate abort server side
         server_handle.join().unwrap().abort().unwrap();
-        
+
         // Client should not have anything to receive, only receives abort Rq
         let received_pdu = association.receive().unwrap();
-        assert_eq!(received_pdu, Pdu::AbortRQ { source: AbortRQSource::ServiceProvider(AbortRQServiceProviderReason::ReasonNotSpecified) });
-        
+        assert_eq!(
+            received_pdu,
+            Pdu::AbortRQ {
+                source: AbortRQSource::ServiceProvider(
+                    AbortRQServiceProviderReason::ReasonNotSpecified
+                )
+            }
+        );
+
         // Client cannot receive the PDU that was sent during association
         // Clean shutdown
         drop(association);
@@ -358,7 +375,10 @@ mod successive_pdus_during_client_association {
                 .with_abstract_syntax(VERIFICATION)
                 .ae_title("THIS-SCP");
 
-            let association = server_options.establish_with_extra_pdus_async(stream, vec![echo_pdu]).await.unwrap();
+            let association = server_options
+                .establish_with_extra_pdus_async(stream, vec![echo_pdu])
+                .await
+                .unwrap();
             association
         });
 
@@ -373,15 +393,26 @@ mod successive_pdus_during_client_association {
             .read_timeout(std::time::Duration::from_secs(5));
 
         // Client's broken implementation will miss the extra PDU from server
-        let mut association = scu_options.broken_establish_async(
-            server_addr.into()
-        ).await.unwrap();
+        let mut association = scu_options
+            .broken_establish_async(server_addr.into())
+            .await
+            .unwrap();
         // Initiate abort server-side
         server_handle.await.unwrap().abort().await.unwrap();
 
         // Client should be able to receive the release request that was sent consecutively
-        let received_pdu = association.receive().await.expect("Could not receive abort PDU");
-        assert_eq!(received_pdu, Pdu::AbortRQ { source: AbortRQSource::ServiceProvider(AbortRQServiceProviderReason::ReasonNotSpecified) });
+        let received_pdu = association
+            .receive()
+            .await
+            .expect("Could not receive abort PDU");
+        assert_eq!(
+            received_pdu,
+            Pdu::AbortRQ {
+                source: AbortRQSource::ServiceProvider(
+                    AbortRQServiceProviderReason::ReasonNotSpecified
+                )
+            }
+        );
 
         // Client cannot receive the PDU that was sent during association
         // Clean shutdown

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -149,9 +149,7 @@ pub enum ReadError {
     #[snafu(display("Missing transfer syntax"))]
     MissingTransferSyntax { backtrace: Backtrace },
     #[snafu(display("Invalid PDU field length"))]
-    InvalidPduFieldLength {
-        backtrace: Backtrace,
-    },
+    InvalidPduFieldLength { backtrace: Backtrace },
     #[snafu(display("Could not read user variable"))]
     ReadUserVariable { backtrace: Backtrace },
 }

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -226,7 +226,10 @@ pub fn read_pdu(mut buf: impl Buf, max_pdu_length: u32, strict: bool) -> Result<
 
             // 7 - Reserved - This reserved field shall be sent with a value 00H but not tested to
             // this value when received.
-            ensure!(bytes.remaining() >= 1 + 1 + 2, InvalidPduFieldLengthSnafu {});
+            ensure!(
+                bytes.remaining() >= 1 + 1 + 2,
+                InvalidPduFieldLengthSnafu {}
+            );
             bytes.get_u8();
 
             // 8 - Result - This Result field shall contain an integer value encoded as an unsigned

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -1080,8 +1080,8 @@ fn write_pdu_variable_user_variables(
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
     use super::*;
+    use std::io::Cursor;
 
     #[test]
     fn can_write_chunks_with_preceding_u32_length() -> Result<()> {
@@ -1199,12 +1199,10 @@ mod tests {
             called_ae_title: "SCP".to_string(),
             application_context_name: "1.2.3".to_string(),
             presentation_contexts: vec![],
-            user_variables: vec![
-                UserVariableItem::SopClassExtendedNegotiationSubItem(
-                    "1.2.3.4".to_string(),
-                    vec![1, 0, 1, 1],
-                ),
-            ],
+            user_variables: vec![UserVariableItem::SopClassExtendedNegotiationSubItem(
+                "1.2.3.4".to_string(),
+                vec![1, 0, 1, 1],
+            )],
         });
         let mut out = Vec::<u8>::new();
 

--- a/ul/tests/association_echo.rs
+++ b/ul/tests/association_echo.rs
@@ -1,12 +1,13 @@
+#[cfg(feature = "async")]
+use dicom_ul::association::AsyncServerAssociation;
 use dicom_ul::{
-    ServerAssociation, association::{Error, client::ClientAssociationOptions, server::ServerAssociationOptions},
+    association::{client::ClientAssociationOptions, server::ServerAssociationOptions, Error},
     pdu::{
         PDataValue, PDataValueType, Pdu, PresentationContextNegotiated,
         PresentationContextResultReason,
-    }
+    },
+    ServerAssociation,
 };
-#[cfg(feature = "async")]
-use dicom_ul::association::AsyncServerAssociation;
 use std::io::Write;
 
 #[cfg(feature = "async")]
@@ -47,7 +48,10 @@ fn bogus_packet(len: usize) -> Pdu {
 fn spawn_scp(
     max_server_pdu_len: usize,
     max_client_pdu_len: usize,
-) -> Result<(std::thread::JoinHandle<Result<ServerAssociation<std::net::TcpStream>>>, SocketAddr)> {
+) -> Result<(
+    std::thread::JoinHandle<Result<ServerAssociation<std::net::TcpStream>>>,
+    SocketAddr,
+)> {
     let listener = std::net::TcpListener::bind("localhost:0")?;
     let addr = listener.local_addr()?;
     let scp = ServerAssociationOptions::new()
@@ -121,8 +125,12 @@ fn spawn_scp(
                 assert_eq!(data.len(), 1);
                 assert_eq!(data[0].data.len(), max_server_pdu_len - PDV_HDR_LEN);
             }
-            Ok(other_pdus) => { panic!("Unknown PDU: {:?}", other_pdus); }
-            Err(err) => { panic!("Receive returned error {:?}", err); }
+            Ok(other_pdus) => {
+                panic!("Unknown PDU: {:?}", other_pdus);
+            }
+            Err(err) => {
+                panic!("Receive returned error {:?}", err);
+            }
         }
         // Second packet
         match association.receive() {
@@ -130,8 +138,12 @@ fn spawn_scp(
                 assert_eq!(data.len(), 1);
                 assert_eq!(data[0].data.len(), 2);
             }
-            Ok(other_pdus) => { panic!("Unknown PDU: {:?}", other_pdus); }
-            Err(err) => { panic!("Receive returned error {:?}", err); }
+            Ok(other_pdus) => {
+                panic!("Unknown PDU: {:?}", other_pdus);
+            }
+            Err(err) => {
+                panic!("Receive returned error {:?}", err);
+            }
         }
         // Let the client test our send_pdata() fragmentation for us
         {
@@ -140,7 +152,9 @@ fn spawn_scp(
             let buf = vec![0_u8; filler_len];
             let mut sender = association.send_pdata(1);
             // This should split the data in two packets
-            sender.write_all(&buf).expect("Error sending fragmented data");
+            sender
+                .write_all(&buf)
+                .expect("Error sending fragmented data");
         }
 
         // handle one release request
@@ -157,7 +171,10 @@ fn spawn_scp(
 async fn spawn_scp_async(
     max_server_pdu_len: usize,
     max_client_pdu_len: usize,
-) -> Result<(tokio::task::JoinHandle<Result<AsyncServerAssociation<tokio::net::TcpStream>>>, SocketAddr)> {
+) -> Result<(
+    tokio::task::JoinHandle<Result<AsyncServerAssociation<tokio::net::TcpStream>>>,
+    SocketAddr,
+)> {
     let listener = tokio::net::TcpListener::bind("localhost:0").await?;
     let addr = listener.local_addr()?;
     let scp = ServerAssociationOptions::new()
@@ -167,7 +184,6 @@ async fn spawn_scp_async(
         .with_abstract_syntax(VERIFICATION_SOP_CLASS);
 
     let h = tokio::spawn(async move {
-
         let (stream, _addr) = listener.accept().await?;
         let mut association = scp.establish_async(stream).await?;
 
@@ -235,8 +251,12 @@ async fn spawn_scp_async(
                 assert_eq!(data.len(), 1);
                 assert_eq!(data[0].data.len(), max_server_pdu_len - PDV_HDR_LEN);
             }
-            Ok(other_pdus) => { panic!("Unknown PDU: {:?}", other_pdus); }
-            Err(err) => { panic!("Receive returned error {:?}", err); }
+            Ok(other_pdus) => {
+                panic!("Unknown PDU: {:?}", other_pdus);
+            }
+            Err(err) => {
+                panic!("Receive returned error {:?}", err);
+            }
         }
         // Second packet
         match association.receive().await {
@@ -244,8 +264,12 @@ async fn spawn_scp_async(
                 assert_eq!(data.len(), 1);
                 assert_eq!(data[0].data.len(), 2);
             }
-            Ok(other_pdus) => { panic!("Unknown PDU: {:?}", other_pdus); }
-            Err(err) => { panic!("Receive returned error {:?}", err); }
+            Ok(other_pdus) => {
+                panic!("Unknown PDU: {:?}", other_pdus);
+            }
+            Err(err) => {
+                panic!("Receive returned error {:?}", err);
+            }
         }
         // Let the client test our send_pdata() fragmentation
         {
@@ -254,7 +278,10 @@ async fn spawn_scp_async(
             let buf = vec![0_u8; filler_len];
             let mut sender = association.send_pdata(1);
             // This should split the data in two packets
-            sender.write_all(&buf).await.expect("Error sending fragmented data");
+            sender
+                .write_all(&buf)
+                .await
+                .expect("Error sending fragmented data");
         }
 
         // handle one release request
@@ -333,7 +360,9 @@ fn run_scu_scp_association_test(max_is_client: bool) {
         let buf = vec![0_u8; filler_len];
         let mut sender = association.send_pdata(1);
         // This should split the data in two packets
-        sender.write_all(&buf).expect("Error sending fragmented data");
+        sender
+            .write_all(&buf)
+            .expect("Error sending fragmented data");
     }
     // Test send_pdata() fragmentation of the server; we should receive two packets
     // First packet
@@ -342,8 +371,12 @@ fn run_scu_scp_association_test(max_is_client: bool) {
             assert_eq!(data.len(), 1);
             assert_eq!(data[0].data.len(), max_client_pdu_len - PDV_HDR_LEN);
         }
-        Ok(other_pdus) => { panic!("Unknown PDU: {:?}", other_pdus); }
-        Err(err) => { panic!("Receive returned error {:?}", err); }
+        Ok(other_pdus) => {
+            panic!("Unknown PDU: {:?}", other_pdus);
+        }
+        Err(err) => {
+            panic!("Receive returned error {:?}", err);
+        }
     }
     // Second packet
     match association.receive() {
@@ -351,8 +384,12 @@ fn run_scu_scp_association_test(max_is_client: bool) {
             assert_eq!(data.len(), 1);
             assert_eq!(data[0].data.len(), 2);
         }
-        Ok(other_pdus) => { panic!("Unknown PDU: {:?}", other_pdus); }
-        Err(err) => { panic!("Receive returned error {:?}", err); }
+        Ok(other_pdus) => {
+            panic!("Unknown PDU: {:?}", other_pdus);
+        }
+        Err(err) => {
+            panic!("Receive returned error {:?}", err);
+        }
     }
 
     association
@@ -375,7 +412,6 @@ async fn scu_scp_association_test_async() {
 
 #[cfg(feature = "async")]
 async fn run_scu_scp_association_test_async(max_is_client: bool) {
-
     let (max_client_pdu_len, max_server_pdu_len) = if max_is_client {
         (HI_PDU_LEN, LO_PDU_LEN)
     } else {
@@ -442,7 +478,10 @@ async fn run_scu_scp_association_test_async(max_is_client: bool) {
         let buf = vec![0_u8; filler_len];
         let mut sender = association.send_pdata(1);
         // This should split the data in two packets
-        sender.write_all(&buf).await.expect("Error sending fragmented data");
+        sender
+            .write_all(&buf)
+            .await
+            .expect("Error sending fragmented data");
     }
     // Test send_pdata() fragmentation of the server; we should receive two packets
     // First packet
@@ -451,8 +490,12 @@ async fn run_scu_scp_association_test_async(max_is_client: bool) {
             assert_eq!(data.len(), 1);
             assert_eq!(data[0].data.len(), max_client_pdu_len - PDV_HDR_LEN);
         }
-        Ok(other_pdus) => { panic!("Unknown PDU: {:?}", other_pdus); }
-        Err(err) => { panic!("Receive returned error {:?}", err); }
+        Ok(other_pdus) => {
+            panic!("Unknown PDU: {:?}", other_pdus);
+        }
+        Err(err) => {
+            panic!("Receive returned error {:?}", err);
+        }
     }
     // Second packet
     match association.receive().await {
@@ -460,8 +503,12 @@ async fn run_scu_scp_association_test_async(max_is_client: bool) {
             assert_eq!(data.len(), 1);
             assert_eq!(data[0].data.len(), 2);
         }
-        Ok(other_pdus) => { panic!("Unknown PDU: {:?}", other_pdus); }
-        Err(err) => { panic!("Receive returned error {:?}", err); }
+        Ok(other_pdus) => {
+            panic!("Unknown PDU: {:?}", other_pdus);
+        }
+        Err(err) => {
+            panic!("Receive returned error {:?}", err);
+        }
     }
 
     association

--- a/ul/tests/association_promiscuous.rs
+++ b/ul/tests/association_promiscuous.rs
@@ -1,15 +1,16 @@
 use std::net::SocketAddr;
 
-use dicom_ul::association::Error::NoAcceptedPresentationContexts;
 #[cfg(feature = "async")]
 use dicom_ul::association::AsyncServerAssociation;
+use dicom_ul::association::Error::NoAcceptedPresentationContexts;
 use dicom_ul::pdu::PresentationContextResultReason::Acceptance;
 use dicom_ul::pdu::{
     PresentationContextNegotiated, PresentationContextResultReason, UserVariableItem,
     DEFAULT_MAX_PDU,
 };
 use dicom_ul::{
-    ClientAssociationOptions, IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME, Pdu, ServerAssociation, ServerAssociationOptions
+    ClientAssociationOptions, Pdu, ServerAssociation, ServerAssociationOptions,
+    IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
 };
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>;
@@ -25,7 +26,10 @@ const ULTRASOUND_IMAGE_STORAGE_RAW: &str = "1.2.840.10008.5.1.4.1.1.6.1\0";
 fn spawn_scp(
     abstract_syntax_uids: &'static [&str],
     promiscuous: bool,
-) -> Result<(std::thread::JoinHandle<Result<ServerAssociation<std::net::TcpStream>>>, SocketAddr)> {
+) -> Result<(
+    std::thread::JoinHandle<Result<ServerAssociation<std::net::TcpStream>>>,
+    SocketAddr,
+)> {
     let listener = std::net::TcpListener::bind("localhost:0")?;
     let addr = listener.local_addr()?;
     let mut options = ServerAssociationOptions::new()
@@ -64,7 +68,10 @@ fn spawn_scp(
 async fn spawn_scp_async(
     abstract_syntax_uids: &'static [&str],
     promiscuous: bool,
-) -> Result<(tokio::task::JoinHandle<Result<AsyncServerAssociation<tokio::net::TcpStream>>>, SocketAddr)> {
+) -> Result<(
+    tokio::task::JoinHandle<Result<AsyncServerAssociation<tokio::net::TcpStream>>>,
+    SocketAddr,
+)> {
     let listener = tokio::net::TcpListener::bind("localhost:0").await?;
     let addr = listener.local_addr()?;
     let mut options = ServerAssociationOptions::new()


### PR DESCRIPTION
This commit makes no other changes whatsoever, and can be reproduced by running `rustfmt --edition 2018` on the files present.

Since I had to rebase #734 anyway, I thought it would be convenient to start with a cleanly formatted base. Some of the files that are formatted will be used in the upcoming Role Selection Negotiation PR.

This may affect some other PRs, notably #707.