### PR TITLE
[encoding] Check for overflow of u16 before writing the header

### DIFF
--- a/encoding/src/encode/explicit_be.rs
+++ b/encoding/src/encode/explicit_be.rs
@@ -2,8 +2,8 @@
 
 use crate::encode::basic::BigEndianBasicEncoder;
 use crate::encode::{
-    BasicEncode, Encode, Result, WriteHeaderSnafu, WriteItemDelimiterSnafu, WriteItemHeaderSnafu,
-    WriteOffsetTableSnafu, WriteSequenceDelimiterSnafu, WriteTagSnafu,
+    BasicEncode, Encode, Result, WriteHeaderSnafu, WriteHeaderTooLongSnafu, WriteItemDelimiterSnafu,
+    WriteItemHeaderSnafu, WriteOffsetTableSnafu, WriteSequenceDelimiterSnafu, WriteTagSnafu,
 };
 
 use byteordered::byteorder::{BigEndian, ByteOrder};
@@ -124,13 +124,19 @@ impl Encode for ExplicitVRBigEndianEncoder {
             | VR::UI
             | VR::UL
             | VR::US => {
+                let length = de.length().0;
+                if length > u16::MAX as u32 {
+                    return WriteHeaderTooLongSnafu {
+                        length,
+                    }.fail();
+                }
                 let mut buf = [0u8; 8];
                 BigEndian::write_u16(&mut buf[0..], de.tag().group());
                 BigEndian::write_u16(&mut buf[2..], de.tag().element());
                 let vr_bytes = de.vr().to_bytes();
                 buf[4] = vr_bytes[0];
                 buf[5] = vr_bytes[1];
-                BigEndian::write_u16(&mut buf[6..], de.length().0 as u16);
+                BigEndian::write_u16(&mut buf[6..], length as u16);
                 to.write_all(&buf).context(WriteHeaderSnafu)?;
 
                 Ok(8)

--- a/encoding/src/encode/explicit_le.rs
+++ b/encoding/src/encode/explicit_le.rs
@@ -2,8 +2,8 @@
 
 use crate::encode::basic::LittleEndianBasicEncoder;
 use crate::encode::{
-    BasicEncode, Encode, Result, WriteHeaderSnafu, WriteItemDelimiterSnafu, WriteItemHeaderSnafu,
-    WriteOffsetTableSnafu, WriteSequenceDelimiterSnafu, WriteTagSnafu,
+    BasicEncode, Encode, Result, WriteHeaderSnafu, WriteHeaderTooLongSnafu, WriteItemDelimiterSnafu,
+    WriteItemHeaderSnafu, WriteOffsetTableSnafu, WriteSequenceDelimiterSnafu, WriteTagSnafu,
 };
 use byteordered::byteorder::{ByteOrder, LittleEndian};
 use byteordered::Endianness;
@@ -123,13 +123,19 @@ impl Encode for ExplicitVRLittleEndianEncoder {
             | VR::UI
             | VR::UL
             | VR::US => {
+                let length = de.length().0;
+                if length > u16::MAX as u32 {
+                    return WriteHeaderTooLongSnafu {
+                        length,
+                    }.fail();
+                }
                 let mut buf = [0u8; 8];
                 LittleEndian::write_u16(&mut buf[0..], de.tag().group());
                 LittleEndian::write_u16(&mut buf[2..], de.tag().element());
                 let vr_bytes = de.vr().to_bytes();
                 buf[4] = vr_bytes[0];
                 buf[5] = vr_bytes[1];
-                LittleEndian::write_u16(&mut buf[6..], de.length().0 as u16);
+                LittleEndian::write_u16(&mut buf[6..], length as u16);
                 to.write_all(&buf).context(WriteHeaderSnafu)?;
                 Ok(8)
             }

--- a/encoding/src/encode/mod.rs
+++ b/encoding/src/encode/mod.rs
@@ -88,6 +88,11 @@ pub enum Error {
         backtrace: Backtrace,
         source: io::Error,
     },
+    #[snafu(display("Item too long ({} bytes) for a 16-bit length", length))]
+    WriteHeaderTooLong {
+        length: u32,
+        backtrace: Backtrace,
+    }
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
Fixes OVF_6 of #768.