### PR TITLE
Add `read_to` parameter, that allows to read certain dicom file, without excluding chosen tag

### DIFF
--- a/object/src/collector.rs
+++ b/object/src/collector.rs
@@ -794,7 +794,7 @@ where
             self.source.parser()
         };
 
-        Self::collect_to_object(&mut self.state, parser, false, None, to, &self.dictionary)
+        Self::collect_to_object(&mut self.state, parser, false, None, None, to, &self.dictionary)
     }
 
     /// Read a DICOM data set until it reaches the given stop tag
@@ -823,6 +823,7 @@ where
             parser,
             false,
             Some(stop_tag),
+            None,
             to,
             &self.dictionary,
         )
@@ -1068,11 +1069,12 @@ where
         token_src: &mut LazyDataSetReader<DynStatefulDecoder<BufReader<S>>>,
         in_item: bool,
         read_until: Option<Tag>,
+        read_to: Option<Tag>,
         to: &mut InMemDicomObject<D>,
         dict: &D,
     ) -> Result<()> {
         let mut elements = Vec::new();
-        Self::collect_elements(state, token_src, in_item, read_until, &mut elements, dict)?;
+        Self::collect_elements(state, token_src, in_item, read_until, read_to, &mut elements, dict)?;
         to.extend(elements);
         Ok(())
     }
@@ -1083,6 +1085,7 @@ where
         token_src: &mut LazyDataSetReader<DynStatefulDecoder<BufReader<S>>>,
         in_item: bool,
         read_until: Option<Tag>,
+        read_to: Option<Tag>,
         to: &mut Vec<DataElement<InMemDicomObject<D>>>,
         dict: &D,
     ) -> Result<()> {
@@ -1091,9 +1094,16 @@ where
             let token = token.clone();
             let elem = match token {
                 DataToken::PixelSequenceStart => {
-                    // stop reading if reached `read_until` tag
+                    // stop reading if reached `read_until` tag (exclusive)
                     if read_until
                         .map(|t| t <= Tag(0x7fe0, 0x0010))
+                        .unwrap_or(false)
+                    {
+                        break;
+                    }
+                    // stop reading if exceeded `read_to` tag (inclusive)
+                    if read_to
+                        .map(|t| t < Tag(0x7fe0, 0x0010))
                         .unwrap_or(false)
                     {
                         break;
@@ -1104,8 +1114,12 @@ where
                     DataElement::new(Tag(0x7fe0, 0x0010), VR::OB, value)
                 }
                 DataToken::ElementHeader(header) => {
-                    // stop reading if reached `read_until` tag
+                    // stop reading if reached `read_until` tag (exclusive)
                     if read_until.map(|t| t <= header.tag).unwrap_or(false) {
+                        break;
+                    }
+                    // stop reading if exceeded `read_to` tag (inclusive)
+                    if read_to.map(|t| t < header.tag).unwrap_or(false) {
                         break;
                     }
 
@@ -1134,8 +1148,12 @@ where
                     }
                 }
                 DataToken::SequenceStart { tag, len } => {
-                    // stop reading if reached `read_until` tag
+                    // stop reading if reached `read_until` tag (exclusive)
                     if read_until.map(|t| t <= tag).unwrap_or(false) {
+                        break;
+                    }
+                    // stop reading if exceeded `read_to` tag (inclusive)
+                    if read_to.map(|t| t < tag).unwrap_or(false) {
                         break;
                     }
                     *state = CollectorState::InDataset;
@@ -1255,7 +1273,7 @@ where
             match token.context(ReadTokenSnafu)? {
                 LazyDataToken::ItemStart { len: _ } => {
                     let mut obj = InMemDicomObject::new_empty_with_dict(dict.clone());
-                    Self::collect_to_object(state, token_src, true, None, &mut obj, dict)?;
+                    Self::collect_to_object(state, token_src, true, None, None, &mut obj, dict)?;
                     items.push(obj);
                 }
                 LazyDataToken::SequenceEnd => {

--- a/object/src/file.rs
+++ b/object/src/file.rs
@@ -61,6 +61,7 @@ pub struct OpenFileOptions<D = StandardDataDictionary, T = TransferSyntaxRegistr
     data_dictionary: D,
     ts_index: T,
     read_until: Option<Tag>,
+    read_to: Option<Tag>,
     read_preamble: ReadPreamble,
     odd_length: OddLengthStrategy,
     charset_override: CharacterSetOverride,
@@ -79,8 +80,24 @@ impl<D, T> OpenFileOptions<D, T> {
     /// or any other tag that is next in the standard DICOM tag ordering,
     /// is found in the object's root data set.
     /// An element with the exact tag will be excluded from the output.
+    ///
+    /// If both `read_until` and [`read_to`](Self::read_to) are set to the same tag,
+    /// `read_until` takes priority and the tag is excluded.
     pub fn read_until(mut self, tag: Tag) -> Self {
         self.read_until = Some(tag);
+        self
+    }
+
+    /// Set the operation to read up to and including the given tag.
+    ///
+    /// The reading process ends right after the element with this tag
+    /// is read into the object's root data set.
+    /// An element with the exact tag will be included in the output.
+    ///
+    /// If both [`read_until`](Self::read_until) and `read_to` are set to the same tag,
+    /// `read_until` takes priority and the tag is excluded.
+    pub fn read_to(mut self, tag: Tag) -> Self {
+        self.read_to = Some(tag);
         self
     }
 
@@ -89,6 +106,7 @@ impl<D, T> OpenFileOptions<D, T> {
     /// This is the default behavior.
     pub fn read_all(mut self) -> Self {
         self.read_until = None;
+        self.read_to = None;
         self
     }
 
@@ -118,6 +136,7 @@ impl<D, T> OpenFileOptions<D, T> {
         OpenFileOptions {
             data_dictionary: self.data_dictionary,
             read_until: self.read_until,
+            read_to: self.read_to,
             read_preamble: self.read_preamble,
             ts_index,
             odd_length: self.odd_length,
@@ -143,6 +162,7 @@ impl<D, T> OpenFileOptions<D, T> {
         OpenFileOptions {
             data_dictionary: dict,
             read_until: self.read_until,
+            read_to: self.read_to,
             read_preamble: self.read_preamble,
             ts_index: self.ts_index,
             odd_length: self.odd_length,
@@ -163,6 +183,7 @@ impl<D, T> OpenFileOptions<D, T> {
             self.data_dictionary,
             self.ts_index,
             self.read_until,
+            self.read_to,
             self.read_preamble,
             self.odd_length,
             self.charset_override,
@@ -186,6 +207,7 @@ impl<D, T> OpenFileOptions<D, T> {
             self.data_dictionary,
             self.ts_index,
             self.read_until,
+            self.read_to,
             self.read_preamble,
             self.odd_length,
             self.charset_override,

--- a/object/src/mem.rs
+++ b/object/src/mem.rs
@@ -410,17 +410,20 @@ where
             dict,
             ts_index,
             None,
+            None,
             ReadPreamble::Auto,
             Default::default(),
             Default::default(),
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn open_file_with_all_options<P, R>(
         path: P,
         dict: D,
         ts_index: R,
         read_until: Option<Tag>,
+        read_to: Option<Tag>,
         mut read_preamble: ReadPreamble,
         odd_length: OddLengthStrategy,
         charset_override: CharacterSetOverride,
@@ -450,6 +453,7 @@ where
             dict,
             ts_index,
             read_until,
+            read_to,
             odd_length,
             charset_override,
         )
@@ -492,17 +496,20 @@ where
             dict,
             ts_index,
             None,
+            None,
             ReadPreamble::Auto,
             Default::default(),
             Default::default(),
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_reader_with_all_options<S, R>(
         src: S,
         dict: D,
         ts_index: R,
         read_until: Option<Tag>,
+        read_to: Option<Tag>,
         mut read_preamble: ReadPreamble,
         odd_length: OddLengthStrategy,
         charset_override: CharacterSetOverride,
@@ -529,6 +536,7 @@ where
             dict,
             ts_index,
             read_until,
+            read_to,
             odd_length,
             charset_override,
         )
@@ -571,6 +579,7 @@ where
         dict: D,
         ts_index: R,
         read_until: Option<Tag>,
+        read_to: Option<Tag>,
         odd_length: OddLengthStrategy,
         charset_override: CharacterSetOverride,
     ) -> Result<Self, ReadError>
@@ -599,6 +608,7 @@ where
                         false,
                         Length::UNDEFINED,
                         read_until,
+                        read_to,
                     )?
                 }
                 Codec::Dataset(None) => {
@@ -629,6 +639,7 @@ where
                         false,
                         Length::UNDEFINED,
                         read_until,
+                        read_to,
                     )?
                 }
             };
@@ -769,7 +780,7 @@ where
         D: DataDictionary,
     {
         let mut dataset = DataSetReader::new(decoder, Default::default());
-        InMemDicomObject::build_object(&mut dataset, dict, false, Length::UNDEFINED, None)
+        InMemDicomObject::build_object(&mut dataset, dict, false, Length::UNDEFINED, None, None)
     }
 
     /// Read an object from a source,
@@ -811,7 +822,7 @@ where
                 let adapter = adapter.adapt_reader(Box::new(from));
                 let mut dataset =
                     DataSetReader::new_with_ts_cs(adapter, ts, cs).context(CreateParserSnafu)?;
-                InMemDicomObject::build_object(&mut dataset, dict, false, Length::UNDEFINED, None)
+                InMemDicomObject::build_object(&mut dataset, dict, false, Length::UNDEFINED, None, None)
             }
             Codec::Dataset(None) => {
                 let uid = ts.uid();
@@ -836,7 +847,7 @@ where
             Codec::None | Codec::EncapsulatedPixelData(..) => {
                 let mut dataset =
                     DataSetReader::new_with_ts_cs(from, ts, cs).context(CreateParserSnafu)?;
-                InMemDicomObject::build_object(&mut dataset, dict, false, Length::UNDEFINED, None)
+                InMemDicomObject::build_object(&mut dataset, dict, false, Length::UNDEFINED, None, None)
             }
         }
     }
@@ -2132,6 +2143,7 @@ where
         in_item: bool,
         len: Length,
         read_until: Option<Tag>,
+        read_to: Option<Tag>,
     ) -> Result<Self, ReadError>
     where
         I: ?Sized + Iterator<Item = ParserResult<DataToken>>,
@@ -2141,19 +2153,31 @@ where
         while let Some(token) = dataset.next() {
             let elem = match token.context(ReadTokenSnafu)? {
                 DataToken::PixelSequenceStart => {
-                    // stop reading if reached `read_until` tag
+                    let sq_start_tag = Tag(0x7fe0, 0x0010);
+                    // stop reading if reached `read_until` tag (exclusive)
                     if read_until
-                        .map(|t| t <= Tag(0x7fe0, 0x0010))
+                        .map(|t| t <= sq_start_tag)
+                        .unwrap_or(false)
+                    {
+                        break;
+                    }
+                    // stop reading if exceeded `read_to` tag (inclusive)
+                    if read_to
+                        .map(|t| t < sq_start_tag)
                         .unwrap_or(false)
                     {
                         break;
                     }
                     let value = InMemDicomObject::build_encapsulated_data(&mut *dataset)?;
-                    DataElement::new(Tag(0x7fe0, 0x0010), VR::OB, value)
+                    DataElement::new(sq_start_tag, VR::OB, value)
                 }
                 DataToken::ElementHeader(header) => {
-                    // stop reading if reached `read_until` tag
+                    // stop reading if reached `read_until` tag (exclusive)
                     if read_until.map(|t| t <= header.tag).unwrap_or(false) {
+                        break;
+                    }
+                    // stop reading if exceeded `read_to` tag (inclusive)
+                    if read_to.map(|t| t < header.tag).unwrap_or(false) {
                         break;
                     }
 
@@ -2172,8 +2196,12 @@ where
                     }
                 }
                 DataToken::SequenceStart { tag, len } => {
-                    // stop reading if reached `read_until` tag
+                    // stop reading if reached `read_until` tag (exclusive)
                     if read_until.map(|t| t <= tag).unwrap_or(false) {
+                        break;
+                    }
+                    // stop reading if exceeded `read_to` tag (inclusive)
+                    if read_to.map(|t| t < tag).unwrap_or(false) {
                         break;
                     }
 
@@ -2280,6 +2308,7 @@ where
                         dict.clone(),
                         true,
                         len,
+                        None,
                         None,
                     )?);
                 }
@@ -3092,6 +3121,7 @@ mod tests {
             false,
             Length::UNDEFINED,
             None,
+            None,
         )
         .unwrap();
 
@@ -3208,6 +3238,7 @@ mod tests {
             false,
             Length::UNDEFINED,
             None,
+            None,
         )
         .unwrap();
 
@@ -3315,6 +3346,7 @@ mod tests {
             StandardDataDictionary,
             false,
             Length::UNDEFINED,
+            None,
             None,
         )
         .unwrap();
@@ -4340,5 +4372,131 @@ mod tests {
             res.err().unwrap().to_string(),
             "No space available in group 0x0009"
         );
+    }
+
+    /// Helper to build the token stream used in read_to/read_until sequence tests:
+    /// - (0018,6011) SQ  (sequence with two items)
+    /// - (0020,4000) LT  "TEST"
+    fn tokens_with_sequence() -> Vec<DataToken> {
+        vec![
+            DataToken::SequenceStart {
+                tag: Tag(0x0018, 0x6011),
+                len: Length::UNDEFINED,
+            },
+            DataToken::ItemStart {
+                len: Length::UNDEFINED,
+            },
+            DataToken::ElementHeader(DataElementHeader {
+                tag: Tag(0x0018, 0x6012),
+                vr: VR::US,
+                len: Length(2),
+            }),
+            DataToken::PrimitiveValue(PrimitiveValue::U16([1].as_ref().into())),
+            DataToken::ItemEnd,
+            DataToken::SequenceEnd,
+            DataToken::ElementHeader(DataElementHeader {
+                tag: Tag(0x0020, 0x4000),
+                vr: VR::LT,
+                len: Length(4),
+            }),
+            DataToken::PrimitiveValue(PrimitiveValue::Str("TEST".into())),
+        ]
+    }
+
+    #[test]
+    fn build_object_read_to_sequence_tag() {
+        // read_to(0x0018,0x6011) must include the sequence and stop before (0020,4000)
+        let tokens = tokens_with_sequence();
+        let obj = InMemDicomObject::build_object(
+            &mut tokens.into_iter().map(Result::Ok),
+            StandardDataDictionary,
+            false,
+            Length::UNDEFINED,
+            None,
+            Some(Tag(0x0018, 0x6011)),
+        )
+        .unwrap();
+
+        assert!(
+            obj.element(Tag(0x0018, 0x6011)).is_ok(),
+            "sequence should be present"
+        );
+        assert!(
+            obj.element(Tag(0x0020, 0x4000)).is_err(),
+            "element after sequence should be absent"
+        );
+    }
+
+    #[test]
+    fn build_object_read_to_element_after_sequence() {
+        // read_to(0x0020,0x4000) must include both the sequence and (0020,4000)
+        let tokens = tokens_with_sequence();
+        let obj = InMemDicomObject::build_object(
+            &mut tokens.into_iter().map(Result::Ok),
+            StandardDataDictionary,
+            false,
+            Length::UNDEFINED,
+            None,
+            Some(Tag(0x0020, 0x4000)),
+        )
+        .unwrap();
+
+        assert!(
+            obj.element(Tag(0x0018, 0x6011)).is_ok(),
+            "sequence should be present"
+        );
+        assert!(
+            obj.element(Tag(0x0020, 0x4000)).is_ok(),
+            "element at read_to tag should be present"
+        );
+    }
+
+    #[test]
+    fn build_object_read_to_and_read_until_same_sequence_tag() {
+        // when both are the same tag, read_until wins and the tag is excluded
+        let tokens = tokens_with_sequence();
+        let obj = InMemDicomObject::build_object(
+            &mut tokens.into_iter().map(Result::Ok),
+            StandardDataDictionary,
+            false,
+            Length::UNDEFINED,
+            Some(Tag(0x0018, 0x6011)),
+            Some(Tag(0x0018, 0x6011)),
+        )
+        .unwrap();
+
+        assert!(
+            obj.element(Tag(0x0018, 0x6011)).is_err(),
+            "read_until takes priority: sequence should be excluded"
+        );
+    }
+
+    #[test]
+    fn build_object_read_to_sequence_equals_read_until_next() {
+        // read_to(seq) should give the same result as read_until(next element)
+        let tokens_a = tokens_with_sequence();
+        let tokens_b = tokens_with_sequence();
+
+        let obj_read_to = InMemDicomObject::build_object(
+            &mut tokens_a.into_iter().map(Result::Ok),
+            StandardDataDictionary,
+            false,
+            Length::UNDEFINED,
+            None,
+            Some(Tag(0x0018, 0x6011)),
+        )
+        .unwrap();
+
+        let obj_read_until = InMemDicomObject::build_object(
+            &mut tokens_b.into_iter().map(Result::Ok),
+            StandardDataDictionary,
+            false,
+            Length::UNDEFINED,
+            Some(Tag(0x0020, 0x4000)),
+            None,
+        )
+        .unwrap();
+
+        assert_obj_eq(&obj_read_to, &obj_read_until);
     }
 }

--- a/object/tests/integration_test.rs
+++ b/object/tests/integration_test.rs
@@ -57,6 +57,49 @@ fn test_read_until_pixel_data() {
 }
 
 #[test]
+fn test_read_to_pixel_data() {
+    let path =
+        dicom_test_files::path("pydicom/JPEG2000.dcm").expect("test DICOM file should exist");
+    let object = OpenFileOptions::new()
+        .read_to(tags::PIXEL_DATA)
+        .open_file(&path)
+        .expect("File should open successfully");
+
+    // contains other elements such as modality
+    let element = object.element(tags::MODALITY).unwrap();
+    assert_eq!(element.value().to_str().unwrap(), "NM");
+
+    // also contains pixel data (unlike read_until)
+    assert!(
+        object.element(tags::PIXEL_DATA).is_ok(),
+        "read_to should include the target tag"
+    );
+}
+
+#[test]
+fn test_read_to_priority_of_read_until() {
+    // When both read_until and read_to are set to the same tag,
+    // read_until takes priority and the tag is excluded.
+    let path =
+        dicom_test_files::path("pydicom/JPEG2000.dcm").expect("test DICOM file should exist");
+    let object = OpenFileOptions::new()
+        .read_to(tags::PIXEL_DATA)
+        .read_until(tags::PIXEL_DATA)
+        .open_file(&path)
+        .expect("File should open successfully");
+
+    // contains other elements such as modality
+    let element = object.element(tags::MODALITY).unwrap();
+    assert_eq!(element.value().to_str().unwrap(), "NM");
+
+    // read_until wins: pixel data is excluded
+    assert!(matches!(
+        object.element(tags::PIXEL_DATA),
+        Err(dicom_object::AccessError::NoSuchDataElementTag { .. })
+    ));
+}
+
+#[test]
 fn test_read_data_with_preamble() {
     let path = dicom_test_files::path("pydicom/liver.dcm").expect("test DICOM file should exist");
     let source = BufReader::new(File::open(path).unwrap());


### PR DESCRIPTION
`read_until` is a parameter that reads a file until it finds a specific tag and excludes it from the results. The problem is that, to speed up reading data from disk, I often want to read only part of file. 
In that case, I currently need to manually determine a greater tag to search for in order to include the desired one, e.g. to read MANUFACTURER_MODEL_NAME, I need to read until I find SERIES_INSTANCE_UID(or other greater tag), which looks quite strange
```
    let obj = OpenFileOptions::new()
        .read_until(tags::SERIES_INSTANCE_UID) 
        .open_file(path)
        .ok()?
        .into_inner();
```

`read_to` reads data up to and including the specified tag, without discarding it.