### PR TITLE
ENH: Expose called_ae_title method on server association structs

### DIFF
--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -11,27 +11,27 @@ use std::{io::Write, net::TcpStream};
 
 use crate::association::private::SyncAssociationSealed;
 use crate::association::{
-    encode_pdu, read_pdu_from_wire, AbortedSnafu, Association, CloseSocket,
-    MissingAbstractSyntaxSnafu, RejectedSnafu, SendPduSnafu, SocketOptions, SyncAssociation,
-    UnexpectedPduSnafu, UnknownPduSnafu, WireSendSnafu,
+    AbortedSnafu, Association, CloseSocket, MissingAbstractSyntaxSnafu, RejectedSnafu,
+    SendPduSnafu, SocketOptions, SyncAssociation, UnexpectedPduSnafu, UnknownPduSnafu,
+    WireSendSnafu, encode_pdu, read_pdu_from_wire,
 };
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
-use snafu::{ensure, ResultExt};
+use snafu::{ResultExt, ensure};
 
 use crate::association::NegotiatedOptions;
-use crate::pdu::{PresentationContextNegotiated, LARGE_PDU_SIZE};
+use crate::pdu::{LARGE_PDU_SIZE, PresentationContextNegotiated};
 use crate::{
-    pdu::{
-        write_pdu, AbortRQServiceProviderReason, AbortRQSource, AssociationAC, AssociationRJ,
-        AssociationRJResult, AssociationRJServiceUserReason, AssociationRJSource, AssociationRQ,
-        Pdu, PresentationContextResult, PresentationContextResultReason, UserIdentity,
-        UserVariableItem, DEFAULT_MAX_PDU, PDU_HEADER_SIZE,
-    },
     IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
+    pdu::{
+        AbortRQServiceProviderReason, AbortRQSource, AssociationAC, AssociationRJ,
+        AssociationRJResult, AssociationRJServiceUserReason, AssociationRJSource, AssociationRQ,
+        DEFAULT_MAX_PDU, PDU_HEADER_SIZE, Pdu, PresentationContextResult,
+        PresentationContextResultReason, UserIdentity, UserVariableItem, write_pdu,
+    },
 };
 
-use super::{uid::trim_uid, Error, Result};
+use super::{Error, Result, uid::trim_uid};
 
 #[cfg(feature = "async")]
 use crate::association::AsyncAssociation;
@@ -631,7 +631,7 @@ where
                         presentation_contexts: presentation_contexts_negotiated,
                         peer_ae_title: calling_ae_title,
                     },
-                    called_ae_title
+                    called_ae_title,
                 ))
             }
             Pdu::ReleaseRQ => Err((Pdu::ReleaseRP, AbortedSnafu.build())),
@@ -691,7 +691,7 @@ where
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
-                called_ae_title
+                called_ae_title,
             )) => {
                 write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                 socket.write_all(&write_buffer).context(WireSendSnafu)?;
@@ -705,7 +705,7 @@ where
                     strict: self.strict,
                     read_buffer,
                     user_variables,
-                    called_ae_title
+                    called_ae_title,
                 })
             }
             Err((pdu, err)) => {
@@ -759,7 +759,7 @@ where
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
-                called_ae_title
+                called_ae_title,
             )) => {
                 write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                 tls_stream.write_all(&write_buffer).context(WireSendSnafu)?;
@@ -773,7 +773,7 @@ where
                     strict: self.strict,
                     read_buffer,
                     user_variables,
-                    called_ae_title
+                    called_ae_title,
                 })
             }
             Err((pdu, err)) => {
@@ -1130,7 +1130,7 @@ where
                         peer_max_pdu_length,
                         peer_ae_title,
                     },
-                    called_ae_title
+                    called_ae_title,
                 )) => {
                     write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                     socket
@@ -1149,7 +1149,7 @@ where
                         read_timeout: self.socket_options.read_timeout,
                         write_timeout: self.socket_options.write_timeout,
                         user_variables,
-                        called_ae_title
+                        called_ae_title,
                     })
                 }
                 Err((pdu, err)) => {
@@ -1212,7 +1212,7 @@ where
                         peer_max_pdu_length,
                         peer_ae_title,
                     },
-                    called_ae_title
+                    called_ae_title,
                 )) => {
                     write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                     socket
@@ -1231,7 +1231,7 @@ where
                         read_timeout: self.socket_options.read_timeout,
                         write_timeout: self.socket_options.write_timeout,
                         user_variables,
-                        called_ae_title
+                        called_ae_title,
                     })
                 }
                 Err((pdu, err)) => {
@@ -1552,7 +1552,7 @@ mod tests {
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
-                called_ae_title
+                called_ae_title,
             ) = self
                 .process_a_association_rq(pdu)
                 .expect("Could not parse association req");
@@ -1575,7 +1575,7 @@ mod tests {
                 read_buffer,
                 strict: self.strict,
                 user_variables,
-                called_ae_title
+                called_ae_title,
             })
         }
 
@@ -1608,7 +1608,7 @@ mod tests {
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
-                called_ae_title
+                called_ae_title,
             ) = self
                 .process_a_association_rq(pdu)
                 .expect("Could not parse association req");
@@ -1636,7 +1636,7 @@ mod tests {
                 user_variables,
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
-                called_ae_title
+                called_ae_title,
             })
         }
 
@@ -1662,7 +1662,7 @@ mod tests {
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
-                called_ae_title
+                called_ae_title,
             ) = self
                 .process_a_association_rq(msg)
                 .expect("Could not parse association req");
@@ -1683,7 +1683,7 @@ mod tests {
                     (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
                 ),
                 user_variables,
-                called_ae_title
+                called_ae_title,
             })
         }
 
@@ -1715,7 +1715,7 @@ mod tests {
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
-                called_ae_title
+                called_ae_title,
             ) = self
                 .process_a_association_rq(msg)
                 .expect("Could not parse association req");
@@ -1738,7 +1738,7 @@ mod tests {
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
                 user_variables,
-                called_ae_title
+                called_ae_title,
             })
         }
     }

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -493,7 +493,7 @@ where
     fn process_a_association_rq(
         &self,
         msg: Pdu,
-    ) -> std::result::Result<(Pdu, NegotiatedOptions), (Pdu, Error)> {
+    ) -> std::result::Result<(Pdu, NegotiatedOptions, String), (Pdu, Error)> {
         match msg {
             Pdu::AssociationRQ(AssociationRQ {
                 protocol_version,
@@ -612,7 +612,7 @@ where
                         })
                         .collect(),
                     calling_ae_title: calling_ae_title.clone(),
-                    called_ae_title,
+                    called_ae_title: called_ae_title.clone(),
                     user_variables: vec![
                         UserVariableItem::MaxLength(self.max_pdu_length),
                         UserVariableItem::ImplementationClassUID(
@@ -631,6 +631,7 @@ where
                         presentation_contexts: presentation_contexts_negotiated,
                         peer_ae_title: calling_ae_title,
                     },
+                    called_ae_title
                 ))
             }
             Pdu::ReleaseRQ => Err((Pdu::ReleaseRP, AbortedSnafu.build())),
@@ -690,6 +691,7 @@ where
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
+                called_ae_title
             )) => {
                 write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                 socket.write_all(&write_buffer).context(WireSendSnafu)?;
@@ -703,6 +705,7 @@ where
                     strict: self.strict,
                     read_buffer,
                     user_variables,
+                    called_ae_title
                 })
             }
             Err((pdu, err)) => {
@@ -756,6 +759,7 @@ where
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
+                called_ae_title
             )) => {
                 write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                 tls_stream.write_all(&write_buffer).context(WireSendSnafu)?;
@@ -769,6 +773,7 @@ where
                     strict: self.strict,
                     read_buffer,
                     user_variables,
+                    called_ae_title
                 })
             }
             Err((pdu, err)) => {
@@ -830,6 +835,8 @@ pub struct ServerAssociation<S> {
     socket: S,
     /// The application entity title of the other DICOM node
     client_ae_title: String,
+    /// The AE title the calling client used.
+    called_ae_title: String,
     /// Reusable buffer used for sending PDUs on the wire
     /// prevents reallocation on each send
     write_buffer: Vec<u8>,
@@ -867,6 +874,11 @@ impl<S> ServerAssociation<S> {
     )]
     pub fn client_ae_title(&self) -> &str {
         &self.client_ae_title
+    }
+
+    /// Obtain the AE title the client called.
+    pub fn called_ae_title(&self) -> &str {
+        &self.called_ae_title
     }
 }
 
@@ -1117,6 +1129,7 @@ where
                         peer_max_pdu_length,
                         peer_ae_title,
                     },
+                    called_ae_title
                 )) => {
                     write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                     socket
@@ -1135,6 +1148,7 @@ where
                         read_timeout: self.socket_options.read_timeout,
                         write_timeout: self.socket_options.write_timeout,
                         user_variables,
+                        called_ae_title
                     })
                 }
                 Err((pdu, err)) => {
@@ -1197,6 +1211,7 @@ where
                         peer_max_pdu_length,
                         peer_ae_title,
                     },
+                    called_ae_title
                 )) => {
                     write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                     socket
@@ -1215,6 +1230,7 @@ where
                         read_timeout: self.socket_options.read_timeout,
                         write_timeout: self.socket_options.write_timeout,
                         user_variables,
+                        called_ae_title
                     })
                 }
                 Err((pdu, err)) => {
@@ -1256,6 +1272,8 @@ pub struct AsyncServerAssociation<S> {
     socket: S,
     /// The application entity title of the other DICOM node
     client_ae_title: String,
+    /// The AE title the calling client used.
+    called_ae_title: String,
     /// write buffer to send fully assembled PDUs on wire
     write_buffer: Vec<u8>,
     /// whether to receive PDUs in strict mode
@@ -1404,6 +1422,11 @@ impl<S> AsyncServerAssociation<S> {
     pub fn client_ae_title(&self) -> &str {
         &self.client_ae_title
     }
+
+    /// Obtain the AE title the client called.
+    pub fn called_ae_title(&self) -> &str {
+        &self.called_ae_title
+    }
 }
 
 // compatibility filler, remove in 0.10.0
@@ -1528,6 +1551,7 @@ mod tests {
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
+                called_ae_title
             ) = self
                 .process_a_association_rq(pdu)
                 .expect("Could not parse association req");
@@ -1550,6 +1574,7 @@ mod tests {
                 read_buffer,
                 strict: self.strict,
                 user_variables,
+                called_ae_title
             })
         }
 
@@ -1582,6 +1607,7 @@ mod tests {
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
+                called_ae_title
             ) = self
                 .process_a_association_rq(pdu)
                 .expect("Could not parse association req");
@@ -1609,6 +1635,7 @@ mod tests {
                 user_variables,
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
+                called_ae_title
             })
         }
 
@@ -1634,6 +1661,7 @@ mod tests {
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
+                called_ae_title
             ) = self
                 .process_a_association_rq(msg)
                 .expect("Could not parse association req");
@@ -1654,6 +1682,7 @@ mod tests {
                     (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
                 ),
                 user_variables,
+                called_ae_title
             })
         }
 
@@ -1685,6 +1714,7 @@ mod tests {
                     peer_max_pdu_length,
                     peer_ae_title,
                 },
+                called_ae_title
             ) = self
                 .process_a_association_rq(msg)
                 .expect("Could not parse association req");
@@ -1707,6 +1737,7 @@ mod tests {
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
                 user_variables,
+                called_ae_title
             })
         }
     }

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -835,7 +835,8 @@ pub struct ServerAssociation<S> {
     socket: S,
     /// The application entity title of the other DICOM node
     client_ae_title: String,
-    /// The AE title the calling client used.
+    /// The application entity title used by the client
+    /// to call this server
     called_ae_title: String,
     /// Reusable buffer used for sending PDUs on the wire
     /// prevents reallocation on each send
@@ -876,7 +877,7 @@ impl<S> ServerAssociation<S> {
         &self.client_ae_title
     }
 
-    /// Obtain the AE title the client called.
+    /// Obtain the application entity title called by the client.
     pub fn called_ae_title(&self) -> &str {
         &self.called_ae_title
     }
@@ -1423,7 +1424,7 @@ impl<S> AsyncServerAssociation<S> {
         &self.client_ae_title
     }
 
-    /// Obtain the AE title the client called.
+    /// Obtain the application entity title called by the client.
     pub fn called_ae_title(&self) -> &str {
         &self.called_ae_title
     }


### PR DESCRIPTION
Sometimes it is useful to know which AE title a calling entity used, such as if different behavior or access to different images are gated by AE title.

Called AE title is now stored on the server association structs, and methods are implemented to retrieve it

Context: I am writing a storescp server implementation which will route dicoms to various places based on which AE title has been called.  I use `accept_any` and then want to check which AE was called in order to route