### PR TITLE
[ul] Implement role negotiation

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -788,7 +788,10 @@ impl<'a> ClientAssociationOptions<'a> {
         for sub_item in scu_scp_role_selection {
             user_variables.push(UserVariableItem::ScuScpRoleSelectionSubItem(
                 sub_item.0.to_string(),
-                RequestorRoles { scu: sub_item.1, scp: sub_item.2 },
+                RequestorRoles {
+                    scu: sub_item.1,
+                    scp: sub_item.2,
+                },
             ));
         }
 

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -23,8 +23,8 @@ use crate::{
     pdu::{
         AbortRQSource, AssociationAC, AssociationRQ, DEFAULT_MAX_PDU, LARGE_PDU_SIZE,
         PDU_HEADER_SIZE, Pdu, PresentationContextNegotiated, PresentationContextProposed,
-        PresentationContextResultReason, UserIdentity, UserIdentityType, UserVariableItem,
-        write_pdu,
+        PresentationContextResultReason, RequestorRoles, UserIdentity, UserIdentityType,
+        UserVariableItem, write_pdu,
     },
 };
 use snafu::{ResultExt, ensure};
@@ -788,8 +788,7 @@ impl<'a> ClientAssociationOptions<'a> {
         for sub_item in scu_scp_role_selection {
             user_variables.push(UserVariableItem::ScuScpRoleSelectionSubItem(
                 sub_item.0.to_string(),
-                sub_item.1,
-                sub_item.2,
+                RequestorRoles { scu: sub_item.1, scp: sub_item.2 },
             ));
         }
 

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -265,6 +265,8 @@ pub struct ClientAssociationOptions<'a> {
     jwt: Option<Cow<'a, str>>,
     /// Extended Negotiation info
     extended_negotiation: Vec<(Cow<'a, str>, Vec<u8>)>,
+    /// SCU/SCP Role Selection info
+    scu_scp_role_selection: Vec<(Cow<'a, str>, bool, bool)>,
     /// Socket options for TCP connections
     socket_options: SocketOptions,
     /// TLS configuration to use for the connection
@@ -295,6 +297,7 @@ impl Default for ClientAssociationOptions<'_> {
             saml_assertion: None,
             jwt: None,
             extended_negotiation: Vec::new(),
+            scu_scp_role_selection: Vec::new(),
             socket_options: SocketOptions {
                 read_timeout: None,
                 write_timeout: None,
@@ -516,6 +519,15 @@ impl<'a> ClientAssociationOptions<'a> {
         self
     }
 
+    pub fn with_role_selection<T>(mut self, sop_class: T, scu_role: bool, scp_role: bool) -> Self
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        self.scu_scp_role_selection
+            .push((sop_class.into(), scu_role, scp_role));
+        self
+    }
+
     /// Set the TLS configuration to use for the connection
     #[cfg(feature = "sync-tls")]
     pub fn tls_config(mut self, config: impl Into<std::sync::Arc<rustls::ClientConfig>>) -> Self {
@@ -707,6 +719,7 @@ impl<'a> ClientAssociationOptions<'a> {
             saml_assertion,
             jwt,
             extended_negotiation,
+            scu_scp_role_selection,
             ..
         } = self;
         // fail if no presentation contexts were provided: they represent intent,
@@ -754,6 +767,13 @@ impl<'a> ClientAssociationOptions<'a> {
             user_variables.push(UserVariableItem::SopClassExtendedNegotiationSubItem(
                 sub_item.0.to_string(),
                 sub_item.1.clone(),
+            ));
+        }
+        for sub_item in scu_scp_role_selection {
+            user_variables.push(UserVariableItem::ScuScpRoleSelectionSubItem(
+                sub_item.0.to_string(),
+                sub_item.1,
+                sub_item.2,
             ));
         }
 

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -15,20 +15,21 @@ use std::{
 #[cfg(feature = "async")]
 use crate::association::AsyncAssociation;
 use crate::{
+    AeAddr, IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
     association::{
-        encode_pdu, extended_negotiation_filter_impl, private::SyncAssociationSealed,
-        read_pdu_from_wire, Association, NegotiatedOptions, SocketOptions, SyncAssociation,
+        Association, NegotiatedOptions, SocketOptions, SyncAssociation, encode_pdu,
+        extended_negotiation_filter_impl, private::SyncAssociationSealed, read_pdu_from_wire,
     },
     pdu::{
-        write_pdu, AbortRQSource, AssociationAC, AssociationRQ, Pdu, PresentationContextNegotiated,
-        PresentationContextProposed, PresentationContextResultReason, UserIdentity,
-        UserIdentityType, UserVariableItem, DEFAULT_MAX_PDU, LARGE_PDU_SIZE, PDU_HEADER_SIZE,
+        AbortRQSource, AssociationAC, AssociationRQ, DEFAULT_MAX_PDU, LARGE_PDU_SIZE,
+        PDU_HEADER_SIZE, Pdu, PresentationContextNegotiated, PresentationContextProposed,
+        PresentationContextResultReason, UserIdentity, UserIdentityType, UserVariableItem,
+        write_pdu,
     },
-    AeAddr, IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
 };
-use snafu::{ensure, ResultExt};
+use snafu::{ResultExt, ensure};
 
-use super::{uid::trim_uid, Result};
+use super::{Result, uid::trim_uid};
 
 // stray module from 0.9.0, remove in 0.10.0
 #[deprecated(since = "0.9.1")]
@@ -519,6 +520,21 @@ impl<'a> ClientAssociationOptions<'a> {
         self
     }
 
+    /// Tell the server the roles that the client is willing to assume
+    /// for a given SOP class. Normally the client's role is SCU and not
+    /// SCP, and indeed that's the default in absence of a role
+    /// selection for a particular SOP Class; however, in the case of
+    /// C-GET, the client becomes the SCP when the server starts making
+    /// C-STORE requests, so in case of using C-GET, for each SOP Class
+    /// that the client wishes to retrieve, an entry should be added
+    /// with `scp_role` set to `true`. For these cases, if the client
+    /// also wants to send files to the server via C-STORE of any of
+    /// these SOP Classes as well, the `scu_role` should also be set to
+    /// `true`. Ultimately, the server may reject any of these roles,
+    /// so the client should check the result of the negotiation for a
+    /// particular SOP Class using
+    /// [`requestor_roles_for`](Association::requestor_roles_for)
+    /// before performing any operation on that SOP class.
     pub fn with_role_selection<T>(mut self, sop_class: T, scu_role: bool, scp_role: bool) -> Self
     where
         T: Into<Cow<'a, str>>,

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -45,7 +45,10 @@ use snafu::{ResultExt, Snafu, ensure};
 
 use crate::{
     Pdu,
-    pdu::{self, AssociationRJ, PresentationContextNegotiated, ReadPduSnafu, UserVariableItem},
+    pdu::{
+        self, AssociationRJ, PresentationContextNegotiated, ReadPduSnafu, UserVariableItem,
+        RequestorRoles,
+    },
     write_pdu,
 };
 
@@ -210,14 +213,6 @@ pub(crate) struct SocketOptions {
     connection_timeout: Option<Duration>,
 }
 
-/// Roles that the association requestor can adopt for a
-/// particular SOP class.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct RequestorRoles {
-    pub scu: bool,
-    pub scp: bool,
-}
-
 /// Trait to close underlying socket
 pub trait CloseSocket {
     fn close(&mut self) -> std::io::Result<()>;
@@ -309,13 +304,10 @@ pub trait Association {
         self.user_variables()
             .iter()
             .find_map(|uv| match uv {
-                UserVariableItem::ScuScpRoleSelectionSubItem(uid, scu_role, scp_role)
+                UserVariableItem::ScuScpRoleSelectionSubItem(uid, roles)
                     if uid == sop_class_uid =>
                 {
-                    Some(RequestorRoles {
-                        scu: *scu_role,
-                        scp: *scp_role,
-                    })
+                    Some(*roles)
                 }
                 _ => None,
             })

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -46,8 +46,8 @@ use snafu::{ResultExt, Snafu, ensure};
 use crate::{
     Pdu,
     pdu::{
-        self, AssociationRJ, PresentationContextNegotiated, ReadPduSnafu, UserVariableItem,
-        RequestorRoles,
+        self, AssociationRJ, PresentationContextNegotiated, ReadPduSnafu, RequestorRoles,
+        UserVariableItem,
     },
     write_pdu,
 };

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -41,11 +41,12 @@ pub use pdata::{PDataReader, PDataWriter};
 #[cfg(feature = "async")]
 pub use server::AsyncServerAssociation;
 pub use server::{ServerAssociation, ServerAssociationOptions};
-use snafu::{ensure, ResultExt, Snafu};
+use snafu::{ResultExt, Snafu, ensure};
 
 use crate::{
+    Pdu,
     pdu::{self, AssociationRJ, PresentationContextNegotiated, ReadPduSnafu, UserVariableItem},
-    write_pdu, Pdu,
+    write_pdu,
 };
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -209,6 +210,14 @@ pub(crate) struct SocketOptions {
     connection_timeout: Option<Duration>,
 }
 
+/// Roles that the association requestor can adopt for a
+/// particular SOP class.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct RequestorRoles {
+    pub scu: bool,
+    pub scp: bool,
+}
+
 /// Trait to close underlying socket
 pub trait CloseSocket {
     fn close(&mut self) -> std::io::Result<()>;
@@ -293,17 +302,20 @@ pub trait Association {
     /// Returns `None` if that SOP class was rejected or not requested.
     fn extended_negotiation_for(&self, sop_class_uid: &str) -> Option<&[u8]>;
 
-    /// Roles that the Association-requestor may assume. Returns a pair
-    /// of booleans; the first is whether it can assume an SCU role and
-    /// the second whether it can assume an SCP role.
-    fn requestor_roles_for(&self, sop_class_uid: &str) -> (bool, bool) {
+    /// Roles that the Association-requestor may assume. Returns a
+    /// `RequestorRoles` struct. If the given SOP Class UID was not
+    /// returned by the server, the default values are returned.
+    fn requestor_roles_for(&self, sop_class_uid: &str) -> RequestorRoles {
         self.user_variables()
             .iter()
             .find_map(|uv| match uv {
                 UserVariableItem::ScuScpRoleSelectionSubItem(uid, scu_role, scp_role)
                     if uid == sop_class_uid =>
                 {
-                    Some((*scu_role, *scp_role))
+                    Some(RequestorRoles {
+                        scu: *scu_role,
+                        scp: *scp_role,
+                    })
                 }
                 _ => None,
             })
@@ -312,14 +324,17 @@ pub trait Association {
             // Association-acceptor then the role of the Association-requestor
             // shall be SCU and the role of the Association-acceptor shall be SCP.
             // These apply to the requestor only, so only SCU is set.
-            .unwrap_or((true, false))
+            .unwrap_or(RequestorRoles {
+                scu: true,
+                scp: false,
+            })
     }
 }
 
 mod private {
     use crate::{
-        pdu::{AbortRQServiceProviderReason, AbortRQSource},
         Pdu,
+        pdu::{AbortRQServiceProviderReason, AbortRQSource},
     };
     use snafu::ResultExt;
 

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -292,6 +292,28 @@ pub trait Association {
     ///
     /// Returns `None` if that SOP class was rejected or not requested.
     fn extended_negotiation_for(&self, sop_class_uid: &str) -> Option<&[u8]>;
+
+    /// Roles that the Association-requestor may assume. Returns a pair
+    /// of booleans; the first is whether it can assume an SCU role and
+    /// the second whether it can assume an SCP role.
+    fn requestor_roles_for(&self, sop_class_uid: &str) -> (bool, bool) {
+        self.user_variables()
+            .iter()
+            .find_map(|uv| match uv {
+                UserVariableItem::ScuScpRoleSelectionSubItem(uid, scu_role, scp_role)
+                    if uid == sop_class_uid =>
+                {
+                    Some((*scu_role, *scp_role))
+                }
+                _ => None,
+            })
+            // PS3.7 D.3.3.4:
+            // If the SCP/SCU Role Selection item is not returned by the
+            // Association-acceptor then the role of the Association-requestor
+            // shall be SCU and the role of the Association-acceptor shall be SCP.
+            // These apply to the requestor only, so only SCU is set.
+            .unwrap_or((true, false))
+    }
 }
 
 mod private {

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -224,7 +224,8 @@ pub trait Negotiation {
     /// to be an SCP for the Storage MR SOP Class:
     /// ```no_run
     /// # use dicom_ul::association::server::{Negotiation, ServerAssociationOptions};
-    /// # use dicom_ul::association::{Association, RequestorRoles};
+    /// # use dicom_ul::association::Association;
+    /// # use dicom_ul::pdu::RequestorRoles;
     /// # use std::net::TcpListener;
     /// const STORAGE_MR_SOP_CLASS: &str = "1.2.840.10008.5.1.4.1.1.4";
     /// struct RoleOptions;
@@ -793,15 +794,18 @@ where
                         // SCU/SCP Role Selection negotiation is performed here: add only the
                         // variables for which the user-supplied negotiation function returns
                         // Some(x).
-                        ScuScpRoleSelectionSubItem(sop_class_uid, scu_role, scp_role) => {
-                            if let Some(RequestorRoles { scu, scp }) = self
-                                .negotiation
-                                .negotiate_roles(&sop_class_uid, scu_role, scp_role)
+                        ScuScpRoleSelectionSubItem(
+                            sop_class_uid,
+                            RequestorRoles { scu: scu_requested, scp: scp_requested },
+                        ) => {
+                            if let Some(RequestorRoles { scu: scu_accepted, scp: scp_accepted }) =
+                                self
+                                    .negotiation
+                                    .negotiate_roles(&sop_class_uid, scu_requested, scp_requested)
                             {
                                 new_user_variables.push(ScuScpRoleSelectionSubItem(
                                     sop_class_uid,
-                                    scu,
-                                    scp,
+                                    RequestorRoles { scu: scu_accepted, scp: scp_accepted },
                                 ));
                             }
                         }

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -796,16 +796,25 @@ where
                         // Some(x).
                         ScuScpRoleSelectionSubItem(
                             sop_class_uid,
-                            RequestorRoles { scu: scu_requested, scp: scp_requested },
+                            RequestorRoles {
+                                scu: scu_requested,
+                                scp: scp_requested,
+                            },
                         ) => {
-                            if let Some(RequestorRoles { scu: scu_accepted, scp: scp_accepted }) =
-                                self
-                                    .negotiation
-                                    .negotiate_roles(&sop_class_uid, scu_requested, scp_requested)
-                            {
+                            if let Some(RequestorRoles {
+                                scu: scu_accepted,
+                                scp: scp_accepted,
+                            }) = self.negotiation.negotiate_roles(
+                                &sop_class_uid,
+                                scu_requested,
+                                scp_requested,
+                            ) {
                                 new_user_variables.push(ScuScpRoleSelectionSubItem(
                                     sop_class_uid,
-                                    RequestorRoles { scu: scu_accepted, scp: scp_accepted },
+                                    RequestorRoles {
+                                        scu: scu_accepted,
+                                        scp: scp_accepted,
+                                    },
                                 ));
                             }
                         }

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -201,6 +201,74 @@ pub trait Negotiation {
     fn extended_negotiation(&self, sop_class_uid: &str, input: &[u8]) -> Option<Vec<u8>> {
         None
     }
+
+    /// User-provided negotiation of accepted association-requestor
+    /// (client) roles for a given SOP Class. The client may request
+    /// to be either an SCU, an SCP, or both for any given SOP Class.
+    /// Through this function, the server will decide for that SOP
+    /// Class whether to allow the client to take that role or not.
+    /// Note that if the client specifies `false` for one of its
+    /// roles, it's not allowed for the server to return `true` for
+    /// that role in that SOP Class.
+    ///
+    /// The return value is an `Option<(bool, bool)>`. It shall be
+    /// `None` if this negotiation item is not to be returned to the
+    /// client, or `Some((scu_role, scp_role))` with the accepted
+    /// values.
+    ///
+    /// The default action is to ignore this negotiation and not
+    /// send back any role selection for any SOP CLass, which
+    /// implicitly makes the client be an SCU.
+    ///
+    /// In this example, the server rejects any client's proposal
+    /// to be an SCP for the Storage MR SOP Class:
+    /// ```no_run
+    /// # use dicom_ul::association::server::{Negotiation, ServerAssociationOptions};
+    /// # use dicom_ul::association::Association;
+    /// # use std::net::TcpListener;
+    /// const STORAGE_MR_SOP_CLASS: &str = "1.2.840.10008.5.1.4.1.1.4";
+    /// struct RoleOptions;
+    ///
+    /// impl Negotiation for RoleOptions {
+    ///     fn negotiate_roles(
+    ///         &self,
+    ///         sop_class_uid: &str,
+    ///         scu_role: bool,
+    ///         scp_role: bool,
+    ///     ) -> Option<(bool, bool)> {
+    ///         // Only this SOP Class is supported, so ditch the rest
+    ///         if sop_class_uid != STORAGE_MR_SOP_CLASS {
+    ///             return None;
+    ///         }
+    ///         // Always set SCP role to false
+    ///         Some((scu_role, false))
+    ///     }
+    /// }
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let tcp_listener: TcpListener = unimplemented!();
+    /// let role_options = RoleOptions;
+    ///
+    /// let scp_options = ServerAssociationOptions::new()
+    ///     .with_negotiation(role_options);
+    ///
+    /// let (stream, _address) = tcp_listener.accept()?;
+    /// let assoc = scp_options.establish(stream)?;
+    ///
+    /// // Association is established; read the flags that were negotiated
+    /// // (or not) for the association requestor.
+    /// let (client_is_scu, client_is_scp) = assoc.requestor_roles_for(STORAGE_MR_SOP_CLASS);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn negotiate_roles(
+        &self,
+        _sop_class_uid: &str,
+        _scu_role: bool,
+        _scp_role: bool,
+    ) -> Option<(bool, bool)> {
+        None
+    }
 }
 
 /// A Negotiation rule that causes the server to omit the negotiation in the response, thus forcing
@@ -678,19 +746,74 @@ where
                     return Err((pdu, RejectedSnafu { association_rj }.build()));
                 }
 
+                // User variables resulting from the negotiation are stored here
+                let mut new_user_variables = vec![
+                    UserVariableItem::MaxLength(self.max_pdu_length),
+                    UserVariableItem::ImplementationClassUID(IMPLEMENTATION_CLASS_UID.to_string()),
+                    UserVariableItem::ImplementationVersionName(
+                        IMPLEMENTATION_VERSION_NAME.to_string(),
+                    ),
+                ];
+
+                // Process user variables in a single pass
+                let mut user_identity = None;
+                let mut requestor_max_pdu_length = DEFAULT_MAX_PDU;
+                for user_variable in user_variables {
+                    use UserVariableItem::*;
+                    match user_variable {
+                        UserIdentityItem(negotiated_user_identity) => {
+                            user_identity = Some(negotiated_user_identity);
+                        }
+
+                        MaxLength(len) => {
+                            requestor_max_pdu_length = if len == 0 {
+                                // treat 0 as practically unlimited,
+                                // so use the largest 32-bit unsigned number
+                                u32::MAX
+                            } else {
+                                len
+                            };
+                        }
+
+                        // Extended negotiation is performed here: add only the variables
+                        // for which the user-supplied negotiation function returns Some(x).
+                        SopClassExtendedNegotiationSubItem(sop_class_uid, scai) => {
+                            if let Some(extended_negotiation_result) =
+                                self.negotiation.extended_negotiation(&sop_class_uid, &scai)
+                            {
+                                new_user_variables.push(SopClassExtendedNegotiationSubItem(
+                                    sop_class_uid.clone(),
+                                    extended_negotiation_result,
+                                ));
+                            }
+                        }
+
+                        // SCU/SCP Role Selection negotiation is performed here: add only the
+                        // variables for which the user-supplied negotiation function returns
+                        // Some(x).
+                        ScuScpRoleSelectionSubItem(sop_class_uid, scu_role, scp_role) => {
+                            if let Some((scu, scp)) =
+                                self.negotiation
+                                    .negotiate_roles(&sop_class_uid, scu_role, scp_role)
+                            {
+                                new_user_variables.push(ScuScpRoleSelectionSubItem(
+                                    sop_class_uid,
+                                    scu,
+                                    scp,
+                                ));
+                            }
+                        }
+
+                        _ => (),
+                    }
+                }
+
                 self.ae_access_control
                     .check_access(
                         &self.ae_title,
                         &calling_ae_title,
                         &called_ae_title,
-                        user_variables
-                            .iter()
-                            .find_map(|user_variable| match user_variable {
-                                UserVariableItem::UserIdentityItem(user_identity) => {
-                                    Some(user_identity)
-                                }
-                                _ => None,
-                            }),
+                        user_identity.as_ref(),
                     )
                     .map(Ok)
                     .unwrap_or_else(|reason| {
@@ -701,23 +824,6 @@ where
                         let pdu = Pdu::AssociationRJ(association_rj.clone());
                         Err((pdu, RejectedSnafu { association_rj }.build()))
                     })?;
-
-                // fetch requested maximum PDU length
-                let requestor_max_pdu_length = user_variables
-                    .iter()
-                    .find_map(|item| match item {
-                        UserVariableItem::MaxLength(len) => Some(*len),
-                        _ => None,
-                    })
-                    .unwrap_or(DEFAULT_MAX_PDU);
-
-                // treat 0 as practically unlimited,
-                // so use the largest 32-bit unsigned number
-                let requestor_max_pdu_length = if requestor_max_pdu_length == 0 {
-                    u32::MAX
-                } else {
-                    requestor_max_pdu_length
-                };
 
                 let presentation_contexts_negotiated: Vec<_> = presentation_contexts
                     .into_iter()
@@ -752,34 +858,6 @@ where
                         }
                     })
                     .collect();
-
-                let mut new_user_variables = vec![
-                    UserVariableItem::MaxLength(self.max_pdu_length),
-                    UserVariableItem::ImplementationClassUID(IMPLEMENTATION_CLASS_UID.to_string()),
-                    UserVariableItem::ImplementationVersionName(
-                        IMPLEMENTATION_VERSION_NAME.to_string(),
-                    ),
-                ];
-                // Extended negotiation is performed here: add only the variables
-                // for which the user-supplied negotiation function returns Some(x).
-                for item in user_variables.iter() {
-                    if let UserVariableItem::SopClassExtendedNegotiationSubItem(
-                        sop_class_uid,
-                        scai,
-                    ) = item
-                    {
-                        if let Some(extended_negotiation_result) =
-                            self.negotiation.extended_negotiation(sop_class_uid, scai)
-                        {
-                            new_user_variables.push(
-                                UserVariableItem::SopClassExtendedNegotiationSubItem(
-                                    sop_class_uid.clone(),
-                                    extended_negotiation_result,
-                                ),
-                            );
-                        }
-                    }
-                }
 
                 let pdu = Pdu::AssociationAC(AssociationAC {
                     protocol_version: self.protocol_version,

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -19,7 +19,7 @@ use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use snafu::{ResultExt, ensure};
 
-use crate::association::NegotiatedOptions;
+use crate::association::{NegotiatedOptions, RequestorRoles};
 use crate::pdu::{LARGE_PDU_SIZE, PresentationContextNegotiated};
 use crate::{
     IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
@@ -224,7 +224,7 @@ pub trait Negotiation {
     /// to be an SCP for the Storage MR SOP Class:
     /// ```no_run
     /// # use dicom_ul::association::server::{Negotiation, ServerAssociationOptions};
-    /// # use dicom_ul::association::Association;
+    /// # use dicom_ul::association::{Association, RequestorRoles};
     /// # use std::net::TcpListener;
     /// const STORAGE_MR_SOP_CLASS: &str = "1.2.840.10008.5.1.4.1.1.4";
     /// struct RoleOptions;
@@ -235,13 +235,13 @@ pub trait Negotiation {
     ///         sop_class_uid: &str,
     ///         scu_role: bool,
     ///         scp_role: bool,
-    ///     ) -> Option<(bool, bool)> {
+    ///     ) -> Option<RequestorRoles> {
     ///         // Only this SOP Class is supported, so ditch the rest
     ///         if sop_class_uid != STORAGE_MR_SOP_CLASS {
     ///             return None;
     ///         }
     ///         // Always set SCP role to false
-    ///         Some((scu_role, false))
+    ///         Some(RequestorRoles { scu: scu_role, scp: false })
     ///     }
     /// }
     ///
@@ -257,16 +257,18 @@ pub trait Negotiation {
     ///
     /// // Association is established; read the flags that were negotiated
     /// // (or not) for the association requestor.
-    /// let (client_is_scu, client_is_scp) = assoc.requestor_roles_for(STORAGE_MR_SOP_CLASS);
+    /// let RequestorRoles { scu: client_is_scu, scp: client_is_scp } =
+    ///     assoc.requestor_roles_for(STORAGE_MR_SOP_CLASS);
     /// # Ok(())
     /// # }
     /// ```
+    #[allow(unused_variables)]
     fn negotiate_roles(
         &self,
-        _sop_class_uid: &str,
-        _scu_role: bool,
-        _scp_role: bool,
-    ) -> Option<(bool, bool)> {
+        sop_class_uid: &str,
+        scu_role: bool,
+        scp_role: bool,
+    ) -> Option<RequestorRoles> {
         None
     }
 }
@@ -792,9 +794,9 @@ where
                         // variables for which the user-supplied negotiation function returns
                         // Some(x).
                         ScuScpRoleSelectionSubItem(sop_class_uid, scu_role, scp_role) => {
-                            if let Some((scu, scp)) =
-                                self.negotiation
-                                    .negotiate_roles(&sop_class_uid, scu_role, scp_role)
+                            if let Some(RequestorRoles { scu, scp }) = self
+                                .negotiation
+                                .negotiate_roles(&sop_class_uid, scu_role, scp_role)
                             {
                                 new_user_variables.push(ScuScpRoleSelectionSubItem(
                                     sop_class_uid,

--- a/ul/src/association/tests.rs
+++ b/ul/src/association/tests.rs
@@ -1,4 +1,4 @@
-use dicom_core::{dicom_value, DataElement, VR};
+use dicom_core::{DataElement, VR, dicom_value};
 use dicom_dictionary_std::{tags, uids::VERIFICATION};
 use dicom_object::InMemDicomObject;
 use dicom_transfer_syntax_registry::entries::IMPLICIT_VR_LITTLE_ENDIAN;
@@ -32,8 +32,8 @@ mod successive_pdus_during_client_association {
 
     use super::*;
     use crate::{
-        pdu::{AbortRQServiceProviderReason, AbortRQSource, PDataValue, PDataValueType},
         ClientAssociationOptions, Pdu,
+        pdu::{AbortRQServiceProviderReason, AbortRQSource, PDataValue, PDataValueType},
     };
 
     use crate::association::server::*;
@@ -424,8 +424,8 @@ mod successive_pdus_during_server_association {
     use super::*;
     use crate::association::server::*;
     use crate::{
-        pdu::{PDataValue, PDataValueType},
         AeAddr, ClientAssociationOptions, Pdu,
+        pdu::{PDataValue, PDataValueType},
     };
     use std::net::TcpListener;
 

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -482,6 +482,14 @@ pub enum PduVariableItem {
     UserVariables(Vec<UserVariableItem>),
 }
 
+/// Roles that the association requestor can adopt for a
+/// particular SOP class.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd)]
+pub struct RequestorRoles {
+    pub scu: bool,
+    pub scp: bool,
+}
+
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Debug)]
 pub enum UserVariableItem {
     Unknown(u8, Vec<u8>),
@@ -489,7 +497,7 @@ pub enum UserVariableItem {
     ImplementationClassUID(String),
     ImplementationVersionName(String),
     SopClassExtendedNegotiationSubItem(String, Vec<u8>),
-    ScuScpRoleSelectionSubItem(String, bool, bool),
+    ScuScpRoleSelectionSubItem(String, RequestorRoles),
     UserIdentityItem(UserIdentity),
 }
 
@@ -500,6 +508,7 @@ pub struct UserIdentity {
     primary_field: Vec<u8>,
     secondary_field: Vec<u8>,
 }
+
 impl UserIdentity {
     pub fn new(
         positive_response_requested: bool,
@@ -541,6 +550,7 @@ pub enum UserIdentityType {
     SamlAssertion,
     Jwt,
 }
+
 impl UserIdentityType {
     fn from(user_identity_type: u8) -> Option<Self> {
         match user_identity_type {

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -489,6 +489,7 @@ pub enum UserVariableItem {
     ImplementationClassUID(String),
     ImplementationVersionName(String),
     SopClassExtendedNegotiationSubItem(String, Vec<u8>),
+    ScuScpRoleSelectionSubItem(String, bool, bool),
     UserIdentityItem(UserIdentity),
 }
 

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -11,7 +11,7 @@ use std::fmt::Display;
 
 pub use reader::read_pdu;
 use snafu::{Backtrace, Snafu};
-pub use writer::{write_pdu, WriteChunkError};
+pub use writer::{WriteChunkError, write_pdu};
 
 /// The length of the PDU header in bytes,
 /// comprising the PDU type (1 byte),
@@ -102,7 +102,9 @@ pub enum ReadError {
     #[snafu(display("Invalid item length {} (must be >=2)", length))]
     InvalidItemLength { length: u32 },
 
-    #[snafu(display("SOP Class Extended Negotiation item length {length} is too short (should be >= 2 + SOP Class UID length {sop_class_uid_length})"))]
+    #[snafu(display(
+        "SOP Class Extended Negotiation item length {length} is too short (should be >= 2 + SOP Class UID length {sop_class_uid_length})"
+    ))]
     ShortSopClassExtendedNegotiationItemLength {
         length: u32,
         sop_class_uid_length: u16,

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -730,6 +730,64 @@ fn read_pdu_variable(mut buf: impl Buf, codec: &dyn TextCodec) -> Result<Option<
                             implementation_class_uid,
                         ));
                     }
+                    0x54 => {
+                        // SCP/SCU Role Selection Sub-Item Structure
+
+                        // 5-6 - UID-length - This UID-length shall be the number of bytes from the
+                        // first byte of the following field to the last byte of the SOP-class-uid
+                        // field. It shall be encoded as an unsigned binary number.
+                        if bytes.remaining() < 2 {
+                            return Ok(None);
+                        }
+                        let sop_class_uid_length = bytes.get_u16();
+
+                        // 7 - xxx - SOP-class-uid - The SOP Class or Meta SOP Class identifier
+                        // encoded as a UID as defined in Section 9 “Unique Identifiers (UIDs)” in PS3.5.
+                        if bytes.remaining() < sop_class_uid_length as usize {
+                            return Ok(None);
+                        }
+                        let sop_class_uid = codec
+                            .decode(bytes.copy_to_bytes(sop_class_uid_length as usize).as_ref())
+                            .context(DecodeTextSnafu {
+                                field: "SOP-class-uid",
+                            })?
+                            .trim()
+                            .to_string();
+
+                        // xxx - SCU-role - This byte field shall contain the SCU-role as defined in
+                        // Section D.3.3.4. It shall be encoded as an unsigned binary and shall use
+                        // one of the following values:
+                        //
+                        // 0 - The Association-acceptor rejects the Association-requestor's proposal
+                        // of the SCU role selection
+                        //
+                        // 1 - The Association-acceptor accepts the Association-requestor's proposal
+                        // of the SCU role selection
+                        if bytes.remaining() < 1 {
+                            return Ok(None);
+                        }
+                        let scu_role = bytes.get_u8() != 0;
+
+                        // xxx - SCP-role - This byte field shall contain the SCP-role as defined
+                        // for the Association-acceptor in Section D.3.3.4. It shall be encoded as
+                        // an unsigned binary and shall use one of the following values:
+                        //
+                        // 0 - The Association-acceptor rejects the Association-requestor's proposal
+                        // of the SCP role selection
+                        //
+                        // 1 - The Association-acceptor accepts the Association-requestor's proposal
+                        // of the SCP role selection
+                        if bytes.remaining() < 1 {
+                            return Ok(None);
+                        }
+                        let scp_role = bytes.get_u8() != 0;
+
+                        user_variables.push(UserVariableItem::ScuScpRoleSelectionSubItem(
+                            sop_class_uid,
+                            scu_role,
+                            scp_role,
+                        ));
+                    }
                     0x55 => {
                         // Implementation Version Name Structure
 

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -2,7 +2,7 @@
 use crate::pdu::*;
 use bytes::Buf;
 use dicom_encoding::text::{DefaultCharacterSetCodec, TextCodec};
-use snafu::{ensure, OptionExt, ResultExt};
+use snafu::{OptionExt, ResultExt, ensure};
 use tracing::warn;
 
 pub type Error = crate::pdu::ReadError;
@@ -784,7 +784,10 @@ fn read_pdu_variable(mut buf: impl Buf, codec: &dyn TextCodec) -> Result<Option<
 
                         user_variables.push(UserVariableItem::ScuScpRoleSelectionSubItem(
                             sop_class_uid,
-                            RequestorRoles { scu: scu_role, scp: scp_role },
+                            RequestorRoles {
+                                scu: scu_role,
+                                scp: scp_role,
+                            },
                         ));
                     }
                     0x55 => {

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -784,8 +784,7 @@ fn read_pdu_variable(mut buf: impl Buf, codec: &dyn TextCodec) -> Result<Option<
 
                         user_variables.push(UserVariableItem::ScuScpRoleSelectionSubItem(
                             sop_class_uid,
-                            scu_role,
-                            scp_role,
+                            RequestorRoles { scu: scu_role, scp: scp_role },
                         ));
                     }
                     0x55 => {

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -951,7 +951,10 @@ fn write_pdu_variable_user_variables(
                         name: "Implementation-class-uid",
                     })?;
                 }
-                UserVariableItem::ScuScpRoleSelectionSubItem(sop_class_uid, scu_role, scp_role) => {
+                UserVariableItem::ScuScpRoleSelectionSubItem(
+                    sop_class_uid,
+                    RequestorRoles { scu: scu_role, scp: scp_role },
+                ) => {
                     // 1 - Item-type - 54H
                     writer
                         .write_u8(0x54)

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -953,7 +953,10 @@ fn write_pdu_variable_user_variables(
                 }
                 UserVariableItem::ScuScpRoleSelectionSubItem(
                     sop_class_uid,
-                    RequestorRoles { scu: scu_role, scp: scp_role },
+                    RequestorRoles {
+                        scu: scu_role,
+                        scp: scp_role,
+                    },
                 ) => {
                     // 1 - Item-type - 54H
                     writer

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -951,6 +951,50 @@ fn write_pdu_variable_user_variables(
                         name: "Implementation-class-uid",
                     })?;
                 }
+                UserVariableItem::ScuScpRoleSelectionSubItem(sop_class_uid, scu_role, scp_role) => {
+                    // 1 - Item-type - 54H
+                    writer
+                        .write_u8(0x54)
+                        .context(WriteFieldSnafu { field: "Item-type" })?;
+
+                    // 2 - Reserved - This reserved field shall be sent with a value 00H but not
+                    // tested to this value when received.
+                    writer
+                        .write_u8(0x00)
+                        .context(WriteReservedSnafu { bytes: 1_u32 })?;
+
+                    // 3-4 - Item-length
+                    write_chunk_u16(writer, |writer| {
+                        // 5-6 - UID-length
+                        write_chunk_u16(writer, |writer| {
+                            //  7-xxx - The SOP Class or Meta SOP Class identifier encoded as a UID
+                            //  as defined in Section 9 “Unique Identifiers (UIDs)” in PS3.5.
+                            writer
+                                .write_all(&codec.encode(sop_class_uid).context(
+                                    EncodeFieldSnafu {
+                                        field: "SOP-class-uid",
+                                    },
+                                )?)
+                                .context(WriteFieldSnafu {
+                                    field: "SOP-class-uid",
+                                })
+                        })
+                        .context(WriteChunkSnafu {
+                            name: "SOP-class-uid",
+                        })?;
+
+                        // xxx - SCU-role
+                        writer
+                            .write_u8(if *scu_role { 1 } else { 0 })
+                            .context(WriteFieldSnafu { field: "SCU-role" })?;
+
+                        // xxx - SCP-role
+                        writer
+                            .write_u8(if *scp_role { 1 } else { 0 })
+                            .context(WriteFieldSnafu { field: "SCP-role" })
+                    })
+                    .context(WriteChunkSnafu { name: "Sub-item" })?;
+                }
                 UserVariableItem::SopClassExtendedNegotiationSubItem(sop_class_uid, data) => {
                     // 1 - Item-type - 56H
                     writer

--- a/ul/tests/association_echo.rs
+++ b/ul/tests/association_echo.rs
@@ -71,6 +71,21 @@ fn spawn_scp(
                 None
             }
         }
+
+        fn negotiate_roles(
+            &self,
+            sop_class_uid: &str,
+            scu: bool,
+            scp: bool,
+        ) -> Option<(bool, bool)> {
+            if sop_class_uid == "1.2.3.4" {
+                Some((scu, scp))
+            } else if sop_class_uid == "1.2.3.5" {
+                Some((false, scp))
+            } else {
+                None
+            }
+        }
     }
     let test_negotiation = TestNegotiation;
 
@@ -127,6 +142,10 @@ fn spawn_scp(
             association.extended_negotiation_for("1.2.3.7"), // not offered by client
             None
         );
+        assert_eq!(association.requestor_roles_for("1.2.3.4"), (true, true));
+        assert_eq!(association.requestor_roles_for("1.2.3.5"), (false, true));
+        assert_eq!(association.requestor_roles_for("1.2.3.6"), (true, false));
+        assert_eq!(association.requestor_roles_for("1.2.3.7"), (true, false));
 
         // handle one bogus payload
         let pdu = association.receive()?;
@@ -358,6 +377,9 @@ fn run_scu_scp_association_test(max_is_client: bool) {
         .with_extended_negotiation("1.2.3.4", &[1, 1, 0, 0])
         .with_extended_negotiation("1.2.3.5", &[0, 1, 1, 1])
         .with_extended_negotiation("1.2.3.6", &[1, 1, 1, 1])
+        .with_role_selection("1.2.3.4", true, true)
+        .with_role_selection("1.2.3.5", true, true)
+        .with_role_selection("1.2.3.6", true, true)
         .max_pdu_length(max_client_pdu_len as u32)
         .establish(scp_addr)
         .unwrap();
@@ -386,6 +408,10 @@ fn run_scu_scp_association_test(max_is_client: bool) {
         association.extended_negotiation_for("1.2.3.7"), // not offered by client
         None
     );
+    assert_eq!(association.requestor_roles_for("1.2.3.4"), (true, true));
+    assert_eq!(association.requestor_roles_for("1.2.3.5"), (false, true));
+    assert_eq!(association.requestor_roles_for("1.2.3.6"), (true, false));
+    assert_eq!(association.requestor_roles_for("1.2.3.7"), (true, false));
 
     // Create a bogus payload which fills the PDU to the max.
     // Take into account the PDU and PDV header lengths for that purpose.

--- a/ul/tests/association_echo.rs
+++ b/ul/tests/association_echo.rs
@@ -1,16 +1,16 @@
 #[cfg(feature = "async")]
 use dicom_ul::association::AsyncServerAssociation;
 use dicom_ul::{
+    ServerAssociation,
     association::{
+        Association, Error, RequestorRoles,
         client::ClientAssociationOptions,
         server::{Negotiation, ServerAssociationOptions},
-        Association, Error,
     },
     pdu::{
         PDataValue, PDataValueType, Pdu, PresentationContextNegotiated,
         PresentationContextResultReason,
     },
-    ServerAssociation,
 };
 use std::io::Write;
 
@@ -77,11 +77,11 @@ fn spawn_scp(
             sop_class_uid: &str,
             scu: bool,
             scp: bool,
-        ) -> Option<(bool, bool)> {
+        ) -> Option<RequestorRoles> {
             if sop_class_uid == "1.2.3.4" {
-                Some((scu, scp))
+                Some(RequestorRoles { scu, scp })
             } else if sop_class_uid == "1.2.3.5" {
-                Some((false, scp))
+                Some(RequestorRoles { scu: false, scp })
             } else {
                 None
             }
@@ -142,10 +142,34 @@ fn spawn_scp(
             association.extended_negotiation_for("1.2.3.7"), // not offered by client
             None
         );
-        assert_eq!(association.requestor_roles_for("1.2.3.4"), (true, true));
-        assert_eq!(association.requestor_roles_for("1.2.3.5"), (false, true));
-        assert_eq!(association.requestor_roles_for("1.2.3.6"), (true, false));
-        assert_eq!(association.requestor_roles_for("1.2.3.7"), (true, false));
+        assert_eq!(
+            association.requestor_roles_for("1.2.3.4"),
+            RequestorRoles {
+                scu: true,
+                scp: true
+            }
+        );
+        assert_eq!(
+            association.requestor_roles_for("1.2.3.5"),
+            RequestorRoles {
+                scu: false,
+                scp: true
+            }
+        );
+        assert_eq!(
+            association.requestor_roles_for("1.2.3.6"),
+            RequestorRoles {
+                scu: true,
+                scp: false
+            }
+        );
+        assert_eq!(
+            association.requestor_roles_for("1.2.3.7"),
+            RequestorRoles {
+                scu: true,
+                scp: false
+            }
+        );
 
         // handle one bogus payload
         let pdu = association.receive()?;
@@ -408,10 +432,34 @@ fn run_scu_scp_association_test(max_is_client: bool) {
         association.extended_negotiation_for("1.2.3.7"), // not offered by client
         None
     );
-    assert_eq!(association.requestor_roles_for("1.2.3.4"), (true, true));
-    assert_eq!(association.requestor_roles_for("1.2.3.5"), (false, true));
-    assert_eq!(association.requestor_roles_for("1.2.3.6"), (true, false));
-    assert_eq!(association.requestor_roles_for("1.2.3.7"), (true, false));
+    assert_eq!(
+        association.requestor_roles_for("1.2.3.4"),
+        RequestorRoles {
+            scu: true,
+            scp: true
+        }
+    );
+    assert_eq!(
+        association.requestor_roles_for("1.2.3.5"),
+        RequestorRoles {
+            scu: false,
+            scp: true
+        }
+    );
+    assert_eq!(
+        association.requestor_roles_for("1.2.3.6"),
+        RequestorRoles {
+            scu: true,
+            scp: false
+        }
+    );
+    assert_eq!(
+        association.requestor_roles_for("1.2.3.7"),
+        RequestorRoles {
+            scu: true,
+            scp: false
+        }
+    );
 
     // Create a bogus payload which fills the PDU to the max.
     // Take into account the PDU and PDV header lengths for that purpose.

--- a/ul/tests/association_echo.rs
+++ b/ul/tests/association_echo.rs
@@ -3,13 +3,13 @@ use dicom_ul::association::AsyncServerAssociation;
 use dicom_ul::{
     ServerAssociation,
     association::{
-        Association, Error, RequestorRoles,
+        Association, Error,
         client::ClientAssociationOptions,
         server::{Negotiation, ServerAssociationOptions},
     },
     pdu::{
         PDataValue, PDataValueType, Pdu, PresentationContextNegotiated,
-        PresentationContextResultReason,
+        PresentationContextResultReason, RequestorRoles,
     },
 };
 use std::io::Write;


### PR DESCRIPTION
Implements role negotiation for association objects, allowing applications to implement a C-GET SCU that follows the standard (currently the library does not allow it). Fixes #731.