### PR TITLE
fix(ul): echo SCP/SCU Role Selection items in Association Accept

### DIFF
--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -600,6 +600,25 @@ where
                     })
                     .collect();
 
+                // Collect SCP/SCU Role Selection sub-items (type 0x54) from the
+                // requestor's user variables so we can echo them back in the AC,
+                // confirming the requested roles (required by strict SCUs such as
+                // pynetdicom >= 2.0 for C-GET where we act as SCP for storage classes).
+                let role_selection_items: Vec<UserVariableItem> = user_variables
+                    .iter()
+                    .filter(|item| matches!(item, UserVariableItem::Unknown(0x54, _)))
+                    .cloned()
+                    .collect();
+
+                let mut ac_user_variables = vec![
+                    UserVariableItem::MaxLength(self.max_pdu_length),
+                    UserVariableItem::ImplementationClassUID(IMPLEMENTATION_CLASS_UID.to_string()),
+                    UserVariableItem::ImplementationVersionName(
+                        IMPLEMENTATION_VERSION_NAME.to_string(),
+                    ),
+                ];
+                ac_user_variables.extend(role_selection_items);
+
                 let pdu = Pdu::AssociationAC(AssociationAC {
                     protocol_version: self.protocol_version,
                     application_context_name,
@@ -613,15 +632,7 @@ where
                         .collect(),
                     calling_ae_title: calling_ae_title.clone(),
                     called_ae_title: called_ae_title.clone(),
-                    user_variables: vec![
-                        UserVariableItem::MaxLength(self.max_pdu_length),
-                        UserVariableItem::ImplementationClassUID(
-                            IMPLEMENTATION_CLASS_UID.to_string(),
-                        ),
-                        UserVariableItem::ImplementationVersionName(
-                            IMPLEMENTATION_VERSION_NAME.to_string(),
-                        ),
-                    ],
+                    user_variables: ac_user_variables,
                 });
                 Ok((
                     pdu,
@@ -1504,6 +1515,72 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pdu::PresentationContextProposed;
+
+    #[test]
+    fn test_ac_echoes_role_selection_items() {
+        // SCP/SCU Role Selection sub-items are carried as User Variable items
+        // with item type 0x54. Strict SCUs (e.g. pynetdicom >= 2.0) require
+        // these items to be echoed in the Association Accept response.
+        let verification_uid = "1.2.840.10008.1.1";
+        let role_payload_a = vec![0x01, 0x02, 0x03];
+        let role_payload_b = vec![0x0A, 0x0B];
+
+        let options = ServerAssociationOptions::default().with_abstract_syntax(verification_uid);
+
+        let rq = Pdu::AssociationRQ(AssociationRQ {
+            protocol_version: 1,
+            calling_ae_title: "SCU".to_string(),
+            called_ae_title: "THIS-SCP".to_string(),
+            application_context_name: "1.2.840.10008.3.1.1.1".to_string(),
+            presentation_contexts: vec![PresentationContextProposed {
+                id: 1,
+                abstract_syntax: verification_uid.to_string(),
+                transfer_syntaxes: vec!["1.2.840.10008.1.2".to_string()],
+            }],
+            user_variables: vec![
+                UserVariableItem::MaxLength(16384),
+                UserVariableItem::Unknown(0x54, role_payload_a.clone()),
+                UserVariableItem::Unknown(0x54, role_payload_b.clone()),
+                // An unrelated unknown item must not be echoed.
+                UserVariableItem::Unknown(0x99, vec![0xFF]),
+            ],
+        });
+
+        let (pdu, _options, _called_ae) = options
+            .process_a_association_rq(rq)
+            .expect("association request should be accepted");
+
+        let ac = match pdu {
+            Pdu::AssociationAC(ac) => ac,
+            other => panic!("expected AssociationAC, got {:?}", other),
+        };
+
+        let echoed: Vec<&Vec<u8>> = ac
+            .user_variables
+            .iter()
+            .filter_map(|item| match item {
+                UserVariableItem::Unknown(0x54, data) => Some(data),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            echoed.len(),
+            2,
+            "both role selection items should be echoed"
+        );
+        assert_eq!(echoed[0], &role_payload_a);
+        assert_eq!(echoed[1], &role_payload_b);
+
+        // Unrelated unknown sub-items must not be propagated.
+        assert!(
+            !ac.user_variables
+                .iter()
+                .any(|item| matches!(item, UserVariableItem::Unknown(0x99, _))),
+            "unrelated unknown sub-items must not be echoed in the AC"
+        );
+    }
 
     #[test]
     fn test_choose_supported() {


### PR DESCRIPTION
## Summary

Strict DICOM SCUs (notably pynetdicom >= 2.0) require the Association Acceptor to confirm requested SCP/SCU roles by echoing Role Selection sub-items (item type 0x54) in the Association Accept (AC) PDU. Without this echo, C-GET operations fail when the server is acting as SCP for negotiated storage classes.

This change filters `UserVariableItem::Unknown(0x54, _)` entries from the requestor's user variables in `process_a_association_rq` and appends them to the AC's user variables. Both synchronous and asynchronous establish paths flow through this shared function, so a single change covers sync, async, plain TCP, and TLS acceptors.

Refs upstream issue: https://github.com/Enet4/dicom-rs/issues/731

## Changes

- `ul/src/association/server.rs`: collect role-selection items from the request and extend them onto the AC response.
- `ul/src/association/server.rs` (tests): add `test_ac_echoes_role_selection_items` covering the echo behaviour and asserting unrelated unknown sub-items are NOT propagated.

## Compatibility

Strictly additive, non-API-breaking. SCUs that do not send role-selection items observe the previous AC structure unchanged.

## Credit

Original patch authored by Christof Schadt for the rust-dicom-broker project. Ported unchanged in substance; rebased onto current upstream master where the sync/async AC sites have converged into a single shared method.

## Test plan

- [x] cargo build -p dicom-ul
- [x] cargo test -p dicom-ul --lib --all-features (new test passes)
- [x] cargo clippy -p dicom-ul --no-deps --all-features -- -D warnings
- [x] cargo fmt --check clean on modified file

