### PR TITLE
Fix more Max PDU confusion

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -381,8 +381,10 @@ impl<'a> ClientAssociationOptions<'a> {
 
     /// Override the maximum PDU length
     /// that this application entity will admit.
+    /// Values larger than MAXIMUM_PDU_SIZE will
+    /// be silently truncated to MAXIMUM_PDU_SIZE.
     pub fn max_pdu_length(mut self, value: u32) -> Self {
-        self.max_pdu_length = value;
+        self.max_pdu_length = value.min(MAXIMUM_PDU_SIZE);
         self
     }
 

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -22,9 +22,9 @@ use crate::{
     },
     pdu::{
         AbortRQSource, AssociationAC, AssociationRQ, DEFAULT_MAX_PDU, LARGE_PDU_SIZE,
-        PDU_HEADER_SIZE, Pdu, PresentationContextNegotiated, PresentationContextProposed,
-        PresentationContextResultReason, RequestorRoles, UserIdentity, UserIdentityType,
-        UserVariableItem, write_pdu,
+        MAXIMUM_PDU_SIZE, PDU_HEADER_SIZE, Pdu, PresentationContextNegotiated,
+        PresentationContextProposed, PresentationContextResultReason, RequestorRoles, UserIdentity,
+        UserIdentityType, UserVariableItem, write_pdu,
     },
 };
 use snafu::{ResultExt, ensure};
@@ -851,11 +851,11 @@ impl<'a> ClientAssociationOptions<'a> {
                     })
                     .unwrap_or(DEFAULT_MAX_PDU);
 
-                // treat 0 as practically unlimited
                 let acceptor_max_pdu_length = if acceptor_max_pdu_length == 0 {
-                    u32::MAX
+                    // treat 0 as the largest we support
+                    MAXIMUM_PDU_SIZE
                 } else {
-                    acceptor_max_pdu_length
+                    acceptor_max_pdu_length.min(MAXIMUM_PDU_SIZE)
                 };
 
                 let presentation_contexts: Vec<_> = presentation_contexts_scp

--- a/ul/src/association/pdata.rs
+++ b/ul/src/association/pdata.rs
@@ -87,7 +87,7 @@ fn setup_pdata_header(buffer: &mut [u8], is_last: bool) {
 pub struct PDataWriter<W: Write> {
     buffer: Vec<u8>,
     stream: W,
-    max_data_len: u32,
+    max_pdu_length: u32,
 }
 
 impl<W> PDataWriter<W>
@@ -98,7 +98,6 @@ where
     ///
     /// `max_pdu_length` is the maximum value of the PDU-length property.
     pub(crate) fn new(stream: W, presentation_context_id: u8, max_pdu_length: u32) -> Self {
-        let max_data_length = calculate_max_data_len_single(max_pdu_length);
         let mut buffer =
             Vec::with_capacity((max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize);
         // initial buffer set up
@@ -124,7 +123,7 @@ where
 
         PDataWriter {
             stream,
-            max_data_len: max_data_length,
+            max_pdu_length,
             buffer,
         }
     }
@@ -172,7 +171,7 @@ where
     W: Write,
 {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let total_len = self.max_data_len as usize + PDU_PDV_HEADER_SIZE;
+        let total_len = (self.max_pdu_length + PDU_HEADER_SIZE) as usize;
         if self.buffer.len() + buf.len() <= total_len {
             // accumulate into buffer, do nothing
             self.buffer.extend(buf);
@@ -246,18 +245,18 @@ pub struct PDataReader<'a, R> {
     buffer: VecDeque<u8>,
     stream: R,
     presentation_context_id: Option<u8>,
-    max_data_length: u32,
+    max_pdu_length: u32,
     last_pdu: bool,
     read_buffer: &'a mut BytesMut,
 }
 
 impl<'a, R> PDataReader<'a, R> {
-    pub fn new(stream: R, max_data_length: u32, remaining: &'a mut BytesMut) -> Self {
+    pub fn new(stream: R, max_pdu_length: u32, remaining: &'a mut BytesMut) -> Self {
         PDataReader {
-            buffer: VecDeque::with_capacity(max_data_length.min(LARGE_PDU_SIZE) as usize),
+            buffer: VecDeque::with_capacity((max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize),
             stream,
             presentation_context_id: None,
-            max_data_length,
+            max_pdu_length,
             last_pdu: false,
             read_buffer: remaining,
         }
@@ -288,7 +287,7 @@ where
             let mut reader = BufReader::new(&mut self.stream);
             let msg = loop {
                 let mut buf = Cursor::new(&self.read_buffer[..]);
-                match read_pdu(&mut buf, self.max_data_length, false)
+                match read_pdu(&mut buf, self.max_pdu_length, false)
                     .map_err(std::io::Error::other)?
                 {
                     Some(pdu) => {
@@ -337,14 +336,6 @@ where
     }
 }
 
-/// Determine the maximum length of actual PDV data
-/// when encapsulated in a PDU with the given length property.
-/// Does not account for the first 2 bytes (type + reserved).
-#[inline]
-fn calculate_max_data_len_single(pdu_len: u32) -> u32 {
-    pdu_len - PDV_HEADER_SIZE
-}
-
 #[cfg(feature = "async")]
 pub mod non_blocking {
     use std::{
@@ -363,7 +354,7 @@ pub mod non_blocking {
     };
 
     pub use super::PDataReader;
-    use super::{calculate_max_data_len_single, setup_pdata_header};
+    use super::setup_pdata_header;
 
     const PDU_PDV_HEADER_SIZE: usize = (PDU_HEADER_SIZE + PDV_HEADER_SIZE) as usize;
 
@@ -426,7 +417,7 @@ pub mod non_blocking {
     pub struct AsyncPDataWriter<W: AsyncWrite + Unpin> {
         buffer: Vec<u8>,
         stream: W,
-        max_data_len: u32,
+        max_pdu_length: u32,
         state: WriteState,
     }
 
@@ -441,7 +432,6 @@ pub mod non_blocking {
         pub(crate) fn new(stream: W, presentation_context_id: u8, max_pdu_length: u32) -> Self {
             use crate::pdu::LARGE_PDU_SIZE;
 
-            let max_data_length = calculate_max_data_len_single(max_pdu_length);
             let mut buffer =
                 Vec::with_capacity((max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize);
             // initial buffer set up
@@ -467,7 +457,7 @@ pub mod non_blocking {
 
             AsyncPDataWriter {
                 stream,
-                max_data_len: max_data_length,
+                max_pdu_length,
                 buffer,
                 state: WriteState::Ready,
             }
@@ -513,7 +503,7 @@ pub mod non_blocking {
             match self.state {
                 WriteState::Ready => {
                     // If we're in ready state, we can prepare another PDU
-                    let total_len = self.max_data_len as usize + PDU_PDV_HEADER_SIZE;
+                    let total_len = (self.max_pdu_length + PDU_HEADER_SIZE) as usize;
                     if self.buffer.len() + buf.len() <= total_len {
                         // Still have space in `self.buffer`, accumulate into buffer
                         self.buffer.extend(buf);
@@ -620,13 +610,13 @@ pub mod non_blocking {
                 let &mut Self {
                     ref mut stream,
                     ref mut read_buffer,
-                    max_data_length,
+                    max_pdu_length,
                     ..
                 } = &mut *self;
                 let mut reader = BufReader::new(stream);
                 let msg = loop {
                     let mut buf = Cursor::new(&read_buffer[..]);
-                    match read_pdu(&mut buf, max_data_length + PDV_HEADER_SIZE, false)
+                    match read_pdu(&mut buf, max_pdu_length, false)
                         .map_err(std::io::Error::other)?
                     {
                         Some(pdu) => {

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -612,8 +612,10 @@ where
     }
 
     /// Override the maximum expected PDU length.
+    /// Values greater than MAXIMUM_PDU_SIZE will be
+    /// silently truncated to MAXIMUM_PDU_SIZE.
     pub fn max_pdu_length(mut self, value: u32) -> Self {
-        self.max_pdu_length = value;
+        self.max_pdu_length = value.min(MAXIMUM_PDU_SIZE);
         self
     }
 

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -20,7 +20,7 @@ use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use snafu::{ResultExt, ensure};
 
 use crate::association::{NegotiatedOptions, RequestorRoles};
-use crate::pdu::{LARGE_PDU_SIZE, PresentationContextNegotiated};
+use crate::pdu::{LARGE_PDU_SIZE, MAXIMUM_PDU_SIZE, PresentationContextNegotiated};
 use crate::{
     IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
     pdu::{
@@ -770,11 +770,12 @@ where
 
                         MaxLength(len) => {
                             requestor_max_pdu_length = if len == 0 {
-                                // treat 0 as practically unlimited,
-                                // so use the largest 32-bit unsigned number
-                                u32::MAX
+                                // treat 0 as the largest we support
+                                MAXIMUM_PDU_SIZE
                             } else {
-                                len
+                                // Don't accept more than MAXIMUM_PDU_SIZE
+                                // as max_pdu_length.
+                                len.min(MAXIMUM_PDU_SIZE)
                             };
                         }
 

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -35,6 +35,9 @@ pub const MINIMUM_PDU_SIZE: u32 = 1_024 - PDU_HEADER_SIZE;
 /// The largest PDU size supported. It must be an even number.
 /// Together with the PDU header, it must not exceed u32::MAX,
 /// and when adding the PDU header size, it must not overflow.
+// `clippy` complains that !1 and u32::MAX-1 are equal, but this
+// formulation expresses intent, so disable the warning
+#[allow(clippy::eq_op)]
 pub const MAXIMUM_PDU_SIZE: u32 = ((u32::MAX - 1) & !1) - PDU_HEADER_SIZE;
 
 /// A generous PDU size for internal use.

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -32,6 +32,11 @@ pub const DEFAULT_MAX_PDU: u32 = 16_384 - PDU_HEADER_SIZE;
 /// by this implementation
 pub const MINIMUM_PDU_SIZE: u32 = 1_024 - PDU_HEADER_SIZE;
 
+/// The largest PDU size supported. It must be an even number.
+/// Together with the PDU header, it must not exceed u32::MAX,
+/// and when adding the PDU header size, it must not overflow.
+pub const MAXIMUM_PDU_SIZE: u32 = ((u32::MAX - 1) & !1) - PDU_HEADER_SIZE;
+
 /// A generous PDU size for internal use.
 /// Prefer to initialize buffers no larger than this size
 pub(crate) const LARGE_PDU_SIZE: u32 = 262_144 - PDU_HEADER_SIZE;

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -12,7 +12,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Read a PDU from the given byte buffer.
 pub fn read_pdu(mut buf: impl Buf, max_pdu_length: u32, strict: bool) -> Result<Option<Pdu>> {
     ensure!(
-        max_pdu_length >= super::MINIMUM_PDU_SIZE && max_pdu_length <= super::MAXIMUM_PDU_SIZE,
+        (super::MINIMUM_PDU_SIZE..=super::MAXIMUM_PDU_SIZE).contains(&max_pdu_length),
         InvalidMaxPduSnafu { max_pdu_length },
     );
 

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -12,7 +12,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Read a PDU from the given byte buffer.
 pub fn read_pdu(mut buf: impl Buf, max_pdu_length: u32, strict: bool) -> Result<Option<Pdu>> {
     ensure!(
-        max_pdu_length >= super::MINIMUM_PDU_SIZE,
+        max_pdu_length >= super::MINIMUM_PDU_SIZE && max_pdu_length <= super::MAXIMUM_PDU_SIZE,
         InvalidMaxPduSnafu { max_pdu_length },
     );
 


### PR DESCRIPTION
Fix more instances of broken maximum lengths.  This is a follow-up to #733 which fixes a few oversights. Standarize to use max_pdu_size for everything and with a uniform meaning (total PDU size minus the PDU header, which is the same definition the standard uses for the PDU Length field and the Maximum PDU Length items).

Includes a patch that fixes the case where if the user configures a max_pdu_size between MAXIMUM_PDU_LENGTH+1 and u32::MAX, there's a potentially catastrophic addition wraparound (panic or impossibly small buffer).

Prompted by a bug reported by @qarmin in #768.

Fixes LOGIC_12, OVF_3 and OVF_4 from #768.