### PR TITLE
Make buffer allocations more precise

### DIFF
--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -912,7 +912,7 @@ impl<'a> ClientAssociationOptions<'a> {
         S: CloseSocket + std::io::Read + std::io::Write,
     {
         let (pc_proposed, a_associate) = self.create_a_associate_req(ae_address.ae_title())?;
-        let mut buffer: Vec<u8> = Vec::with_capacity(self.max_pdu_length as usize);
+        let mut buffer: Vec<u8> = Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
 
         write_pdu(&mut buffer, &a_associate).context(super::SendPduSnafu)?;
         socket.write_all(&buffer).context(super::WireSendSnafu)?;
@@ -1373,7 +1373,8 @@ impl<'a> ClientAssociationOptions<'a> {
     {
         use tokio::io::AsyncWriteExt;
         let (pc_proposed, a_associate) = self.create_a_associate_req(ae_address.ae_title())?;
-        let mut write_buffer: Vec<u8> = Vec::with_capacity(DEFAULT_MAX_PDU as usize);
+        let mut write_buffer: Vec<u8> =
+            Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
 
         // send request
         write_pdu(&mut write_buffer, &a_associate).context(crate::association::SendPduSnafu)?;
@@ -1809,7 +1810,8 @@ mod tests {
         {
             let (pc_proposed, a_associate) = self.create_a_associate_req(ae_address.ae_title())?;
             let mut socket = tcp_connection(&ae_address, &self.socket_options)?;
-            let mut write_buffer: Vec<u8> = Vec::with_capacity(DEFAULT_MAX_PDU as usize);
+            let mut write_buffer: Vec<u8> =
+                Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
             // send request
 
             write_pdu(&mut write_buffer, &a_associate).context(crate::association::SendPduSnafu)?;
@@ -1867,7 +1869,8 @@ mod tests {
 
             let (pc_proposed, a_associate) = self.create_a_associate_req(ae_address.ae_title())?;
             let mut socket = async_connection(&ae_address, &self.socket_options).await?;
-            let mut buffer: Vec<u8> = Vec::with_capacity(DEFAULT_MAX_PDU as usize);
+            let mut buffer: Vec<u8> =
+                Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
             // send request
 
             write_pdu(&mut buffer, &a_associate).context(crate::association::SendPduSnafu)?;
@@ -1920,7 +1923,8 @@ mod tests {
         {
             let (pc_proposed, a_associate) = self.create_a_associate_req(ae_address.ae_title())?;
             let mut socket = tcp_connection(&ae_address, &self.socket_options)?;
-            let mut buffer: Vec<u8> = Vec::with_capacity(DEFAULT_MAX_PDU as usize);
+            let mut buffer: Vec<u8> =
+                Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
             // send request
             write_pdu(&mut buffer, &a_associate).context(crate::association::SendPduSnafu)?;
             socket
@@ -1970,7 +1974,8 @@ mod tests {
 
             let (pc_proposed, a_associate) = self.create_a_associate_req(ae_address.ae_title())?;
             let mut socket = async_connection(&ae_address, &self.socket_options).await?;
-            let mut buffer: Vec<u8> = Vec::with_capacity(DEFAULT_MAX_PDU as usize);
+            let mut buffer: Vec<u8> =
+                Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
             // send request
             write_pdu(&mut buffer, &a_associate).context(crate::association::SendPduSnafu)?;
             socket

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -950,7 +950,8 @@ where
             self.max_pdu_length,
             self.strict,
         )?;
-        let mut write_buffer: Vec<u8> = Vec::with_capacity(self.max_pdu_length as usize);
+        let mut write_buffer: Vec<u8> =
+            Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
         match self.process_a_association_rq(msg) {
             Ok((
                 pdu,
@@ -1018,7 +1019,8 @@ where
             self.max_pdu_length,
             self.strict,
         )?;
-        let mut write_buffer: Vec<u8> = Vec::with_capacity(self.max_pdu_length as usize);
+        let mut write_buffer: Vec<u8> =
+            Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
         match self.process_a_association_rq(msg) {
             Ok((
                 pdu,
@@ -1937,22 +1939,20 @@ mod tests {
             ) = self
                 .process_a_association_rq(msg)
                 .expect("Could not parse association req");
-            let mut buffer: Vec<u8> = Vec::with_capacity(
-                (peer_max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
-            );
-            write_pdu(&mut buffer, &pdu).context(SendPduSnafu)?;
-            socket.write_all(&buffer).context(WireSendSnafu)?;
+            let mut write_buffer: Vec<u8> =
+                Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
+            write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
+            socket.write_all(&write_buffer).context(WireSendSnafu)?;
+            read_buffer.clear();
             Ok(ServerAssociation {
                 presentation_contexts,
                 requestor_max_pdu_length: peer_max_pdu_length,
                 acceptor_max_pdu_length: self.max_pdu_length,
                 socket,
                 client_ae_title: peer_ae_title,
-                write_buffer: buffer,
+                write_buffer,
                 strict: self.strict,
-                read_buffer: BytesMut::with_capacity(
-                    (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
-                ),
+                read_buffer,
                 user_variables,
                 called_ae_title,
             })
@@ -1990,22 +1990,23 @@ mod tests {
             ) = self
                 .process_a_association_rq(msg)
                 .expect("Could not parse association req");
-            let mut buffer: Vec<u8> = Vec::with_capacity(
-                (peer_max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
-            );
-            write_pdu(&mut buffer, &pdu).context(SendPduSnafu)?;
-            socket.write_all(&buffer).await.context(WireSendSnafu)?;
+            let mut write_buffer: Vec<u8> =
+                Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
+            write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
+            socket
+                .write_all(&write_buffer)
+                .await
+                .context(WireSendSnafu)?;
+            read_buffer.clear();
             Ok(AsyncServerAssociation {
                 presentation_contexts,
                 requestor_max_pdu_length: peer_max_pdu_length,
                 acceptor_max_pdu_length: self.max_pdu_length,
                 socket,
                 client_ae_title: peer_ae_title,
-                write_buffer: buffer,
+                write_buffer,
                 strict: self.strict,
-                read_buffer: BytesMut::with_capacity(
-                    (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
-                ),
+                read_buffer,
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
                 user_variables,

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -37,8 +37,8 @@ pub const MINIMUM_PDU_SIZE: u32 = 1_024 - PDU_HEADER_SIZE;
 /// and when adding the PDU header size, it must not overflow.
 // `clippy` complains that !1 and u32::MAX-1 are equal, but this
 // formulation expresses intent, so disable the warning
-#[allow(clippy::eq_op)]
-pub const MAXIMUM_PDU_SIZE: u32 = ((u32::MAX - 1) & !1) - PDU_HEADER_SIZE;
+#[allow(clippy::identity_op)]
+pub const MAXIMUM_PDU_SIZE: u32 = (u32::MAX & !1) - PDU_HEADER_SIZE;
 
 /// A generous PDU size for internal use.
 /// Prefer to initialize buffers no larger than this size

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -26,7 +26,7 @@ pub const PDU_HEADER_SIZE: u32 = 6;
 pub const PDV_HEADER_SIZE: u32 = 6;
 
 /// The default maximum PDU size
-pub const DEFAULT_MAX_PDU: u32 = 16_384 - PDU_HEADER_SIZE;
+pub const DEFAULT_MAX_PDU: u32 = 32_768 - PDU_HEADER_SIZE;
 
 /// The smallest maximum PDU length negotiable
 /// by this implementation
@@ -35,7 +35,7 @@ pub const MINIMUM_PDU_SIZE: u32 = 1_024 - PDU_HEADER_SIZE;
 /// The largest PDU size supported. It must be an even number.
 /// Together with the PDU header, it must not exceed u32::MAX,
 /// and when adding the PDU header size, it must not overflow.
-// `clippy` complains that !1 and u32::MAX-1 are equal, but this
+// `clippy` complains that !1 already equals u32::MAX & !1, but this
 // formulation expresses intent, so disable the warning
 #[allow(clippy::identity_op)]
 pub const MAXIMUM_PDU_SIZE: u32 = (u32::MAX & !1) - PDU_HEADER_SIZE;


### PR DESCRIPTION
Ensure all buffers have room for the maximum they specify plus the header size. Use self.max_pdu_length limited to LARGE_PDU_SIZE for receiving, and DEFAULT_MAX_PDU for sending.

Also, the -1 in the formula for MAXIMUM_PDU_SIZE was actually wrong. The resulting value is the same without it though, but the Clippy warning is different.

Worth noting that DEFAULT_MAX_PDU may be too short from the start in many common circumstances. I've observed an A-ASSOCIATE-RQ PDU sent by a DCMTK's `getscu` client that is 17503 bytes long, for instance: just a default query without even any extended negotiation items. The bulk of the data in that case comes from the presentation contexts and the role negotiation (one of each for every SOP Class supported, with three transfer syntaxes per SOP Class in every presentation context). You can blame the complexity of the DICOM standard for this.