### PR TITLE
Fix linear LUT transform based on window level and add constructors for 8-bit LUTs

### DIFF
--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -398,17 +398,27 @@ pub enum ModalityLutOption {
 #[non_exhaustive]
 pub enum VoiLutOption {
     /// _Default behavior:_
-    /// apply the first VOI LUT function transformation described in the pixel data
-    /// only when converting to an image;
-    /// no VOI LUT function is performed
-    /// when converting to an ndarray or to bare pixel values.
+    /// apply the first VOI LUT function transformation
+    /// described in the pixel data object,
+    /// but only when converting to an image;
+    /// no VOI LUT function transformation is performed
+    /// when converting to an ndarray or to a bare pixel value vector.
     ///
-    /// If both a VOI LUT table and window values are present in the pixel data,
-    /// use the VOI LUT table.
+    /// If both a VOI LUT table and window values
+    /// are present in the pixel data object,
+    /// the VOI LUT table is used.
+    /// When converting to an image,
+    /// if no transformation parameters are defined,
+    /// pixel values are min-max normalized
+    /// as described in [`Normalize`](Self::Normalize).
     #[default]
     Default,
     /// Apply the first VOI LUT function transformation
-    /// described in the pixel data.
+    /// described in the pixel data object.
+    ///
+    /// If no transformation parameters are defined,
+    /// pixel values are min-max normalized
+    /// as described in [`Normalize`](Self::Normalize).
     First,
     /// Apply a custom window level instead of the one described in the object.
     Custom(WindowLevel),
@@ -2573,8 +2583,9 @@ mod tests {
         assert_eq!(ndarray[[0, 127, 127, 0]], 0x038D);
     }
 
-    /// conversion of a 16-bit image to a vector of 16-bit processed pixel values
-    /// takes advantage of the output's full spectrum
+    /// Conversion of a 16-bit image to a vector of 16-bit processed pixel values
+    /// when the image does not provide VOI LUT transform properties
+    /// takes advantage of the output's full spectrum.
     #[test]
     fn test_to_vec_16bit_to_window() {
         let test_file = dicom_test_files::path("pydicom/CT_small.dcm").unwrap();
@@ -2582,7 +2593,9 @@ mod tests {
 
         let decoded = obj.decode_pixel_data().unwrap();
         let options = ConvertOptions::new()
+            // will default to intercept = 1 and slope = 1
             .with_modality_lut(ModalityLutOption::Default)
+            // no window levels, so it will normalize
             .with_voi_lut(VoiLutOption::First);
         let values = decoded.to_vec_with_options::<u16>(&options).unwrap();
 

--- a/pixeldata/src/lut.rs
+++ b/pixeldata/src/lut.rs
@@ -387,6 +387,61 @@ where
     }
 }
 
+impl Lut<u8> {
+    /// Create a new 8-bit LUT containing the modality rescale transformation
+    /// and the VOI transformation defined by a window level.
+    ///
+    /// The amplitude of the output values goes from 0 to `255`.
+    ///
+    /// - `bits_stored`:
+    ///   the number of bits effectively used to represent the sample values
+    ///   (the _Bits Stored_ DICOM attribute)
+    /// - `signed`:
+    ///   whether the input sample values are expected to be signed
+    ///   (_Pixel Representation_ = 1)
+    /// - `rescale`: the rescale parameters
+    /// - `voi`: the value of interest (VOI) function and parameters
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bits_stored` is 0 or too large.
+    pub fn new_rescale_and_window_8bit(
+        bits_stored: u16,
+        signed: bool,
+        rescale: Rescale,
+        voi: WindowLevelTransform,
+    ) -> Result<Self, CreateLutError> {
+        Self::new_with_fn(bits_stored, signed, |v| {
+            let v = rescale.apply(v);
+            voi.apply(v, 255.)
+        })
+    }
+
+    /// Create a new 8-bit LUT containing
+    /// a VOI transformation defined by a window level.
+    ///
+    /// The amplitude of the output values goes from 0 to 255.
+    ///
+    /// - `bits_stored`:
+    ///   the number of bits effectively used to represent the sample values
+    ///   (the _Bits Stored_ DICOM attribute)
+    /// - `signed`:
+    ///   whether the input sample values are expected to be signed
+    ///   (_Pixel Representation_ = 1)
+    /// - `voi`: the value of interest (VOI) function and parameters
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bits_stored` is 0 or too large.
+    pub fn new_window_8bit(
+        bits_stored: u16,
+        signed: bool,
+        voi: WindowLevelTransform,
+    ) -> Result<Self, CreateLutError> {
+        Self::new_with_fn(bits_stored, signed, |v| voi.apply(v, 255.))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{VoiLutFunction, WindowLevel};

--- a/pixeldata/src/lut.rs
+++ b/pixeldata/src/lut.rs
@@ -209,7 +209,7 @@ where
 
         // create a linear window level transform
         let voi = WindowLevelTransform::linear(crate::WindowLevel {
-            width: max - min + 1.,
+            width: max - min,
             center: (min + max) / 2.,
         });
 
@@ -575,5 +575,62 @@ mod tests {
 
         let y = lut.get(498_u16);
         assert!(y > 0 && y < 0xFFFF);
+    }
+
+    /// Validates the linear LUT function against the examples found in
+    /// [PS3.3 C.11.2.1.2.1][1].
+    /// [1]: https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.11.2.html#sect_C.11.2.1.2.1
+    #[test]
+    fn lut_8bit() {
+        // c=2048, w=4096
+        let lut = Lut::new_window_8bit(16, false, WindowLevelTransform::linear(
+            WindowLevel { width: 4096., center: 2048. }
+        )).expect("should have created LUT successfully");
+
+        assert_eq!(lut.get(0_u16), 0);
+        assert_eq!(lut.get(4096_u16), 255);
+        assert_eq!(lut.get(4097_u16), 255);
+        assert_eq!(lut.get(5555_u16), 255);
+        assert_eq!(lut.get(65535_u16), 255);
+
+        let x = 500_u16;
+        let y = ((x as f64 - 2047.5) / 4095. + 0.5) * 255.;
+        assert_eq!(lut.get(x), y as u8);
+
+        // c=2048, w=1
+        let lut = Lut::new_window_8bit(16, false, WindowLevelTransform::linear(
+            WindowLevel { width: 1., center: 2048. }
+        )).expect("should have created LUT successfully");
+
+        assert_eq!(lut.get(0_u16), 0);
+        assert_eq!(lut.get(100_u16), 0);
+        assert_eq!(lut.get(1000_u16), 0);
+        assert_eq!(lut.get(2047_u16), 0);
+        assert_eq!(lut.get(2048_u16), 255);
+        assert_eq!(lut.get(2049_u16), 255);
+        assert_eq!(lut.get(5555_u16), 255);
+        assert_eq!(lut.get(65535_u16), 255);
+
+        // c=0, w=100, signed
+        let lut = Lut::new_window_8bit(8, true, WindowLevelTransform::linear(
+            WindowLevel { width: 100., center: 0. }
+        )).expect("should have created LUT successfully");
+
+        assert_eq!(lut.get((-50_i8).cast_unsigned()), 0);
+        assert_eq!(lut.get(50_u8), 255);
+
+        let x: u8 = 10;
+        let y = ((x as f64 + 0.5) / 99. + 0.5) * 255.;
+        assert_eq!(lut.get(x), y as u8);
+
+        // c=0, w=1, signed
+        let lut = Lut::new_window_8bit(8, true, WindowLevelTransform::linear(
+            WindowLevel { width: 1., center: 0. }
+        )).expect("should have created LUT successfully");
+
+        assert_eq!(lut.get((-2_i8).cast_unsigned()), 0);
+        assert_eq!(lut.get((-1_i8).cast_unsigned()), 0);
+        assert_eq!(lut.get(0_u8), 255);
+        assert_eq!(lut.get(1_u8), 255);
     }
 }

--- a/pixeldata/src/transform.rs
+++ b/pixeldata/src/transform.rs
@@ -144,7 +144,9 @@ fn window_level_linear(value: f64, window_width: f64, window_center: f64, y_max:
 
     // C.11.2.1.2.1
 
-    let min = wc - (ww - 1.) / 2.;
+    // c - 0.5 - (w-1) /2)
+    let min = wc - 0.5 - (ww - 1.) / 2.;
+    // c - 0.5 + (w-1) /2)
     let max = wc - 0.5 + (ww - 1.) / 2.;
 
     if value <= min {


### PR DESCRIPTION
Resolves #724.

### Summary

- [pixeldata] New: add LUT constructor functions for 8-bit LUTs
   - Instead of inferring the output spectrum from `bits_stored`, the LUTs constructed using these fucntions output values between 0 and 255 regardless of the input bit depth.
- [pixeldata] Fix linear LUT transform based on window level
   - Rigorously follow the specification in [PS3.3 C.11.2.1.2.1](https://dicom.nema.org/medical/dicom/2026a/output/chtml/part03/sect_C.11.2.html#sect_C.11.2.1.2.1), accounting for the missing `- 0.5` in the minimum intensity threshold
   - adjust VOI normalize transform accordingly, so that the outputs continue to span the full spectrum
   - clarify the behavior of `VoiLutOption::Default` and `VoiLutOption::First`
   - clarify that `test_to_vec_16bit_to_window` normalizes the values because the test file   does not define any window levels
   - add test coverage for 8-bit LUTs, testing the linear LUT transform in the process