### PR TITLE
[ul] Implement the DIMSE Association State Machine

### DIFF
--- a/echoscu/src/main.rs
+++ b/echoscu/src/main.rs
@@ -3,7 +3,7 @@ use dicom_core::{DataElement, VR, dicom_value};
 use dicom_dictionary_std::{tags, uids};
 use dicom_object::{StandardDataDictionary, mem::InMemDicomObject};
 use dicom_ul::{
-    association::client::ClientAssociationOptions,
+    association::{ClientAssociationOptions, SyncAssociation},
     pdu::{self, PDataValueType, Pdu},
 };
 use pdu::PDataValue;

--- a/findscu/src/main.rs
+++ b/findscu/src/main.rs
@@ -8,7 +8,7 @@ use dicom_object::{StandardDataDictionary, mem::InMemDicomObject, open_file};
 use dicom_transfer_syntax_registry::{TransferSyntaxRegistry, entries};
 use dicom_ul::pdu::Pdu;
 use dicom_ul::{
-    association::ClientAssociationOptions,
+    association::{ClientAssociationOptions, SyncAssociation},
     pdu::{PDataValue, PDataValueType},
 };
 use query::parse_queries;

--- a/movescu/src/main.rs
+++ b/movescu/src/main.rs
@@ -8,7 +8,7 @@ use dicom_object::{StandardDataDictionary, mem::InMemDicomObject, open_file};
 use dicom_transfer_syntax_registry::{TransferSyntaxRegistry, entries};
 use dicom_ul::pdu::Pdu;
 use dicom_ul::{
-    association::ClientAssociationOptions,
+    association::{ClientAssociationOptions, SyncAssociation},
     pdu::{PDataValue, PDataValueType},
 };
 use indicatif::ProgressBar;

--- a/movescu/src/store_async.rs
+++ b/movescu/src/store_async.rs
@@ -360,7 +360,14 @@ pub async fn run_store_async(
         }
     }
 
-    let msg = if let Ok(peer_addr) = association.inner_stream().peer_addr() {
+    let Some(socket) = association.inner_stream().as_mut() else {
+        warn!(
+            "Socket was closed by this application entity, probably in response to an abort request"
+        );
+        return Ok(false);
+    };
+
+    let msg = if let Ok(peer_addr) = socket.peer_addr() {
         format!(
             "Dropping connection with {} ({peer_addr})",
             association.peer_ae_title(),

--- a/storescp/src/store_sync.rs
+++ b/storescp/src/store_sync.rs
@@ -7,7 +7,7 @@ use dicom_object::{FileMetaTableBuilder, InMemDicomObject};
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use dicom_ul::{
     Pdu, ServerAssociation,
-    association::{Association, CloseSocket, SetReadTimeout},
+    association::{Association, CloseSocket, SetReadTimeout, SyncAssociation},
     pdu::{PDataValueType, PresentationContextResultReason},
 };
 use snafu::{OptionExt, Report, ResultExt, Whatever};

--- a/storescp/src/store_sync.rs
+++ b/storescp/src/store_sync.rs
@@ -7,7 +7,7 @@ use dicom_object::{FileMetaTableBuilder, InMemDicomObject};
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use dicom_ul::{
     Pdu, ServerAssociation,
-    association::{Association, CloseSocket},
+    association::{Association, CloseSocket, SetReadTimeout},
     pdu::{PDataValueType, PresentationContextResultReason},
 };
 use snafu::{OptionExt, Report, ResultExt, Whatever};
@@ -129,7 +129,7 @@ fn inner<T>(
     out_dir: &Path,
 ) -> Result<(), Whatever>
 where
-    T: std::io::Read + std::io::Write + CloseSocket,
+    T: std::io::Read + std::io::Write + CloseSocket + SetReadTimeout,
 {
     let mut instance_buffer: Vec<u8> = Vec::with_capacity(1024 * 1024);
     let mut msgid = 1;

--- a/storescu/src/store_async.rs
+++ b/storescu/src/store_async.rs
@@ -6,7 +6,7 @@ use dicom_object::{InMemDicomObject, open_file};
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use dicom_ul::{
     Pdu,
-    association::client::AsyncClientAssociation,
+    association::{AsyncAssociation, AsyncClientAssociation},
     pdu::{PDataValue, PDataValueType},
 };
 use indicatif::ProgressBar;

--- a/storescu/src/store_sync.rs
+++ b/storescu/src/store_sync.rs
@@ -6,7 +6,7 @@ use dicom_object::{InMemDicomObject, open_file};
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use dicom_ul::{
     ClientAssociation, Pdu,
-    association::{CloseSocket, SyncAssociation},
+    association::{CloseSocket, SetReadTimeout, SyncAssociation},
     pdu::{PDataValue, PDataValueType},
 };
 use indicatif::ProgressBar;
@@ -28,7 +28,7 @@ pub fn send_file<T>(
     fail_first: bool,
 ) -> Result<ClientAssociation<T>, Error>
 where
-    T: std::io::Read + std::io::Write + CloseSocket,
+    T: std::io::Read + std::io::Write + CloseSocket + SetReadTimeout,
 {
     if let (Some(pc_selected), Some(ts_uid_selected)) = (file.pc_selected, file.ts_selected) {
         if let Some(pb) = &progress_bar {
@@ -215,7 +215,7 @@ pub fn inner<T>(
     ignore_sop_class: bool,
 ) -> Result<(), Error>
 where
-    T: std::io::Read + std::io::Write + CloseSocket,
+    T: std::io::Read + std::io::Write + CloseSocket + SetReadTimeout,
 {
     for (message_id, mut file) in (1..).zip(d_files) {
         // identify the right transfer syntax to use

--- a/storescu/src/store_sync.rs
+++ b/storescu/src/store_sync.rs
@@ -6,7 +6,7 @@ use dicom_object::{InMemDicomObject, open_file};
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
 use dicom_ul::{
     ClientAssociation, Pdu,
-    association::CloseSocket,
+    association::{CloseSocket, SyncAssociation},
     pdu::{PDataValue, PDataValueType},
 };
 use indicatif::ProgressBar;

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -1048,7 +1048,9 @@ impl<'a> ClientAssociationOptions<'a> {
                     &mut write_buffer,
                     &Pdu::AbortRQ {
                         source: AbortRQSource::ServiceProvider(
-                            if let Error::UnknownPdu { .. } = err {
+                            if let Error::NoAcceptedPresentationContexts { .. } = err {
+                                AbortRQServiceProviderReason::ReasonNotSpecified
+                            } else if let Error::UnknownPdu { .. } = err {
                                 AbortRQServiceProviderReason::UnrecognizedPdu
                             } else {
                                 AbortRQServiceProviderReason::UnexpectedPdu

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -16,10 +16,7 @@ use std::{
 use crate::association::AsyncAssociation;
 use crate::{
     AeAddr, IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
-    association::{
-        Association, NegotiatedOptions, SocketOptions, SyncAssociation, encode_pdu,
-        read_pdu_from_wire,
-    },
+    association::{Association, NegotiatedOptions, SocketOptions, SyncAssociation},
     pdu::{
         AbortRQSource, AssociationAC, AssociationRQ, DEFAULT_MAX_PDU, LARGE_PDU_SIZE,
         MAXIMUM_PDU_SIZE, PDU_HEADER_SIZE, Pdu, PresentationContextNegotiated,
@@ -927,7 +924,8 @@ impl<'a> ClientAssociationOptions<'a> {
         let mut buf = BytesMut::with_capacity(
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
-        let resp = read_pdu_from_wire(&mut socket, &mut buf, self.max_pdu_length, self.strict);
+        let resp =
+            super::read_pdu_from_wire(&mut socket, &mut buf, self.max_pdu_length, self.strict);
         // If we're in non-TLS mode and `read_pdu_from_wire` fails, it
         // could be because the server expects TLS but we sent a
         // plaintext request.  In that case, we make a best effort to
@@ -1192,31 +1190,26 @@ where
         &mut self.socket
     }
 
-    fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
+    fn get_mut(&mut self) -> (&mut S, &mut BytesMut, &mut Vec<u8>) {
         let Self {
             socket,
             read_buffer,
+            write_buffer,
             ..
         } = self;
-        (socket, read_buffer)
+        (socket, read_buffer, write_buffer)
     }
 
     /// Send a PDU message to the other intervenient.
     fn send(&mut self, pdu: &Pdu) -> Result<()> {
-        self.write_buffer.clear();
-        encode_pdu(
-            &mut self.write_buffer,
-            pdu,
-            self.acceptor_max_pdu_length + PDU_HEADER_SIZE,
-        )?;
-        self.socket
-            .write_all(&self.write_buffer)
-            .context(super::WireSendSnafu)
+        let max_pdu = self.acceptor_max_pdu_length;
+        let (socket, _, write_buffer) = self.get_mut();
+        super::write_pdu_to_wire(socket, write_buffer, pdu, max_pdu)
     }
 
     /// Read a PDU message from the other intervenient.
     fn receive(&mut self) -> Result<Pdu> {
-        read_pdu_from_wire(
+        super::read_pdu_from_wire(
             &mut self.socket,
             &mut self.read_buffer,
             self.requestor_max_pdu_length,
@@ -1667,37 +1660,26 @@ where
         &mut self.socket
     }
 
-    fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
+    fn get_mut(&mut self) -> (&mut S, &mut BytesMut, &mut Vec<u8>) {
         let Self {
             socket,
             read_buffer,
+            write_buffer,
             ..
         } = self;
-        (socket, read_buffer)
+        (socket, read_buffer, write_buffer)
     }
 
-    async fn send(&mut self, msg: &Pdu) -> Result<()> {
-        use tokio::io::AsyncWriteExt;
-
-        self.write_buffer.clear();
-        encode_pdu(
-            &mut self.write_buffer,
-            msg,
-            self.acceptor_max_pdu_length + PDU_HEADER_SIZE,
-        )?;
-        super::timeout(self.write_timeout, async {
-            self.socket
-                .write_all(&self.write_buffer)
-                .await
-                .context(crate::association::WireSendSnafu)
-        })
-        .await
+    fn send(&mut self, msg: &Pdu) -> impl std::future::Future<Output = Result<()>> + Send {
+        let write_timeout = self.write_timeout;
+        let max_pdu = self.acceptor_max_pdu_length;
+        let (socket, _, write_buffer) = self.get_mut();
+        super::write_pdu_to_wire_async(socket, write_buffer, msg, max_pdu, write_timeout)
     }
 
     async fn receive(&mut self) -> Result<Pdu> {
-        use crate::association::read_pdu_from_wire_async;
         super::timeout(self.read_timeout, async {
-            read_pdu_from_wire_async(
+            super::read_pdu_from_wire_async(
                 &mut self.socket,
                 &mut self.read_buffer,
                 self.requestor_max_pdu_length,
@@ -1717,6 +1699,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::association::read_pdu_from_wire;
     #[cfg(feature = "async")]
     use crate::association::read_pdu_from_wire_async;
     use std::io::Write;

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -33,10 +33,6 @@ use tracing::{debug, error};
 
 use super::{Result, uid::trim_uid};
 
-// stray module from 0.9.0, remove in 0.10.0
-#[deprecated(since = "0.9.1")]
-pub mod non_blocking {}
-
 #[cfg(feature = "sync-tls")]
 pub type TlsStream = rustls::StreamOwned<rustls::ClientConnection, std::net::TcpStream>;
 #[cfg(feature = "async-tls")]
@@ -1188,76 +1184,6 @@ where
     }
 }
 
-// compatibility filler, remove in 0.10.0
-impl<S> ClientAssociation<S>
-where
-    S: CloseSocket + std::io::Read + std::io::Write,
-{
-    /// Send a PDU message to the other intervenient.
-    pub fn send(&mut self, pdu: &Pdu) -> Result<()> {
-        SyncAssociation::send(self, pdu)
-    }
-
-    /// Read a PDU message from the other intervenient.
-    pub fn receive(&mut self) -> Result<Pdu> {
-        SyncAssociation::receive(self)
-    }
-
-    /// Prepare a P-Data writer for sending
-    /// one or more data item PDUs.
-    ///
-    /// Returns a writer which automatically
-    /// splits the inner data into separate PDUs if necessary.
-    pub fn send_pdata(
-        &mut self,
-        presentation_context_id: u8,
-    ) -> crate::association::pdata::PDataWriter<&mut S> {
-        SyncAssociation::send_pdata(self, presentation_context_id)
-    }
-
-    /// Iniate a graceful release of the association.
-    ///
-    /// A DIMSE A-RELEASE transaction is initiated by this application entity,
-    /// and the underlying socket is closed once settled.
-    ///
-    /// Note that as of version 0.9.1,
-    /// `ClientAssociation` no longer calls this method on [`Drop`],
-    /// so remember to call `release` explicitly
-    /// at the end of all DIMSE transactions.
-    pub fn release(self) -> Result<()> {
-        SyncAssociation::release(self)
-    }
-
-    /// Send a provider initiated abort message
-    /// and shut down the TCP connection,
-    /// terminating the association.
-    pub fn abort(self) -> Result<()> {
-        SyncAssociation::abort(self)
-    }
-
-    /// Prepare a P-Data reader for receiving
-    /// one or more data item PDUs.
-    ///
-    /// Returns a reader which automatically
-    /// receives more data PDUs once the bytes collected are consumed.
-    pub fn receive_pdata(&mut self) -> crate::association::pdata::PDataReader<'_, &mut S> {
-        SyncAssociation::receive_pdata(self)
-    }
-
-    /// Obtain access to the inner stream
-    /// connected to the association acceptor.
-    ///
-    /// This can be used to send the PDU in semantic fragments of the message,
-    /// thus using less memory.
-    ///
-    /// **Note:** reading and writing should be done with care
-    /// to avoid inconsistencies in the association state.
-    /// Do not call `send` and `receive` while not in a PDU boundary.
-    pub fn inner_stream(&mut self) -> &mut S {
-        SyncAssociation::inner_stream(self)
-    }
-}
-
 impl<S> SyncAssociation<S> for ClientAssociation<S>
 where
     S: CloseSocket + std::io::Read + std::io::Write,
@@ -1300,20 +1226,6 @@ where
 
     fn close(&mut self) -> std::io::Result<()> {
         self.socket.close()
-    }
-}
-
-/// Trait with the behavior to synchronously release an association
-#[deprecated(since = "0.9.1", note = "Call `SyncAssociation::release` instead")]
-pub trait Release {
-    #[deprecated(since = "0.9.1", note = "Call `SyncAssociation::release` instead")]
-    fn release(self) -> Result<()>;
-}
-
-#[allow(deprecated)]
-impl Release for ClientAssociation<std::net::TcpStream> {
-    fn release(self) -> Result<()> {
-        SyncAssociation::release(self)
     }
 }
 
@@ -1743,77 +1655,6 @@ impl<S> AsyncClientAssociation<S> {
     /// Retrieve the list of negotiated presentation contexts.
     pub fn presentation_contexts(&self) -> &[PresentationContextNegotiated] {
         &self.presentation_contexts
-    }
-}
-
-// compatibility filler, remove in 0.10.0
-#[cfg(feature = "async")]
-impl<S> AsyncClientAssociation<S>
-where
-    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
-{
-    /// Obtain access to the inner stream
-    /// connected to the association acceptor.
-    ///
-    /// This can be used to send the PDU in semantic fragments of the message,
-    /// thus using less memory.
-    ///
-    /// **Note:** reading and writing should be done with care
-    /// to avoid inconsistencies in the association state.
-    /// Do not call `send` and `receive` while not in a PDU boundary.
-    pub fn inner_stream(&mut self) -> &mut S {
-        AsyncAssociation::inner_stream(self)
-    }
-
-    /// Send a PDU message to the other intervenient.
-    pub async fn send(&mut self, msg: &Pdu) -> Result<()> {
-        AsyncAssociation::send(self, msg).await
-    }
-
-    /// Read a PDU message from the other intervenient.
-    pub async fn receive(&mut self) -> Result<Pdu> {
-        AsyncAssociation::receive(self).await
-    }
-
-    /// Iniate a graceful release of the association.
-    ///
-    /// A DIMSE A-RELEASE transaction is initiated by this application entity,
-    /// and the underlying socket is closed once settled.
-    ///
-    /// Note that implementers of this trait
-    /// do not try to release the association on [`Drop`],
-    /// so remember to call `release` explicitly
-    /// at the end of all DIMSE transactions.
-    pub async fn release(self) -> Result<()> {
-        AsyncAssociation::release(self).await
-    }
-
-    /// Send a provider initiated abort message
-    /// and shut down the TCP connection,
-    /// terminating the association.
-    pub async fn abort(self) -> Result<()> {
-        AsyncAssociation::abort(self).await
-    }
-
-    /// Prepare a P-Data writer for sending
-    /// one or more data item PDUs.
-    ///
-    /// Returns a writer which automatically
-    /// splits the inner data into separate PDUs if necessary.
-    pub fn send_pdata(
-        &mut self,
-        presentation_context_id: u8,
-    ) -> crate::association::pdata::non_blocking::AsyncPDataWriter<&mut S> {
-        AsyncAssociation::send_pdata(self, presentation_context_id)
-    }
-
-    /// Prepare a P-Data reader for receiving
-    /// one or more data item PDUs.
-    ///
-    /// Returns a reader which automatically
-    /// receives more data PDUs once the bytes collected are consumed.
-    pub fn receive_pdata(&mut self) -> crate::association::pdata::PDataReader<'_, &mut S> {
-        AsyncAssociation::receive_pdata(self)
     }
 }
 

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -572,6 +572,12 @@ impl<'a> ClientAssociationOptions<'a> {
     /// Initiate simple TCP connection to the given address
     /// and request a new DICOM association,
     /// negotiating the presentation contexts in the process.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// is entered in state Sta1 (no connection established).
+    /// If the return value is `Ok`, the new state is Sta6
+    /// (ready to send/receive data); if it is `Err`, the new
+    /// state is Sta1.
     pub fn establish<A: ToSocketAddrs>(
         self,
         address: A,
@@ -584,6 +590,12 @@ impl<'a> ClientAssociationOptions<'a> {
     /// Initiate simple TCP connection to the given address
     /// and request a new DICOM association,
     /// negotiating the presentation contexts in the process.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// is entered in state Sta1 (no connection established).
+    /// If the return value is `Ok`, the new state is Sta6
+    /// (ready to send/receive data); if it is `Err`, the new
+    /// state is Sta1.
     #[cfg(feature = "sync-tls")]
     pub fn establish_tls<A: ToSocketAddrs>(
         self,
@@ -610,6 +622,12 @@ impl<'a> ClientAssociationOptions<'a> {
     /// However, the AE title in this parameter
     /// is overridden by any `called_ae_title` option
     /// previously received.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// is entered in state Sta1 (no connection established).
+    /// If the return value is `Ok`, the new state is Sta6
+    /// (ready to send/receive data); if it is `Err`, the new
+    /// state is Sta1.
     ///
     /// # Example
     ///
@@ -648,6 +666,12 @@ impl<'a> ClientAssociationOptions<'a> {
     /// However, the AE title in this parameter
     /// is overridden by any `called_ae_title` option
     /// previously received.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// is entered in state Sta1 (no connection established).
+    /// If the return value is `Ok`, the new state is Sta6
+    /// (ready to send/receive data); if it is `Err`, the new
+    /// state is Sta1.
     ///
     /// # Example
     ///
@@ -1284,14 +1308,12 @@ where
         (socket, read_buffer, write_buffer)
     }
 
-    /// Send a PDU message to the other intervenient.
     fn send(&mut self, pdu: &Pdu) -> Result<()> {
         let max_pdu = self.acceptor_max_pdu_length;
         let (socket, _, write_buffer) = self.get_mut();
         super::write_pdu_to_wire(socket, write_buffer, pdu, max_pdu)
     }
 
-    /// Read a PDU message from the other intervenient.
     fn receive(&mut self) -> Result<Pdu> {
         super::read_pdu_from_wire(
             &mut self.socket,

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -1817,6 +1817,10 @@ where
         .await
     }
 
+    async fn release(self) -> Result<()> {
+        super::release_impl_async(self, true).await
+    }
+
     fn write_timeout(&self) -> Option<Duration> {
         self.write_timeout
     }

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -1244,6 +1244,10 @@ where
         )
     }
 
+    fn release(self) -> Result<()> {
+        super::release_impl(self, true)
+    }
+
     fn close(&mut self) -> std::io::Result<()> {
         self.socket.close()
     }

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -18,7 +18,7 @@ use crate::{
     AeAddr, IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
     association::{
         Association, NegotiatedOptions, SocketOptions, SyncAssociation, encode_pdu,
-        private::SyncAssociationSealed, read_pdu_from_wire,
+        read_pdu_from_wire,
     },
     pdu::{
         AbortRQSource, AssociationAC, AssociationRQ, DEFAULT_MAX_PDU, LARGE_PDU_SIZE,
@@ -1258,10 +1258,23 @@ where
     }
 }
 
-impl<S> SyncAssociationSealed<S> for ClientAssociation<S>
+impl<S> SyncAssociation<S> for ClientAssociation<S>
 where
     S: CloseSocket + std::io::Read + std::io::Write,
 {
+    fn inner_stream(&mut self) -> &mut S {
+        &mut self.socket
+    }
+
+    fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
+        let Self {
+            socket,
+            read_buffer,
+            ..
+        } = self;
+        (socket, read_buffer)
+    }
+
     /// Send a PDU message to the other intervenient.
     fn send(&mut self, pdu: &Pdu) -> Result<()> {
         self.write_buffer.clear();
@@ -1290,35 +1303,17 @@ where
     }
 }
 
-impl<S> SyncAssociation<S> for ClientAssociation<S>
-where
-    S: CloseSocket + std::io::Read + std::io::Write,
-{
-    fn inner_stream(&mut self) -> &mut S {
-        &mut self.socket
-    }
-
-    fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
-        let Self {
-            socket,
-            read_buffer,
-            ..
-        } = self;
-        (socket, read_buffer)
-    }
-}
-
 /// Trait with the behavior to synchronously release an association
 #[deprecated(since = "0.9.1", note = "Call `SyncAssociation::release` instead")]
 pub trait Release {
     #[deprecated(since = "0.9.1", note = "Call `SyncAssociation::release` instead")]
-    fn release(&mut self) -> Result<()>;
+    fn release(self) -> Result<()>;
 }
 
 #[allow(deprecated)]
 impl Release for ClientAssociation<std::net::TcpStream> {
-    fn release(&mut self) -> Result<()> {
-        SyncAssociationSealed::release(self)
+    fn release(self) -> Result<()> {
+        SyncAssociation::release(self)
     }
 }
 
@@ -1823,10 +1818,23 @@ where
 }
 
 #[cfg(feature = "async")]
-impl<S> super::private::AsyncAssociationSealed<S> for AsyncClientAssociation<S>
+impl<S> AsyncAssociation<S> for AsyncClientAssociation<S>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
 {
+    fn inner_stream(&mut self) -> &mut S {
+        &mut self.socket
+    }
+
+    fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
+        let Self {
+            socket,
+            read_buffer,
+            ..
+        } = self;
+        (socket, read_buffer)
+    }
+
     async fn send(&mut self, msg: &Pdu) -> Result<()> {
         use tokio::io::AsyncWriteExt;
 
@@ -1862,25 +1870,6 @@ where
     async fn close(&mut self) -> std::io::Result<()> {
         use tokio::io::AsyncWriteExt;
         self.socket.shutdown().await
-    }
-}
-
-#[cfg(feature = "async")]
-impl<S> AsyncAssociation<S> for AsyncClientAssociation<S>
-where
-    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
-{
-    fn inner_stream(&mut self) -> &mut S {
-        &mut self.socket
-    }
-
-    fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
-        let Self {
-            socket,
-            read_buffer,
-            ..
-        } = self;
-        (socket, read_buffer)
     }
 }
 

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -1386,8 +1386,9 @@ pub struct AsyncClientAssociation<S> {
     requestor_max_pdu_length: u32,
     /// The maximum PDU length that the remote application entity accepts
     acceptor_max_pdu_length: u32,
-    /// The TCP stream to the other DICOM node
-    socket: S,
+    /// The TCP stream to the other DICOM node, or `None` if the socket was
+    /// closed by this application entity.
+    socket: Option<S>,
     /// Buffer to assemble PDU before sending it on wire
     write_buffer: Vec<u8>,
     /// whether to receive PDUs in strict mode
@@ -1440,7 +1441,7 @@ impl<'a> ClientAssociationOptions<'a> {
         );
         let resp = super::timeout(self.socket_options.read_timeout, async {
             super::read_pdu_from_wire_async(
-                &mut socket,
+                Some(&mut socket),
                 &mut read_buffer,
                 self.max_pdu_length,
                 self.strict,
@@ -1511,7 +1512,7 @@ impl<'a> ClientAssociationOptions<'a> {
                     presentation_contexts,
                     requestor_max_pdu_length: self.max_pdu_length,
                     acceptor_max_pdu_length: peer_max_pdu_length,
-                    socket,
+                    socket: Some(socket),
                     write_buffer,
                     strict: self.strict,
                     // Fixes #589, instead of creating a new buffer, we pass the existing buffer into the Association object.
@@ -1759,11 +1760,11 @@ impl<S> AsyncAssociation<S> for AsyncClientAssociation<S>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
 {
-    fn inner_stream(&mut self) -> &mut S {
+    fn inner_stream(&mut self) -> &mut Option<S> {
         &mut self.socket
     }
 
-    fn get_mut(&mut self) -> (&mut S, &mut BytesMut, &mut Vec<u8>) {
+    fn get_mut(&mut self) -> (&mut Option<S>, &mut BytesMut, &mut Vec<u8>) {
         let Self {
             socket,
             read_buffer,
@@ -1777,13 +1778,14 @@ where
         let write_timeout = self.write_timeout;
         let max_pdu = self.acceptor_max_pdu_length;
         let (socket, _, write_buffer) = self.get_mut();
-        super::write_pdu_to_wire_async(socket, write_buffer, msg, max_pdu, write_timeout)
+
+        super::write_pdu_to_wire_async(socket.as_mut(), write_buffer, msg, max_pdu, write_timeout)
     }
 
     async fn receive(&mut self) -> Result<Pdu> {
         super::timeout(self.read_timeout, async {
             super::read_pdu_from_wire_async(
-                &mut self.socket,
+                self.socket.as_mut(),
                 &mut self.read_buffer,
                 self.requestor_max_pdu_length,
                 self.strict,
@@ -1791,11 +1793,6 @@ where
             .await
         })
         .await
-    }
-
-    async fn close(&mut self) -> std::io::Result<()> {
-        use tokio::io::AsyncWriteExt;
-        self.socket.shutdown().await
     }
 }
 
@@ -1895,9 +1892,13 @@ mod tests {
             let mut buf = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let resp =
-                read_pdu_from_wire_async(&mut socket, &mut buf, self.max_pdu_length, self.strict)
-                    .await?;
+            let resp = read_pdu_from_wire_async(
+                Some(&mut socket),
+                &mut buf,
+                self.max_pdu_length,
+                self.strict,
+            )
+            .await?;
             let NegotiatedOptions {
                 presentation_contexts,
                 peer_max_pdu_length,
@@ -1910,7 +1911,7 @@ mod tests {
                 presentation_contexts,
                 requestor_max_pdu_length: self.max_pdu_length,
                 acceptor_max_pdu_length: peer_max_pdu_length,
-                socket,
+                socket: Some(socket),
                 write_buffer: buffer,
                 strict: self.strict,
                 // Fixes #589, instead of creating a new buffer, we pass the existing buffer into the Association object.
@@ -1998,9 +1999,13 @@ mod tests {
             let mut buf = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let resp =
-                read_pdu_from_wire_async(&mut socket, &mut buf, self.max_pdu_length, self.strict)
-                    .await?;
+            let resp = read_pdu_from_wire_async(
+                Some(&mut socket),
+                &mut buf,
+                self.max_pdu_length,
+                self.strict,
+            )
+            .await?;
             let NegotiatedOptions {
                 presentation_contexts,
                 peer_max_pdu_length,
@@ -2013,7 +2018,7 @@ mod tests {
                 presentation_contexts,
                 requestor_max_pdu_length: self.max_pdu_length,
                 acceptor_max_pdu_length: peer_max_pdu_length,
-                socket,
+                socket: Some(socket),
                 write_buffer: buffer,
                 strict: self.strict,
                 read_buffer: BytesMut::with_capacity(

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -16,7 +16,10 @@ use std::{
 use crate::association::AsyncAssociation;
 use crate::{
     AeAddr, IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
-    association::{Association, NegotiatedOptions, SocketOptions, SyncAssociation},
+    association::{
+        Association, DEFAULT_FINALIZATION_TIMEOUT, NegotiatedOptions, SocketOptions,
+        SyncAssociation,
+    },
     pdu::{
         AbortRQSource, AssociationAC, AssociationRQ, DEFAULT_MAX_PDU, LARGE_PDU_SIZE,
         MAXIMUM_PDU_SIZE, PDU_HEADER_SIZE, Pdu, PresentationContextNegotiated,
@@ -35,7 +38,7 @@ pub type TlsStream = rustls::StreamOwned<rustls::ClientConnection, std::net::Tcp
 #[cfg(feature = "async-tls")]
 pub type AsyncTlsStream = tokio_rustls::client::TlsStream<tokio::net::TcpStream>;
 
-pub use crate::association::CloseSocket;
+pub use crate::association::{CloseSocket, SetReadTimeout};
 
 /// Helper function to establish a TCP client connection
 fn tcp_connection<T>(ae_address: &AeAddr<T>, opts: &SocketOptions) -> Result<TcpStream>
@@ -261,6 +264,8 @@ pub struct ClientAssociationOptions<'a> {
     username: Option<Cow<'a, str>>,
     /// User identity password
     password: Option<Cow<'a, str>>,
+    /// Timeout to wait for the peer to close the connection
+    finalization_timeout: Duration,
     /// User identity Kerberos service ticket
     kerberos_service_ticket: Option<Cow<'a, str>>,
     /// User identity SAML assertion
@@ -295,6 +300,7 @@ impl Default for ClientAssociationOptions<'_> {
             protocol_version: 1,
             max_pdu_length: DEFAULT_MAX_PDU,
             strict: true,
+            finalization_timeout: Duration::from_secs_f32(DEFAULT_FINALIZATION_TIMEOUT),
             username: None,
             password: None,
             kerberos_service_ticket: None,
@@ -722,6 +728,12 @@ impl<'a> ClientAssociationOptions<'a> {
         }
     }
 
+    /// Set the timeout for the peer to close the socket
+    pub fn finalization_timeout(mut self, timeout: Duration) -> Self {
+        self.finalization_timeout = timeout;
+        self
+    }
+
     /// Construct the A-ASSOCIATE-RQ PDU given the options and the AE title.
     fn create_a_associate_req(
         &'a self,
@@ -994,6 +1006,7 @@ impl<'a> ClientAssociationOptions<'a> {
                     read_buffer: buf,
                     read_timeout: self.socket_options.read_timeout,
                     write_timeout: self.socket_options.write_timeout,
+                    finalization_timeout: self.finalization_timeout,
                     user_variables,
                     peer_ae_title,
                 })
@@ -1093,6 +1106,8 @@ pub struct ClientAssociation<S> {
     read_timeout: Option<Duration>,
     /// Timeout for individual socket Writes.
     write_timeout: Option<Duration>,
+    /// Timeout to wait for the peer to close the connection
+    finalization_timeout: Duration,
     /// Buffer to assemble PDU before parsing
     read_buffer: BytesMut,
     /// User variables that were taken from the server
@@ -1133,6 +1148,18 @@ where
         self.acceptor_max_pdu_length
     }
 
+    /// Retrieve the association finalization timeout defined
+    /// for this association.
+    fn finalization_timeout(&self) -> Duration {
+        self.finalization_timeout
+    }
+
+    /// Change the association finalization timeout defined
+    /// for this association.
+    fn set_finalization_timeout(&mut self, timeout: Duration) {
+        self.finalization_timeout = timeout;
+    }
+
     fn presentation_contexts(&self) -> &[PresentationContextNegotiated] {
         &self.presentation_contexts
     }
@@ -1144,7 +1171,7 @@ where
 
 impl<S> ClientAssociation<S>
 where
-    S: CloseSocket + std::io::Read + std::io::Write,
+    S: CloseSocket + SetReadTimeout + std::io::Read + std::io::Write,
 {
     /// Retrieve read timeout for the association
     pub fn read_timeout(&self) -> Option<Duration> {
@@ -1184,7 +1211,7 @@ where
 
 impl<S> SyncAssociation<S> for ClientAssociation<S>
 where
-    S: CloseSocket + std::io::Read + std::io::Write,
+    S: CloseSocket + SetReadTimeout + std::io::Read + std::io::Write,
 {
     fn inner_stream(&mut self) -> &mut S {
         &mut self.socket
@@ -1308,6 +1335,8 @@ pub struct AsyncClientAssociation<S> {
     read_timeout: Option<Duration>,
     /// Timeout for individual socket Writes.
     write_timeout: Option<Duration>,
+    /// Timeout to wait for the peer to close the connection
+    finalization_timeout: Duration,
     /// Buffer to assemble PDU before parsing
     read_buffer: BytesMut,
     /// User variables that were taken from the server
@@ -1428,6 +1457,7 @@ impl<'a> ClientAssociationOptions<'a> {
                     read_buffer,
                     read_timeout: self.socket_options.read_timeout,
                     write_timeout: self.socket_options.write_timeout,
+                    finalization_timeout: self.finalization_timeout,
                     user_variables,
                     peer_ae_title,
                 })
@@ -1598,6 +1628,18 @@ impl<S> Association for AsyncClientAssociation<S> {
         self.requestor_max_pdu_length
     }
 
+    /// Retrieve the association finalization timeout defined
+    /// for this association.
+    fn finalization_timeout(&self) -> Duration {
+        self.finalization_timeout
+    }
+
+    /// Change the association finalization timeout defined
+    /// for this association.
+    fn set_finalization_timeout(&mut self, timeout: Duration) {
+        self.finalization_timeout = timeout;
+    }
+
     /// Retrieve the maximum PDU length that the peer application entity
     /// (the association acceptor) is expecting to receive.
     fn peer_max_pdu_length(&self) -> u32 {
@@ -1756,6 +1798,7 @@ mod tests {
                 read_buffer,
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
+                finalization_timeout: self.finalization_timeout,
                 user_variables,
                 peer_ae_title,
             })
@@ -1813,6 +1856,7 @@ mod tests {
                 read_buffer: buf,
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
+                finalization_timeout: self.finalization_timeout,
                 user_variables,
                 peer_ae_title,
             })
@@ -1861,6 +1905,7 @@ mod tests {
                 ),
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
+                finalization_timeout: self.finalization_timeout,
                 user_variables,
                 peer_ae_title,
             })
@@ -1915,6 +1960,7 @@ mod tests {
                 ),
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
+                finalization_timeout: self.finalization_timeout,
                 user_variables,
                 peer_ae_title,
             })

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -1816,6 +1816,14 @@ where
         })
         .await
     }
+
+    fn write_timeout(&self) -> Option<Duration> {
+        self.write_timeout
+    }
+
+    fn read_timeout(&self) -> Option<Duration> {
+        self.read_timeout
+    }
 }
 
 #[cfg(test)]

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -17,12 +17,12 @@ use crate::association::AsyncAssociation;
 use crate::{
     AeAddr, IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
     association::{
-        Association, DEFAULT_FINALIZATION_TIMEOUT, NegotiatedOptions, SocketOptions,
+        Association, DEFAULT_FINALIZATION_TIMEOUT, Error, NegotiatedOptions, SocketOptions,
         SyncAssociation,
     },
     pdu::{
-        AbortRQSource, AssociationAC, AssociationRQ, DEFAULT_MAX_PDU, LARGE_PDU_SIZE,
-        MAXIMUM_PDU_SIZE, PDU_HEADER_SIZE, Pdu, PresentationContextNegotiated,
+        AbortRQServiceProviderReason, AbortRQSource, AssociationAC, AssociationRQ, DEFAULT_MAX_PDU,
+        LARGE_PDU_SIZE, MAXIMUM_PDU_SIZE, PDU_HEADER_SIZE, Pdu, PresentationContextNegotiated,
         PresentationContextProposed, PresentationContextResultReason, RequestorRoles, UserIdentity,
         UserIdentityType, UserVariableItem, write_pdu,
     },
@@ -843,6 +843,8 @@ impl<'a> ClientAssociationOptions<'a> {
         msg: Pdu,
         presentation_contexts_proposed: &[PresentationContextProposed],
     ) -> Result<NegotiatedOptions> {
+        // We enter this function in state Sta5, after we've already
+        // sent an A-ASSOCIATE-RQ in Sta4.
         match msg {
             Pdu::AssociationAC(AssociationAC {
                 protocol_version: protocol_version_scp,
@@ -852,6 +854,7 @@ impl<'a> ClientAssociationOptions<'a> {
                 called_ae_title,
                 user_variables,
             }) => {
+                // Action AE-3: association confirmed, signaled by Ok(_)
                 ensure!(
                     self.protocol_version == protocol_version_scp,
                     crate::association::ProtocolVersionMismatchSnafu {
@@ -895,7 +898,7 @@ impl<'a> ClientAssociationOptions<'a> {
                     })
                     .collect();
                 if presentation_contexts.is_empty() {
-                    return crate::association::NoAcceptedPresentationContextsSnafu.fail();
+                    return super::NoAcceptedPresentationContextsSnafu.fail();
                 }
                 Ok(NegotiatedOptions {
                     presentation_contexts,
@@ -905,14 +908,29 @@ impl<'a> ClientAssociationOptions<'a> {
                 })
             }
             Pdu::AssociationRJ(association_rj) => {
-                crate::association::RejectedSnafu { association_rj }.fail()
+                // Action AE-4: send rejection notification and
+                // close connection. The connection will be closed
+                // by our caller, since we don't have the socket.
+                super::RejectedSnafu { association_rj }.fail()
             }
-            pdu @ Pdu::AbortRQ { .. }
-            | pdu @ Pdu::ReleaseRQ
-            | pdu @ Pdu::AssociationRQ { .. }
+            Pdu::AbortRQ { .. } => {
+                // Action AA-3: issue abort indication and close
+                // the connection (done by caller)
+                super::AbortedSnafu {}.fail()
+            }
+            pdu @ Pdu::AssociationRQ { .. }
             | pdu @ Pdu::PData { .. }
-            | pdu @ Pdu::ReleaseRP => crate::association::UnexpectedPduSnafu { pdu }.fail(),
-            pdu @ Pdu::Unknown { .. } => crate::association::UnknownPduSnafu { pdu }.fail(),
+            | pdu @ Pdu::ReleaseRQ
+            | pdu @ Pdu::ReleaseRP => {
+                // Action AA-8: send service-provided A-ABORT PDU
+                // (done by caller)
+                super::UnexpectedPduSnafu { pdu }.fail()
+            }
+            pdu @ Pdu::Unknown { .. } => {
+                // Action AA-8: send service-provided A-ABORT PDU
+                // (done by caller)
+                super::UnknownPduSnafu { pdu }.fail()
+            }
         }
     }
 
@@ -924,20 +942,33 @@ impl<'a> ClientAssociationOptions<'a> {
     ) -> Result<ClientAssociation<S>>
     where
         T: ToSocketAddrs,
-        S: CloseSocket + std::io::Read + std::io::Write,
+        S: CloseSocket + SetReadTimeout + std::io::Read + std::io::Write,
     {
+        // Entered in state Sta4 after transport connection confirmation
+        // (transition from Sta1 to Sta4 happened in one of the various
+        // establish_* methods).
+        // Action is AE-2 (send A-ASSOCIATE-RQ); next state is Sta5
         let (pc_proposed, a_associate) = self.create_a_associate_req(ae_address.ae_title())?;
-        let mut buffer: Vec<u8> = Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
+        let mut write_buffer: Vec<u8> =
+            Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
 
-        write_pdu(&mut buffer, &a_associate).context(super::SendPduSnafu)?;
-        socket.write_all(&buffer).context(super::WireSendSnafu)?;
-        buffer.clear();
+        write_pdu(&mut write_buffer, &a_associate).context(super::SendPduSnafu)?;
+        socket
+            .write_all(&write_buffer)
+            .context(super::WireSendSnafu)?;
+        write_buffer.clear();
 
-        let mut buf = BytesMut::with_capacity(
+        // We're now in state Sta5 (waiting for response from server)
+
+        let mut read_buffer = BytesMut::with_capacity(
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
-        let resp =
-            super::read_pdu_from_wire(&mut socket, &mut buf, self.max_pdu_length, self.strict);
+        let resp = super::read_pdu_from_wire(
+            &mut socket,
+            &mut read_buffer,
+            self.max_pdu_length,
+            self.strict,
+        );
         // If we're in non-TLS mode and `read_pdu_from_wire` fails, it
         // could be because the server expects TLS but we sent a
         // plaintext request.  In that case, we make a best effort to
@@ -951,7 +982,7 @@ impl<'a> ClientAssociationOptions<'a> {
             // try to identify whether the server expects TLS
             // (even though the client was not fully prepared for this)
             let mut acceptor = rustls::server::Acceptor::default();
-            let mut read = std::io::Cursor::new(buf.to_vec());
+            let mut read = std::io::Cursor::new(read_buffer.to_vec());
             let res = acceptor.read_tls(&mut read);
             if res.is_err() {
                 return e;
@@ -977,17 +1008,41 @@ impl<'a> ClientAssociationOptions<'a> {
         let resp = resp?;
         let negotiated_options = self.process_a_association_resp(resp, &pc_proposed);
         match negotiated_options {
-            Err(e) => {
-                // abort connection
+            Err(err @ Error::Rejected { .. }) | Err(err @ Error::Aborted { .. }) => {
+                // Association was rejected or aborted.
+                // Close transport connection and return to Sta1.
+                // Note that since Error::Aborted does not have any info
+                // on the AbortRQSource, we can't relay it, so we don't
+                // distinguish an A-ABORT indication from A-P-ABORT one.
+                let _ = socket.close();
+                Err(err)
+            }
+            Err(err) => {
+                // Other errors - send A-ABORT (service provider)
+                // and go to Sta13
                 let _ = write_pdu(
-                    &mut buffer,
+                    &mut write_buffer,
                     &Pdu::AbortRQ {
-                        source: AbortRQSource::ServiceUser,
+                        source: AbortRQSource::ServiceProvider(
+                            if let Error::UnknownPdu { .. } = err {
+                                AbortRQServiceProviderReason::UnrecognizedPdu
+                            } else {
+                                AbortRQServiceProviderReason::UnexpectedPdu
+                            },
+                        ),
                     },
                 );
-                let _ = socket.write_all(&buffer);
-                buffer.clear();
-                Err(e)
+                let _ = socket.write_all(&write_buffer);
+                write_buffer.clear();
+                super::sta13(
+                    &mut socket,
+                    &mut read_buffer,
+                    &mut write_buffer,
+                    self.max_pdu_length,
+                    DEFAULT_MAX_PDU,
+                    self.finalization_timeout,
+                )?;
+                Err(err)
             }
             Ok(NegotiatedOptions {
                 presentation_contexts,
@@ -995,15 +1050,17 @@ impl<'a> ClientAssociationOptions<'a> {
                 user_variables,
                 peer_ae_title,
             }) => {
+                // Action AE-3, next state is Sta6. We indicate both
+                // by returning Ok(_).
                 Ok(ClientAssociation {
                     presentation_contexts,
                     requestor_max_pdu_length: self.max_pdu_length,
                     acceptor_max_pdu_length: peer_max_pdu_length,
                     socket,
-                    write_buffer: buffer,
+                    write_buffer,
                     strict: self.strict,
                     // Fixes #589, instead of creating a new buffer, we pass the existing buffer into the Association object.
-                    read_buffer: buf,
+                    read_buffer,
                     read_timeout: self.socket_options.read_timeout,
                     write_timeout: self.socket_options.write_timeout,
                     finalization_timeout: self.finalization_timeout,

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -387,9 +387,27 @@ pub trait SyncAssociation<S: Read + Write + CloseSocket + SetReadTimeout>: Assoc
     fn get_mut(&mut self) -> (&mut S, &mut BytesMut, &mut Vec<u8>);
 
     /// Send a PDU message to the other intervenient.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// must be entered in state Sta6 (ready to send/receive data).
+    /// If the return value is `Ok`, the new state is still Sta6;
+    /// if it is `Err`, the new state is Sta1 (no connection), and
+    /// the association object should be considered no longer valid.
+    // FIXME: Will that be the case, or only for certain Err values?
+    //        e.g. a SendTooLongPdu error should probably not close
+    //        the connection.
+    // TODO: Actually implement state machine handling.
     fn send(&mut self, pdu: &Pdu) -> Result<()>;
 
     /// Read a PDU message from the other intervenient.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// must be entered in state Sta6 (ready to send/receive data).
+    /// If the return value is `Ok`, the new state is still Sta6;
+    /// if it is `Err`, the new state is Sta1 (no connection), and
+    /// the association object should be considered no longer valid.
+    // FIXME: Will that be the case, or only for certain Err values?
+    // TODO: Actually implement state machine handling.
     fn receive(&mut self) -> Result<Pdu>;
 
     /// Send an abort message with a source/reason
@@ -398,6 +416,11 @@ pub trait SyncAssociation<S: Read + Write + CloseSocket + SetReadTimeout>: Assoc
     /// This function may take up to a time defined by
     /// `finalization_timeout()` to complete, depending
     /// on how long the peer takes to close the socket.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// must be entered in state Sta6 (ready to send/receive data).
+    /// It will return in state Sta1 (no connection) regardless of
+    /// the return value, which serves to identify what happened.
     fn abort_with_source(mut self, source: AbortRQSource) -> Result<()>
     where
         Self: Sized,
@@ -424,6 +447,11 @@ pub trait SyncAssociation<S: Read + Write + CloseSocket + SetReadTimeout>: Assoc
     /// This function may take up to a time defined by
     /// `finalization_timeout()` to complete, depending
     /// on how long the peer takes to close the socket.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// must be entered in state Sta6 (ready to send/receive data).
+    /// It will return in state Sta1 (no connection) regardless of
+    /// the return value, which serves to identify what happened.
     fn abort(self) -> Result<()>
     where
         Self: Sized,
@@ -443,6 +471,14 @@ pub trait SyncAssociation<S: Read + Write + CloseSocket + SetReadTimeout>: Assoc
     /// implementers of this trait no longer call this method on [`Drop`],
     /// so remember to call `release` explicitly
     /// at the end of all DIMSE transactions.
+    ///
+    /// This function may take an indefinite time to continue, if receive
+    /// timeout is not defined and the peer does not respond.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// must be entered in state Sta6 (ready to send/receive data).
+    /// It will return in state Sta1 (no connection) regardless of
+    /// the return value, which serves to identify what happened.
     fn release(self) -> Result<()>
     where
         Self: Sized;

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -46,8 +46,8 @@ use snafu::{ResultExt, Snafu, ensure};
 use crate::{
     Pdu,
     pdu::{
-        self, AssociationRJ, PresentationContextNegotiated, ReadPduSnafu, RequestorRoles,
-        UserVariableItem,
+        self, AbortRQServiceProviderReason, AbortRQSource, AssociationRJ,
+        PresentationContextNegotiated, ReadPduSnafu, RequestorRoles, UserVariableItem,
     },
     write_pdu,
 };
@@ -342,127 +342,8 @@ pub trait Association {
     }
 }
 
-mod private {
-    use crate::{
-        Pdu,
-        pdu::{AbortRQServiceProviderReason, AbortRQSource},
-    };
-    use snafu::ResultExt;
-
-    /// Private trait which exposes "unsafe" methods that should not be called by the user
-    ///
-    /// `close` and `release` _should_ take ownership, and in the public interface, they
-    /// do. However, in order to implement `Drop` we need to expose a version of these
-    /// methods that don't take ownership.
-    ///
-    /// `send` and `receive` implementations are needed in order to provide
-    /// the implementation for `release`
-    pub trait SyncAssociationSealed<S: std::io::Read + std::io::Write + super::CloseSocket> {
-        fn close(&mut self) -> std::io::Result<()>;
-        fn send(&mut self, pdu: &Pdu) -> super::Result<()>;
-        fn receive(&mut self) -> super::Result<Pdu>;
-        fn release(&mut self) -> super::Result<()> {
-            let pdu = Pdu::ReleaseRQ;
-            self.send(&pdu)?;
-            let pdu = self.receive()?;
-
-            match pdu {
-                Pdu::ReleaseRP => {}
-                pdu @ Pdu::AbortRQ { .. }
-                | pdu @ Pdu::AssociationAC { .. }
-                | pdu @ Pdu::AssociationRJ { .. }
-                | pdu @ Pdu::AssociationRQ { .. }
-                | pdu @ Pdu::PData { .. }
-                | pdu @ Pdu::ReleaseRQ => return super::UnexpectedPduSnafu { pdu }.fail(),
-                pdu @ Pdu::Unknown { .. } => return super::UnknownPduSnafu { pdu }.fail(),
-            }
-            self.close().context(super::CloseSnafu)?;
-            Ok(())
-        }
-
-        fn abort(&mut self) -> super::Result<()>
-        where
-            Self: Sized,
-        {
-            let pdu = Pdu::AbortRQ {
-                source: AbortRQSource::ServiceProvider(
-                    AbortRQServiceProviderReason::ReasonNotSpecified,
-                ),
-            };
-            let out = self.send(&pdu);
-            let _ = self.close();
-            out
-        }
-    }
-
-    /// Private trait which exposes "unsafe" methods that should not be called by the user
-    ///
-    /// `close` and `release` _should_ take ownership, and in the public interface, they
-    /// do. However, in order to implement `Drop` we need to expose a version of these
-    /// methods that don't take ownership.
-    ///
-    /// `send` and `receive` implementations are needed in order to provide
-    /// the implementation for `release`
-    #[cfg(feature = "async")]
-    pub trait AsyncAssociationSealed<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin> {
-        fn close(&mut self) -> impl std::future::Future<Output = std::io::Result<()>> + Send
-        where
-            Self: Send;
-        fn send(
-            &mut self,
-            pdu: &Pdu,
-        ) -> impl std::future::Future<Output = super::Result<()>> + Send
-        where
-            Self: Send;
-        fn receive(&mut self) -> impl std::future::Future<Output = super::Result<Pdu>> + Send
-        where
-            Self: Send;
-        fn release(&mut self) -> impl std::future::Future<Output = super::Result<()>> + Send
-        where
-            Self: Send,
-        {
-            async move {
-                let pdu = Pdu::ReleaseRQ;
-                self.send(&pdu).await?;
-                let pdu = self.receive().await?;
-
-                match pdu {
-                    Pdu::ReleaseRP => {}
-                    pdu @ Pdu::AbortRQ { .. }
-                    | pdu @ Pdu::AssociationAC { .. }
-                    | pdu @ Pdu::AssociationRJ { .. }
-                    | pdu @ Pdu::AssociationRQ { .. }
-                    | pdu @ Pdu::PData { .. }
-                    | pdu @ Pdu::ReleaseRQ => return super::UnexpectedPduSnafu { pdu }.fail(),
-                    pdu @ Pdu::Unknown { .. } => return super::UnknownPduSnafu { pdu }.fail(),
-                }
-                self.close().await.context(super::CloseSnafu)?;
-                Ok(())
-            }
-        }
-
-        fn abort(&mut self) -> impl std::future::Future<Output = super::Result<()>> + Send
-        where
-            Self: Sized + Send,
-        {
-            let pdu = Pdu::AbortRQ {
-                source: AbortRQSource::ServiceProvider(
-                    AbortRQServiceProviderReason::ReasonNotSpecified,
-                ),
-            };
-            async move {
-                let out = self.send(&pdu).await;
-                let _ = self.close().await;
-                out
-            }
-        }
-    }
-}
-
 /// Trait that represents methods that can be made on a synchronous association.
-pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>:
-    private::SyncAssociationSealed<S> + Association
-{
+pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>: Association {
     /// Obtain access to the inner stream
     /// connected to the association acceptor.
     ///
@@ -478,14 +359,10 @@ pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>:
     fn get_mut(&mut self) -> (&mut S, &mut BytesMut);
 
     /// Send a PDU message to the other intervenient.
-    fn send(&mut self, pdu: &Pdu) -> Result<()> {
-        private::SyncAssociationSealed::send(self, pdu)
-    }
+    fn send(&mut self, pdu: &Pdu) -> Result<()>;
 
     /// Read a PDU message from the other intervenient.
-    fn receive(&mut self) -> Result<Pdu> {
-        private::SyncAssociationSealed::receive(self)
-    }
+    fn receive(&mut self) -> Result<Pdu>;
 
     /// Send a provider initiated abort message
     /// and shut down the TCP connection,
@@ -494,7 +371,14 @@ pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>:
     where
         Self: Sized,
     {
-        private::SyncAssociationSealed::abort(&mut self)
+        let pdu = Pdu::AbortRQ {
+            source: AbortRQSource::ServiceProvider(
+                AbortRQServiceProviderReason::ReasonNotSpecified,
+            ),
+        };
+        let out = self.send(&pdu);
+        let _ = self.close();
+        out
     }
 
     /// Iniate a graceful release of the association.
@@ -510,7 +394,22 @@ pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>:
     where
         Self: Sized,
     {
-        private::SyncAssociationSealed::release(&mut self)
+        let pdu = Pdu::ReleaseRQ;
+        self.send(&pdu)?;
+        let pdu = self.receive()?;
+
+        match pdu {
+            Pdu::ReleaseRP => {}
+            pdu @ Pdu::AbortRQ { .. }
+            | pdu @ Pdu::AssociationAC { .. }
+            | pdu @ Pdu::AssociationRJ { .. }
+            | pdu @ Pdu::AssociationRQ { .. }
+            | pdu @ Pdu::PData { .. }
+            | pdu @ Pdu::ReleaseRQ => return UnexpectedPduSnafu { pdu }.fail(),
+            pdu @ Pdu::Unknown { .. } => return UnknownPduSnafu { pdu }.fail(),
+        }
+        self.close().context(CloseSnafu)?;
+        Ok(())
     }
 
     /// Prepare a P-Data writer for sending
@@ -533,12 +432,14 @@ pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>:
         let (socket, read_buffer) = self.get_mut();
         PDataReader::new(socket, max_pdu_length, read_buffer)
     }
+
+    fn close(&mut self) -> std::io::Result<()>;
 }
 
 #[cfg(feature = "async")]
 /// Trait that represents methods that can be made on an asynchronous association.
 pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>:
-    private::AsyncAssociationSealed<S> + Association
+    Association
 {
     /// Obtain access to the inner stream
     /// connected to the association acceptor.
@@ -557,18 +458,12 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     /// Send a PDU message to the other intervenient.
     fn send(&mut self, pdu: &Pdu) -> impl std::future::Future<Output = Result<()>> + Send
     where
-        Self: Send,
-    {
-        async move { private::AsyncAssociationSealed::send(self, pdu).await }
-    }
+        Self: Send;
 
     /// Read a PDU message from the other intervenient.
     fn receive(&mut self) -> impl std::future::Future<Output = Result<Pdu>> + Send
     where
-        Self: Send,
-    {
-        async move { private::AsyncAssociationSealed::receive(self).await }
-    }
+        Self: Send;
 
     /// Send a provider initiated abort message
     /// and shut down the TCP connection,
@@ -577,7 +472,16 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     where
         Self: Sized + Send,
     {
-        async move { private::AsyncAssociationSealed::abort(&mut self).await }
+        let pdu = Pdu::AbortRQ {
+            source: AbortRQSource::ServiceProvider(
+                AbortRQServiceProviderReason::ReasonNotSpecified,
+            ),
+        };
+        async move {
+            let out = self.send(&pdu).await;
+            let _ = self.close().await;
+            out
+        }
     }
 
     /// Iniate a graceful release of the association.
@@ -593,7 +497,24 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     where
         Self: Sized + Send,
     {
-        async move { private::AsyncAssociationSealed::release(&mut self).await }
+        async move {
+            let pdu = Pdu::ReleaseRQ;
+            self.send(&pdu).await?;
+            let pdu = self.receive().await?;
+
+            match pdu {
+                Pdu::ReleaseRP => {}
+                pdu @ Pdu::AbortRQ { .. }
+                | pdu @ Pdu::AssociationAC { .. }
+                | pdu @ Pdu::AssociationRJ { .. }
+                | pdu @ Pdu::AssociationRQ { .. }
+                | pdu @ Pdu::PData { .. }
+                | pdu @ Pdu::ReleaseRQ => return UnexpectedPduSnafu { pdu }.fail(),
+                pdu @ Pdu::Unknown { .. } => return UnknownPduSnafu { pdu }.fail(),
+            }
+            self.close().await.context(CloseSnafu)?;
+            Ok(())
+        }
     }
 
     /// Prepare a P-Data writer for sending
@@ -616,6 +537,10 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
         let (socket, read_buffer) = self.get_mut();
         PDataReader::new(socket, max_pdu_length, read_buffer)
     }
+
+    fn close(&mut self) -> impl std::future::Future<Output = std::io::Result<()>> + Send
+    where
+        Self: Send;
 }
 
 // Helper function to perform an operation with timeout
@@ -628,7 +553,7 @@ async fn timeout<T>(
         tokio::time::timeout(timeout, block)
             .await
             .map_err(|_| std::io::Error::from(std::io::ErrorKind::TimedOut))
-            .context(crate::association::TimeoutSnafu)?
+            .context(TimeoutSnafu)?
     } else {
         block.await
     }

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -1038,7 +1038,7 @@ pub(crate) fn sta13<S: Read + Write + CloseSocket + SetReadTimeout>(
 ///
 /// This is the asynchronous version.
 #[cfg(feature = "async")]
-pub(crate) async fn _sta13_async<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>(
+pub(crate) async fn sta13_async<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>(
     socket: &mut Option<S>,
     read_buffer: &mut BytesMut,
     write_buffer: &mut Vec<u8>,

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -52,6 +52,9 @@ use crate::{
     write_pdu,
 };
 
+/// Default timeout in seconds to wait for the peer to close the connection
+pub const DEFAULT_FINALIZATION_TIMEOUT: f32 = 30.0;
+
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
@@ -309,6 +312,14 @@ pub trait Association {
     /// for client objects.
     fn peer_max_pdu_length(&self) -> u32;
 
+    /// Retrieve the association finalization timeout
+    /// defined for this association
+    fn finalization_timeout(&self) -> Duration;
+
+    /// Change the association finalization timeout
+    /// defined for this association
+    fn set_finalization_timeout(&mut self, timeout: Duration);
+
     /// Obtain a view of the negotiated presentation contexts.
     fn presentation_contexts(&self) -> &[PresentationContextNegotiated];
 
@@ -360,7 +371,7 @@ pub trait Association {
 }
 
 /// Trait that represents methods that can be made on a synchronous association.
-pub trait SyncAssociation<S: Read + Write + CloseSocket>: Association {
+pub trait SyncAssociation<S: Read + Write + CloseSocket + SetReadTimeout>: Association {
     /// Obtain access to the inner stream
     /// connected to the association acceptor.
     ///
@@ -381,21 +392,43 @@ pub trait SyncAssociation<S: Read + Write + CloseSocket>: Association {
     /// Read a PDU message from the other intervenient.
     fn receive(&mut self) -> Result<Pdu>;
 
-    /// Send a provider initiated abort message
+    /// Send an abort message with a source/reason
     /// and shut down the TCP connection,
     /// terminating the association.
-    fn abort(mut self) -> Result<()>
+    /// This function may take up to a time defined by
+    /// `finalization_timeout()` to complete, depending
+    /// on how long the peer takes to close the socket.
+    fn abort_with_source(mut self, source: AbortRQSource) -> Result<()>
     where
         Self: Sized,
     {
-        let pdu = Pdu::AbortRQ {
-            source: AbortRQSource::ServiceProvider(
-                AbortRQServiceProviderReason::ReasonNotSpecified,
-            ),
-        };
-        let out = self.send(&pdu);
-        let _ = self.close();
-        out
+        let pdu = Pdu::AbortRQ { source };
+        let local_max_pdu_length = self.local_max_pdu_length();
+        let peer_max_pdu_length = self.peer_max_pdu_length();
+        let close_assoc_timeout = self.finalization_timeout();
+        let (socket, read_buffer, write_buffer) = self.get_mut();
+        write_pdu_to_wire(socket, write_buffer, &pdu, peer_max_pdu_length)?;
+        sta13(
+            socket,
+            read_buffer,
+            write_buffer,
+            local_max_pdu_length,
+            peer_max_pdu_length,
+            close_assoc_timeout,
+        )
+    }
+
+    /// Send a user-initiated abort message
+    /// and shut down the TCP connection,
+    /// terminating the association.
+    /// This function may take up to a time defined by
+    /// `finalization_timeout()` to complete, depending
+    /// on how long the peer takes to close the socket.
+    fn abort(self) -> Result<()>
+    where
+        Self: Sized,
+    {
+        self.abort_with_source(AbortRQSource::ServiceUser)
     }
 
     /// Iniate a graceful release of the association.
@@ -719,7 +752,7 @@ pub async fn read_pdu_from_wire_async<R: tokio::io::AsyncRead + Unpin>(
 ///
 /// For reference see [PS3.8 (2025d) section 9.2.3][1]
 /// [1] https://dicom.nema.org/medical/dicom/2025d/output/html/part08.html
-pub(crate) fn _sta13<S: Read + Write + CloseSocket + SetReadTimeout>(
+pub(crate) fn sta13<S: Read + Write + CloseSocket + SetReadTimeout>(
     socket: &mut S,
     read_buffer: &mut BytesMut,
     write_buffer: &mut Vec<u8>,

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -509,7 +509,7 @@ pub trait SyncAssociation<S: Read + Write + CloseSocket + SetReadTimeout>: Assoc
 
 #[cfg(feature = "async")]
 /// Trait that represents methods that can be made on an asynchronous association.
-pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>:
+pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send>:
     Association
 {
     /// Obtain access to the inner stream
@@ -539,23 +539,68 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     where
         Self: Send;
 
-    /// Send a provider initiated abort message
+    /// Send an abort message with a source/reason
     /// and shut down the TCP connection,
     /// terminating the association.
-    fn abort(mut self) -> impl std::future::Future<Output = Result<()>> + Send
+    /// This function may take up to a time defined by
+    /// `finalization_timeout()` to complete, depending
+    /// on how long the peer takes to close the socket.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// must be entered in state Sta6 (ready to send/receive data).
+    /// It will return in state Sta1 (no connection) regardless of
+    /// the return value, which serves to identify what happened.
+    fn abort_with_source(
+        mut self,
+        source: AbortRQSource,
+    ) -> impl std::future::Future<Output = Result<()>> + Send
     where
         Self: Sized + Send,
     {
-        let pdu = Pdu::AbortRQ {
-            source: AbortRQSource::ServiceProvider(
-                AbortRQServiceProviderReason::ReasonNotSpecified,
-            ),
-        };
         async move {
-            let out = self.send(&pdu).await;
-            self.close();
-            out
+            let pdu = Pdu::AbortRQ { source };
+            let local_max_pdu_length = self.local_max_pdu_length();
+            let peer_max_pdu_length = self.peer_max_pdu_length();
+            let write_timeout = self.write_timeout();
+            let close_assoc_timeout = self.finalization_timeout();
+            let (socket, read_buffer, write_buffer) = self.get_mut();
+            write_pdu_to_wire_async(
+                socket.as_mut(),
+                write_buffer,
+                &pdu,
+                peer_max_pdu_length,
+                write_timeout,
+            )
+            .await?;
+
+            sta13_async(
+                socket,
+                read_buffer,
+                write_buffer,
+                local_max_pdu_length,
+                peer_max_pdu_length,
+                close_assoc_timeout,
+            )
+            .await
         }
+    }
+
+    /// Send a user-initiated abort message
+    /// and shut down the TCP connection,
+    /// terminating the association.
+    /// This function may take up to a time defined by
+    /// `finalization_timeout()` to complete, depending
+    /// on how long the peer takes to close the socket.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// must be entered in state Sta6 (ready to send/receive data).
+    /// It will return in state Sta1 (no connection) regardless of
+    /// the return value, which serves to identify what happened.
+    fn abort(self) -> impl std::future::Future<Output = Result<()>> + Send
+    where
+        Self: Sized + Send,
+    {
+        self.abort_with_source(AbortRQSource::ServiceUser)
     }
 
     /// Iniate a graceful release of the association.
@@ -627,6 +672,14 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     fn close(&mut self) {
         drop(self.inner_stream().take());
     }
+
+    /// Returns the timeout that was set for sending data, or None if no
+    /// timeout was specified.
+    fn write_timeout(&self) -> Option<Duration>;
+
+    /// Returns the timeout that was set for receiving data, or None if no
+    /// timeout was specified.
+    fn read_timeout(&self) -> Option<Duration>;
 }
 
 // Helper function to perform an operation with timeout

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -436,31 +436,16 @@ pub trait SyncAssociation<S: Read + Write + CloseSocket + SetReadTimeout>: Assoc
     /// A DIMSE A-RELEASE transaction is initiated by this application entity,
     /// and the underlying socket is closed once settled.
     ///
+    /// This function may take an indefinite time to continue, if receive
+    /// timeout is not defined and the peer does not respond.
+    ///
     /// Note that as of version 0.9.1,
     /// implementers of this trait no longer call this method on [`Drop`],
     /// so remember to call `release` explicitly
     /// at the end of all DIMSE transactions.
-    fn release(mut self) -> Result<()>
+    fn release(self) -> Result<()>
     where
-        Self: Sized,
-    {
-        let pdu = Pdu::ReleaseRQ;
-        self.send(&pdu)?;
-        let pdu = self.receive()?;
-
-        match pdu {
-            Pdu::ReleaseRP => {}
-            pdu @ Pdu::AbortRQ { .. }
-            | pdu @ Pdu::AssociationAC { .. }
-            | pdu @ Pdu::AssociationRJ { .. }
-            | pdu @ Pdu::AssociationRQ { .. }
-            | pdu @ Pdu::PData { .. }
-            | pdu @ Pdu::ReleaseRQ => return UnexpectedPduSnafu { pdu }.fail(),
-            pdu @ Pdu::Unknown { .. } => return UnknownPduSnafu { pdu }.fail(),
-        }
-        self.close().context(CloseSnafu)?;
-        Ok(())
-    }
+        Self: Sized;
 
     /// Prepare a P-Data writer for sending
     /// one or more data item PDUs.
@@ -730,6 +715,142 @@ pub async fn read_pdu_from_wire_async<R: tokio::io::AsyncRead + Unpin>(
         ensure!(recv > 0, ConnectionClosedSnafu);
     };
     Ok(msg)
+}
+
+/// Helper function to implement the behaviour of the
+/// association release for both servers and clients.
+/// They differ only very slightly, so this factors
+/// both server and client into one function.
+///
+/// This is the sync version.
+pub(crate) fn release_impl<S>(mut assoc: impl SyncAssociation<S>, requestor: bool) -> Result<()>
+where
+    S: Read + Write + CloseSocket + SetReadTimeout,
+{
+    // Entered in Sta6
+    // Action AR-1: send A-RELEASE-RQ PDU; next state: Sta7
+    let max_pdu_peer = assoc.acceptor_max_pdu_length();
+    let max_pdu_local = assoc.requestor_max_pdu_length();
+    let finalization_timeout = assoc.finalization_timeout();
+    let (socket, read_buffer, write_buffer) = assoc.get_mut();
+    write_pdu_to_wire(socket, write_buffer, &Pdu::ReleaseRQ, max_pdu_peer)?;
+    // Sta7
+    loop {
+        // Note: without a socket timeout, this function may
+        // block indefinitely if the peer does not send anything valid.
+        let pdu = read_pdu_from_wire(socket, read_buffer, max_pdu_local, false)?;
+
+        match pdu {
+            Pdu::ReleaseRP => {
+                // Action AR-3 (indicate successful release) and close
+                // connection. Next state is Sta1 (return).
+                assoc.close().context(CloseSnafu)?;
+                return Ok(());
+            }
+            Pdu::PData { .. } => {
+                // Action AR-6, remain in Sta7
+                // We can't send a P-DATA indication because
+                // the API does not allow it at this point.
+                // So we just ignore the PDU.
+            }
+            Pdu::ReleaseRQ => {
+                // Release collision, action AR-8 (nothing in our case).
+                // Here's where client and server differ.
+                if requestor {
+                    // Next state for a client is Sta9.
+                    // We immediately issue an A-RELEASE response primitive,
+                    // so action is AR-9 (send A-RELEASE-RP) and next state
+                    // is Sta11.
+                    write_pdu_to_wire(socket, write_buffer, &Pdu::ReleaseRP, max_pdu_peer)?;
+                } else {
+                    // Next state for a server is Sta10. We start by receiving.
+                }
+                // Sta10 or Sta11
+                // We had sent an A-RELEASE-RQ which may be replied.
+                // We also may receive an A-ABORT which we need to
+                // process. Or the peer may receive our A-RELEASE-RP and
+                // close the socket. In any case, we need to receive
+                // once more.
+                let result = read_pdu_from_wire(socket, read_buffer, max_pdu_local, false);
+                let pdu = match result {
+                    Ok(pdu) => pdu,
+                    Err(Error::ConnectionClosed { .. }) => {
+                        // The peer closed the connection; action is AA-4
+                        // (issue A-ABORT indication). Next state is Sta1.
+                        return AbortedSnafu {}.fail();
+                    }
+                    Err(err) => {
+                        return Err(err);
+                    }
+                };
+                match pdu {
+                    Pdu::ReleaseRP => {
+                        // The peer responded to our release request
+                        if requestor {
+                            // Sta11: Action AR-3 (close socket and confirm
+                            // success). Next state is Sta1.
+                            assoc.close().context(CloseSnafu)?;
+                            return Ok(());
+                        }
+                        // We're a server, so we're still in Sta10. Action
+                        // is AR-10 (confirm release); next state is Sta12.
+                        // From Sta12, we immediately send a release response
+                        // primitive, which results in action AR-4 (send
+                        // A-RELEASE-RP) and state Sta13.
+                        write_pdu_to_wire(socket, write_buffer, &Pdu::ReleaseRP, max_pdu_peer)?;
+                        return sta13(
+                            socket,
+                            read_buffer,
+                            write_buffer,
+                            max_pdu_local,
+                            max_pdu_peer,
+                            finalization_timeout,
+                        );
+                    }
+                    Pdu::AbortRQ { .. } => {
+                        // Action AA-3, close socket and issue A-ABORT indication.
+                        assoc.close().context(CloseSnafu)?;
+                        return AbortedSnafu {}.fail();
+                    }
+                    Pdu::Unknown { .. } => {
+                        // Action AA-8: abort
+                        assoc.abort_with_source(AbortRQSource::ServiceProvider(
+                            AbortRQServiceProviderReason::UnrecognizedPdu,
+                        ))?;
+                        return UnknownPduSnafu { pdu }.fail();
+                    }
+                    _ => {
+                        // Action AA-8, abort
+                        assoc.abort_with_source(AbortRQSource::ServiceProvider(
+                            AbortRQServiceProviderReason::UnexpectedPdu,
+                        ))?;
+                        return UnexpectedPduSnafu { pdu }.fail();
+                    }
+                }
+            }
+            Pdu::AbortRQ { .. } => {
+                // Action AA-3, close socket and issue A-ABORT indication.
+                assoc.close().context(CloseSnafu)?;
+                return AbortedSnafu {}.fail();
+            }
+            pdu @ Pdu::AssociationAC { .. }
+            | pdu @ Pdu::AssociationRJ { .. }
+            | pdu @ Pdu::AssociationRQ { .. } => {
+                // Action AA-8, abort
+                assoc.abort_with_source(AbortRQSource::ServiceProvider(
+                    AbortRQServiceProviderReason::UnexpectedPdu,
+                ))?;
+                return UnexpectedPduSnafu { pdu }.fail();
+            }
+            pdu @ Pdu::Unknown { .. } => {
+                // Action AA-8, abort
+                assoc.abort_with_source(AbortRQSource::ServiceProvider(
+                    AbortRQServiceProviderReason::UnrecognizedPdu,
+                ))?;
+                return UnknownPduSnafu { pdu }.fail();
+            }
+        }
+    }
 }
 
 /// Helper function that handles state Sta13 of the Association

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -612,29 +612,9 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     /// do not try to release the association on [`Drop`],
     /// so remember to call `release` explicitly
     /// at the end of all DIMSE transactions.
-    fn release(mut self) -> impl std::future::Future<Output = Result<()>> + Send
+    fn release(self) -> impl std::future::Future<Output = Result<()>> + Send
     where
-        Self: Sized + Send,
-    {
-        async move {
-            let pdu = Pdu::ReleaseRQ;
-            self.send(&pdu).await?;
-            let pdu = self.receive().await?;
-
-            match pdu {
-                Pdu::ReleaseRP => {}
-                pdu @ Pdu::AbortRQ { .. }
-                | pdu @ Pdu::AssociationAC { .. }
-                | pdu @ Pdu::AssociationRJ { .. }
-                | pdu @ Pdu::AssociationRQ { .. }
-                | pdu @ Pdu::PData { .. }
-                | pdu @ Pdu::ReleaseRQ => return UnexpectedPduSnafu { pdu }.fail(),
-                pdu @ Pdu::Unknown { .. } => return UnknownPduSnafu { pdu }.fail(),
-            }
-            self.close();
-            Ok(())
-        }
-    }
+        Self: Sized + Send;
 
     /// Prepare a P-Data writer for sending
     /// one or more data item PDUs.
@@ -958,6 +938,186 @@ where
                 assoc.abort_with_source(AbortRQSource::ServiceProvider(
                     AbortRQServiceProviderReason::UnrecognizedPdu,
                 ))?;
+                return UnknownPduSnafu { pdu }.fail();
+            }
+        }
+    }
+}
+
+/// Helper function to implement the behaviour of the
+/// association release for both servers and clients.
+/// They differ only very slightly, so this factors
+/// both server and client into one function.
+///
+/// This is the async version.
+#[cfg(feature = "async")]
+pub(crate) async fn release_impl_async<S>(
+    mut assoc: impl AsyncAssociation<S> + Send,
+    requestor: bool,
+) -> Result<()>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
+{
+    // Entered in Sta6
+    // Action AR-1: send A-RELEASE-RQ PDU; next state: Sta7
+    let max_pdu_peer = assoc.acceptor_max_pdu_length();
+    let max_pdu_local = assoc.requestor_max_pdu_length();
+    let finalization_timeout = assoc.finalization_timeout();
+    let read_timeout = assoc.read_timeout();
+    let write_timeout = assoc.write_timeout();
+    let (socket, read_buffer, write_buffer) = assoc.get_mut();
+    write_pdu_to_wire_async(
+        socket.as_mut(),
+        write_buffer,
+        &Pdu::ReleaseRQ,
+        max_pdu_peer,
+        write_timeout,
+    )
+    .await?;
+    // Sta7
+    loop {
+        // Note: without a socket timeout, this function may
+        // block indefinitely if the peer does not send anything valid.
+        let pdu = timeout(
+            read_timeout,
+            read_pdu_from_wire_async(socket.as_mut(), read_buffer, max_pdu_local, false),
+        )
+        .await?;
+
+        match pdu {
+            Pdu::ReleaseRP => {
+                // Action AR-3 (indicate successful release) and close
+                // connection. Next state is Sta1 (return).
+                assoc.close();
+                return Ok(());
+            }
+            Pdu::PData { .. } => {
+                // Action AR-6, remain in Sta7
+                // We can't send a P-DATA indication because
+                // the API does not allow it at this point.
+                // So we just ignore the PDU.
+            }
+            Pdu::ReleaseRQ => {
+                // Release collision, action AR-8 (nothing in our case).
+                // Here's where client and server differ.
+                if requestor {
+                    // Next state for a client is Sta9.
+                    // We immediately issue an A-RELEASE response primitive,
+                    // so action is AR-9 (send A-RELEASE-RP) and next state
+                    // is Sta11.
+                    write_pdu_to_wire_async(
+                        socket.as_mut(),
+                        write_buffer,
+                        &Pdu::ReleaseRP,
+                        max_pdu_peer,
+                        write_timeout,
+                    )
+                    .await?;
+                } else {
+                    // Next state for a server is Sta10. We start by receiving.
+                }
+                // Sta10 or Sta11
+                // We had sent an A-RELEASE-RQ which may be replied.
+                // We also may receive an A-ABORT which we need to
+                // process. Or the peer may receive our A-RELEASE-RP and
+                // close the socket. In any case, we need to receive
+                // once more.
+                let result = timeout(
+                    read_timeout,
+                    read_pdu_from_wire_async(socket.as_mut(), read_buffer, max_pdu_local, false),
+                )
+                .await;
+                let pdu = match result {
+                    Ok(pdu) => pdu,
+                    Err(Error::ConnectionClosed { .. }) => {
+                        // The peer closed the connection; action is AA-4
+                        // (issue A-ABORT indication). Next state is Sta1.
+                        return AbortedSnafu {}.fail();
+                    }
+                    Err(err) => {
+                        return Err(err);
+                    }
+                };
+                match pdu {
+                    Pdu::ReleaseRP => {
+                        // The peer responded to our release request
+                        if requestor {
+                            // Sta11: Action AR-3 (close socket and confirm
+                            // success). Next state is Sta1.
+                            assoc.close();
+                            return Ok(());
+                        }
+                        // We're a server, so we're still in Sta10. Action
+                        // is AR-10 (confirm release); next state is Sta12.
+                        // From Sta12, we immediately send a release response
+                        // primitive, which results in action AR-4 (send
+                        // A-RELEASE-RP) and state Sta13.
+                        write_pdu_to_wire_async(
+                            socket.as_mut(),
+                            write_buffer,
+                            &Pdu::ReleaseRP,
+                            max_pdu_peer,
+                            write_timeout,
+                        )
+                        .await?;
+                        return sta13_async(
+                            socket,
+                            read_buffer,
+                            write_buffer,
+                            max_pdu_local,
+                            max_pdu_peer,
+                            finalization_timeout,
+                        )
+                        .await;
+                    }
+                    Pdu::AbortRQ { .. } => {
+                        // Action AA-3, close socket and issue A-ABORT indication.
+                        assoc.close();
+                        return AbortedSnafu {}.fail();
+                    }
+                    Pdu::Unknown { .. } => {
+                        // Action AA-8: abort
+                        assoc
+                            .abort_with_source(AbortRQSource::ServiceProvider(
+                                AbortRQServiceProviderReason::UnrecognizedPdu,
+                            ))
+                            .await?;
+                        return UnknownPduSnafu { pdu }.fail();
+                    }
+                    _ => {
+                        // Action AA-8, abort
+                        assoc
+                            .abort_with_source(AbortRQSource::ServiceProvider(
+                                AbortRQServiceProviderReason::UnexpectedPdu,
+                            ))
+                            .await?;
+                        return UnexpectedPduSnafu { pdu }.fail();
+                    }
+                }
+            }
+            Pdu::AbortRQ { .. } => {
+                // Action AA-3, close socket and issue A-ABORT indication.
+                assoc.close();
+                return AbortedSnafu {}.fail();
+            }
+            pdu @ Pdu::AssociationAC { .. }
+            | pdu @ Pdu::AssociationRJ { .. }
+            | pdu @ Pdu::AssociationRQ { .. } => {
+                // Action AA-8, abort
+                assoc
+                    .abort_with_source(AbortRQSource::ServiceProvider(
+                        AbortRQServiceProviderReason::UnexpectedPdu,
+                    ))
+                    .await?;
+                return UnexpectedPduSnafu { pdu }.fail();
+            }
+            pdu @ Pdu::Unknown { .. } => {
+                // Action AA-8, abort
+                assoc
+                    .abort_with_source(AbortRQSource::ServiceProvider(
+                        AbortRQServiceProviderReason::UnrecognizedPdu,
+                    ))
+                    .await?;
                 return UnknownPduSnafu { pdu }.fail();
             }
         }

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -956,3 +956,114 @@ pub(crate) fn sta13<S: Read + Write + CloseSocket + SetReadTimeout>(
         }
     }
 }
+
+/// Helper function that handles state Sta13 of the Association
+/// State Machine. It is entered when we're waiting for the peer
+/// to close the connection. In normal conditions, that happens
+/// when we have sent the last PDU of an association (normally
+/// A-ASSOCIATE-RJ, A-RELEASE-RP, or A-ABORT); then it's the
+/// peer's responsibility to close the socket, but just in
+/// case the peer does not respond, we close it after a timeout
+/// if that didn't happen. The response dictated by the ASM in
+/// case certain PDUs are received in the meantime is also
+/// handled here.
+///
+/// Returns with the connection closed either way. The return
+/// value is `Ok(())` if the peer closed the association
+/// before the timer expired; `Err(Error::Timeout)` if the
+/// peer didn't close the connection in time,
+/// `Err(Error::Aborted)` if the peer sent us an abort request
+/// while waiting, or other errors from intermediate functions.
+///
+/// For reference see [PS3.8 (2025d) section 9.2.3][1]
+/// [1] https://dicom.nema.org/medical/dicom/2025d/output/html/part08.html
+///
+/// This is the asynchronous version.
+#[cfg(feature = "async")]
+pub(crate) async fn _sta13_async<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>(
+    socket: &mut S,
+    read_buffer: &mut BytesMut,
+    write_buffer: &mut Vec<u8>,
+    local_max_pdu_length: u32,
+    peer_max_pdu_length: u32,
+    close_wait_timeout: Duration,
+) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let timer = tokio::time::sleep(close_wait_timeout);
+    tokio::pin!(timer);
+
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = &mut timer => {
+                // Action AA-2 (stop timer and close socket); next state is
+                // Sta1.
+                let _ = socket.shutdown().await;
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "Timed out while waiting for peer to close the connection",
+                ))
+                .context(TimeoutSnafu);
+            }
+
+            result = read_pdu_from_wire_async(socket, read_buffer, local_max_pdu_length, false) => {
+
+                match result {
+                    Err(Error::ConnectionClosed { .. }) => {
+                        // Peer did the correct thing and closed the socket;
+                        // action is AR-5 (nothing in our case) and next state
+                        // is Sta1.
+                        return Ok(());
+                    }
+
+                    Ok(Pdu::AbortRQ { .. }) => {
+                        // Peer requested an abort while we waited for peer to
+                        // close the connection, so we close it ourselves
+                        // instead and return Aborted (action AA-2, next state Sta1).
+                        socket.shutdown().await.context(CloseSnafu)?;
+                        return AbortedSnafu {}.fail();
+                    }
+
+                    Ok(Pdu::AssociationAC(_))
+                    | Ok(Pdu::AssociationRJ(_))
+                    | Ok(Pdu::PData { .. })
+                    | Ok(Pdu::ReleaseRQ)
+                    | Ok(Pdu::ReleaseRP) => {
+                        // Action AA-6: Ignore PDU; remain in Sta13 without
+                        // restarting the timer
+                    }
+
+                    Ok(pdu) => {
+                        // A-ASSOCIATE-RQ or invalid PDU
+                        // Action AA-7: Send A-ABORT PDU; remain in Sta13
+                        // without restarting the timer
+                        write_pdu_to_wire_async(
+                            socket,
+                            write_buffer,
+                            &Pdu::AbortRQ {
+                                source: AbortRQSource::ServiceProvider(if let Pdu::Unknown { .. } = pdu {
+                                    AbortRQServiceProviderReason::UnrecognizedPdu
+                                } else {
+                                    AbortRQServiceProviderReason::UnexpectedPdu
+                                }),
+                            },
+                            peer_max_pdu_length,
+                            Some(close_wait_timeout),
+                        ).await?;
+                    }
+
+                    Err(Error::Timeout { .. }) => {
+                        // Do nothing; we will catch it when the timer expires
+                    }
+
+                    Err(e) => {
+                        let _ = socket.shutdown().await.context(CloseSnafu);
+                        return Err(e);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -28,7 +28,7 @@ pub(crate) mod pdata;
 use std::{
     backtrace::Backtrace,
     io::{BufRead, BufReader, Cursor, Read, Write},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use bytes::{Buf, BytesMut};
@@ -258,6 +258,23 @@ impl CloseSocket for rustls::StreamOwned<rustls::ServerConnection, std::net::Tcp
             Err(e) if e.kind() == std::io::ErrorKind::NotConnected => Ok(()),
             Err(e) => Err(e),
         }
+    }
+}
+
+pub trait SetReadTimeout {
+    fn set_read_timeout(&self, dur: Option<Duration>) -> std::io::Result<()>;
+}
+
+impl SetReadTimeout for std::net::TcpStream {
+    fn set_read_timeout(&self, dur: Option<Duration>) -> std::io::Result<()> {
+        std::net::TcpStream::set_read_timeout(self, dur)
+    }
+}
+
+#[cfg(feature = "sync-tls")]
+impl<C> SetReadTimeout for rustls::StreamOwned<C, std::net::TcpStream> {
+    fn set_read_timeout(&self, dur: Option<Duration>) -> std::io::Result<()> {
+        self.sock.set_read_timeout(dur)
     }
 }
 
@@ -680,4 +697,108 @@ pub async fn read_pdu_from_wire_async<R: tokio::io::AsyncRead + Unpin>(
         ensure!(recv > 0, ConnectionClosedSnafu);
     };
     Ok(msg)
+}
+
+/// Helper function that handles state Sta13 of the Association
+/// State Machine. It is entered when we're waiting for the peer
+/// to close the connection. In normal conditions, that happens
+/// when we have sent the last PDU of an association (normally
+/// A-ASSOCIATE-RJ, A-RELEASE-RP, or A-ABORT); then it's the
+/// peer's responsibility to close the socket, but just in
+/// case the peer does not respond, we close it after a timeout
+/// if that didn't happen. The response dictated by the ASM in
+/// case certain PDUs are received in the meantime is also
+/// handled here.
+///
+/// Returns with the connection closed either way. THe return
+/// value is `Ok(())` if the peer closed the association
+/// before the timer expired; `Err(Error::Timeout)` if the
+/// peer didn't close the connection in time,
+/// `Err(Error::Aborted)` if the peer sent us an abort request
+/// while waiting, or other errors from intermediate functions.
+///
+/// For reference see [PS3.8 (2025d) section 9.2.3][1]
+/// [1] https://dicom.nema.org/medical/dicom/2025d/output/html/part08.html
+pub(crate) fn _sta13<S: Read + Write + CloseSocket + SetReadTimeout>(
+    socket: &mut S,
+    read_buffer: &mut BytesMut,
+    write_buffer: &mut Vec<u8>,
+    local_max_pdu_length: u32,
+    peer_max_pdu_length: u32,
+    close_wait_timeout: Duration,
+) -> Result<()> {
+    // Start ARTIM timer. All actions that lead to Sta13 (except some that
+    // happen in Sta13 itself) start it, or restart it if running.
+    let deadline = Instant::now() + close_wait_timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        // ARTIM expired?
+        if remaining.is_zero() {
+            // Action AA-2 (stop timer and close socket); next state is
+            // Sta1.
+            let _ = socket.close();
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "Timed out while waiting for peer to close the connection",
+            ))
+            .context(TimeoutSnafu);
+        }
+
+        socket
+            .set_read_timeout(Some(remaining))
+            .context(SetReadTimeoutSnafu)?;
+
+        match read_pdu_from_wire(socket, read_buffer, local_max_pdu_length, false) {
+            Err(Error::ConnectionClosed { .. }) => {
+                // Peer did the correct thing and closed the socket;
+                // action is AR-5 (nothing in our case) and next state
+                // is Sta1.
+                return Ok(());
+            }
+
+            Ok(Pdu::AbortRQ { .. }) => {
+                // Peer requested an abort while we waited for peer to
+                // close the connection, so we close it ourselves
+                // instead and return Aborted (action AA-2, next state Sta1).
+                socket.close().context(CloseSnafu)?;
+                return AbortedSnafu {}.fail();
+            }
+
+            Ok(Pdu::AssociationAC(_))
+            | Ok(Pdu::AssociationRJ(_))
+            | Ok(Pdu::PData { .. })
+            | Ok(Pdu::ReleaseRQ)
+            | Ok(Pdu::ReleaseRP) => {
+                // Action AA-6: Ignore PDU; remain in Sta13 without
+                // restarting the timer
+            }
+
+            Ok(pdu) => {
+                // A-ASSOCIATE-RQ or invalid PDU
+                // Action AA-7: Send A-ABORT PDU; remain in Sta13
+                // without restarting the timer
+                write_pdu_to_wire(
+                    socket,
+                    write_buffer,
+                    &Pdu::AbortRQ {
+                        source: AbortRQSource::ServiceProvider(if let Pdu::Unknown { .. } = pdu {
+                            AbortRQServiceProviderReason::UnrecognizedPdu
+                        } else {
+                            AbortRQServiceProviderReason::UnexpectedPdu
+                        }),
+                    },
+                    peer_max_pdu_length,
+                )?;
+            }
+
+            Err(Error::Timeout { .. }) => {
+                // Do nothing; we will catch it when the timer expires
+            }
+
+            Err(e) => {
+                let _ = socket.close().context(CloseSnafu);
+                return Err(e);
+            }
+        }
+    }
 }

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -478,6 +478,9 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
 {
     /// Obtain access to the inner stream
     /// connected to the association acceptor.
+    /// The value will be `None` when the stream was
+    /// deliberately closed by this side of the wire,
+    /// for example in response to an A-ABORT PDU.
     ///
     /// This can be used to send the PDU in semantic fragments of the message,
     /// thus using less memory.
@@ -485,10 +488,10 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     /// **Note:** reading and writing should be done with care
     /// to avoid inconsistencies in the association state.
     /// Do not call `send` and `receive` while not in a PDU boundary.
-    fn inner_stream(&mut self) -> &mut S;
+    fn inner_stream(&mut self) -> &mut Option<S>;
 
     /// Obtain mutable access to the inner stream, read and write buffers
-    fn get_mut(&mut self) -> (&mut S, &mut BytesMut, &mut Vec<u8>);
+    fn get_mut(&mut self) -> (&mut Option<S>, &mut BytesMut, &mut Vec<u8>);
 
     /// Send a PDU message to the other intervenient.
     fn send(&mut self, pdu: &Pdu) -> impl std::future::Future<Output = Result<()>> + Send
@@ -514,7 +517,7 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
         };
         async move {
             let out = self.send(&pdu).await;
-            let _ = self.close().await;
+            self.close();
             out
         }
     }
@@ -547,7 +550,7 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
                 | pdu @ Pdu::ReleaseRQ => return UnexpectedPduSnafu { pdu }.fail(),
                 pdu @ Pdu::Unknown { .. } => return UnknownPduSnafu { pdu }.fail(),
             }
-            self.close().await.context(CloseSnafu)?;
+            self.close();
             Ok(())
         }
     }
@@ -557,9 +560,15 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     ///
     /// Returns a writer which automatically
     /// splits the inner data into separate PDUs if necessary.
+    ///
+    /// Panics if used when the socket has been destroyed.
     fn send_pdata(&mut self, presentation_context_id: u8) -> AsyncPDataWriter<&mut S> {
         let max_pdu_length = self.peer_max_pdu_length();
-        AsyncPDataWriter::new(self.inner_stream(), presentation_context_id, max_pdu_length)
+        AsyncPDataWriter::new(
+            self.inner_stream().as_mut().expect("Stream was destroyed"),
+            presentation_context_id,
+            max_pdu_length,
+        )
     }
 
     /// Prepare a P-Data reader for receiving
@@ -567,15 +576,21 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     ///
     /// Returns a reader which automatically
     /// receives more data PDUs once the bytes collected are consumed.
+    ///
+    /// Panics if used when the socket has been destroyed.
     fn receive_pdata(&mut self) -> PDataReader<'_, &mut S> {
         let max_pdu_length = self.local_max_pdu_length();
         let (socket, read_buffer, _) = self.get_mut();
-        PDataReader::new(socket, max_pdu_length, read_buffer)
+        PDataReader::new(
+            socket.as_mut().expect("Stream was destroyed"),
+            max_pdu_length,
+            read_buffer,
+        )
     }
 
-    fn close(&mut self) -> impl std::future::Future<Output = std::io::Result<()>> + Send
-    where
-        Self: Send;
+    fn close(&mut self) {
+        drop(self.inner_stream().take());
+    }
 }
 
 // Helper function to perform an operation with timeout
@@ -664,7 +679,7 @@ where
 /// Helper function to send a PDU to an async writer
 #[cfg(feature = "async")]
 pub async fn write_pdu_to_wire_async<W: tokio::io::AsyncWrite + Unpin>(
-    writer: &mut W,
+    writer: Option<&mut W>,
     write_buffer: &mut Vec<u8>,
     msg: &Pdu,
     max_pdu_length: u32,
@@ -672,6 +687,9 @@ pub async fn write_pdu_to_wire_async<W: tokio::io::AsyncWrite + Unpin>(
 ) -> Result<()> {
     use tokio::io::AsyncWriteExt;
 
+    let Some(writer) = writer else {
+        return ConnectionClosedSnafu.fail();
+    };
     write_buffer.clear();
     encode_pdu(write_buffer, msg, max_pdu_length + pdu::PDU_HEADER_SIZE)?;
     timeout(write_timeout, async {
@@ -687,13 +705,17 @@ pub async fn write_pdu_to_wire_async<W: tokio::io::AsyncWrite + Unpin>(
 /// to receive more PDUs from the same stream.
 #[cfg(feature = "async")]
 pub async fn read_pdu_from_wire_async<R: tokio::io::AsyncRead + Unpin>(
-    reader: &mut R,
+    reader: Option<&mut R>,
     read_buffer: &mut BytesMut,
     max_pdu_length: u32,
     strict: bool,
 ) -> Result<Pdu> {
     use tokio::io::AsyncReadExt;
     // receive response
+
+    let Some(reader) = reader else {
+        return ConnectionClosedSnafu.fail();
+    };
 
     let msg = loop {
         let mut buf = Cursor::new(&read_buffer[..]);
@@ -981,15 +1003,13 @@ pub(crate) fn sta13<S: Read + Write + CloseSocket + SetReadTimeout>(
 /// This is the asynchronous version.
 #[cfg(feature = "async")]
 pub(crate) async fn _sta13_async<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>(
-    socket: &mut S,
+    socket: &mut Option<S>,
     read_buffer: &mut BytesMut,
     write_buffer: &mut Vec<u8>,
     local_max_pdu_length: u32,
     peer_max_pdu_length: u32,
     close_wait_timeout: Duration,
 ) -> Result<()> {
-    use tokio::io::AsyncWriteExt;
-
     let timer = tokio::time::sleep(close_wait_timeout);
     tokio::pin!(timer);
 
@@ -1000,7 +1020,7 @@ pub(crate) async fn _sta13_async<S: tokio::io::AsyncRead + tokio::io::AsyncWrite
             _ = &mut timer => {
                 // Action AA-2 (stop timer and close socket); next state is
                 // Sta1.
-                let _ = socket.shutdown().await;
+                drop(socket.take());
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::TimedOut,
                     "Timed out while waiting for peer to close the connection",
@@ -1008,7 +1028,7 @@ pub(crate) async fn _sta13_async<S: tokio::io::AsyncRead + tokio::io::AsyncWrite
                 .context(TimeoutSnafu);
             }
 
-            result = read_pdu_from_wire_async(socket, read_buffer, local_max_pdu_length, false) => {
+            result = read_pdu_from_wire_async(socket.as_mut(), read_buffer, local_max_pdu_length, false) => {
 
                 match result {
                     Err(Error::ConnectionClosed { .. }) => {
@@ -1022,7 +1042,7 @@ pub(crate) async fn _sta13_async<S: tokio::io::AsyncRead + tokio::io::AsyncWrite
                         // Peer requested an abort while we waited for peer to
                         // close the connection, so we close it ourselves
                         // instead and return Aborted (action AA-2, next state Sta1).
-                        socket.shutdown().await.context(CloseSnafu)?;
+                        drop(socket.take());
                         return AbortedSnafu {}.fail();
                     }
 
@@ -1040,7 +1060,7 @@ pub(crate) async fn _sta13_async<S: tokio::io::AsyncRead + tokio::io::AsyncWrite
                         // Action AA-7: Send A-ABORT PDU; remain in Sta13
                         // without restarting the timer
                         write_pdu_to_wire_async(
-                            socket,
+                            socket.as_mut(),
                             write_buffer,
                             &Pdu::AbortRQ {
                                 source: AbortRQSource::ServiceProvider(if let Pdu::Unknown { .. } = pdu {
@@ -1059,7 +1079,7 @@ pub(crate) async fn _sta13_async<S: tokio::io::AsyncRead + tokio::io::AsyncWrite
                     }
 
                     Err(e) => {
-                        let _ = socket.shutdown().await.context(CloseSnafu);
+                        drop(socket.take());
                         return Err(e);
                     }
                 }

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -27,7 +27,7 @@ pub(crate) mod pdata;
 
 use std::{
     backtrace::Backtrace,
-    io::{BufRead, BufReader, Cursor, Read},
+    io::{BufRead, BufReader, Cursor, Read, Write},
     time::Duration,
 };
 
@@ -343,7 +343,7 @@ pub trait Association {
 }
 
 /// Trait that represents methods that can be made on a synchronous association.
-pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>: Association {
+pub trait SyncAssociation<S: Read + Write + CloseSocket>: Association {
     /// Obtain access to the inner stream
     /// connected to the association acceptor.
     ///
@@ -355,8 +355,8 @@ pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>: Asso
     /// Do not call `send` and `receive` while not in a PDU boundary.
     fn inner_stream(&mut self) -> &mut S;
 
-    /// Obtain mutable access to the inner stream and read buffer
-    fn get_mut(&mut self) -> (&mut S, &mut BytesMut);
+    /// Obtain mutable access to the inner stream, read and write buffers
+    fn get_mut(&mut self) -> (&mut S, &mut BytesMut, &mut Vec<u8>);
 
     /// Send a PDU message to the other intervenient.
     fn send(&mut self, pdu: &Pdu) -> Result<()>;
@@ -429,7 +429,7 @@ pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>: Asso
     /// receives more data PDUs once the bytes collected are consumed.
     fn receive_pdata(&mut self) -> PDataReader<'_, &mut S> {
         let max_pdu_length = self.local_max_pdu_length();
-        let (socket, read_buffer) = self.get_mut();
+        let (socket, read_buffer, _) = self.get_mut();
         PDataReader::new(socket, max_pdu_length, read_buffer)
     }
 
@@ -452,8 +452,8 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     /// Do not call `send` and `receive` while not in a PDU boundary.
     fn inner_stream(&mut self) -> &mut S;
 
-    /// Obtain mutable access to the inner stream and read buffer
-    fn get_mut(&mut self) -> (&mut S, &mut BytesMut);
+    /// Obtain mutable access to the inner stream, read and write buffers
+    fn get_mut(&mut self) -> (&mut S, &mut BytesMut, &mut Vec<u8>);
 
     /// Send a PDU message to the other intervenient.
     fn send(&mut self, pdu: &Pdu) -> impl std::future::Future<Output = Result<()>> + Send
@@ -534,7 +534,7 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     /// receives more data PDUs once the bytes collected are consumed.
     fn receive_pdata(&mut self) -> PDataReader<'_, &mut S> {
         let max_pdu_length = self.local_max_pdu_length();
-        let (socket, read_buffer) = self.get_mut();
+        let (socket, read_buffer, _) = self.get_mut();
         PDataReader::new(socket, max_pdu_length, read_buffer)
     }
 
@@ -569,6 +569,20 @@ pub(crate) fn encode_pdu(buffer: &mut Vec<u8>, pdu: &Pdu, peer_max_pdu_length: u
         .fail();
     }
     Ok(())
+}
+
+/// Helper function to send a PDU to a writer
+pub fn write_pdu_to_wire<W: Write>(
+    writer: &mut W,
+    write_buffer: &mut Vec<u8>,
+    msg: &Pdu,
+    max_pdu_length: u32,
+) -> Result<()> {
+    write_buffer.clear();
+    encode_pdu(write_buffer, msg, max_pdu_length + pdu::PDU_HEADER_SIZE)?;
+    writer
+        .write_all(write_buffer)
+        .context(crate::association::WireSendSnafu)
 }
 
 /// Helper function to get a PDU from a reader.
@@ -610,6 +624,25 @@ where
         ensure!(bytes_read != 0, ConnectionClosedSnafu);
     };
     Ok(msg)
+}
+
+/// Helper function to send a PDU to an async writer
+#[cfg(feature = "async")]
+pub async fn write_pdu_to_wire_async<W: tokio::io::AsyncWrite + Unpin>(
+    writer: &mut W,
+    write_buffer: &mut Vec<u8>,
+    msg: &Pdu,
+    max_pdu_length: u32,
+    write_timeout: Option<Duration>,
+) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    write_buffer.clear();
+    encode_pdu(write_buffer, msg, max_pdu_length + pdu::PDU_HEADER_SIZE)?;
+    timeout(write_timeout, async {
+        writer.write_all(write_buffer).await.context(WireSendSnafu)
+    })
+    .await
 }
 
 /// Helper function to get a PDU from an async reader.

--- a/ul/src/association/pdata.rs
+++ b/ul/src/association/pdata.rs
@@ -758,6 +758,8 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[cfg(feature = "async")]
+    use crate::association::AsyncAssociation;
+    #[cfg(feature = "async")]
     use crate::association::pdata::non_blocking::AsyncPDataWriter;
 
     static IMPLICIT_VR_LE: &str = "1.2.840.10008.1.2";

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -1917,6 +1917,10 @@ where
         .await
     }
 
+    async fn release(self) -> Result<()> {
+        super::release_impl_async(self, false).await
+    }
+
     fn write_timeout(&self) -> Option<Duration> {
         self.write_timeout
     }

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -1377,6 +1377,10 @@ where
         )
     }
 
+    fn release(self) -> Result<()> {
+        super::release_impl(self, false)
+    }
+
     fn close(&mut self) -> std::io::Result<()> {
         self.socket.close()
     }

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -1538,7 +1538,7 @@ where
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
             let pdu = match super::read_pdu_from_wire_async(
-                &mut socket,
+                Some(&mut socket),
                 &mut read_buffer,
                 self.max_pdu_length,
                 self.strict,
@@ -1588,7 +1588,7 @@ where
                         presentation_contexts,
                         requestor_max_pdu_length: peer_max_pdu_length,
                         acceptor_max_pdu_length: self.max_pdu_length,
-                        socket,
+                        socket: Some(socket),
                         client_ae_title: peer_ae_title,
                         write_buffer,
                         strict: self.strict,
@@ -1612,7 +1612,7 @@ where
                     } else {
                         // No PDU to send means it's our turn to close the socket
                         // (this is most likely in response to an A-ABORT request)
-                        let _ = socket.shutdown().await;
+                        drop(socket);
                     }
                     Err(err)
                 }
@@ -1644,7 +1644,7 @@ where
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
             let pdu = super::read_pdu_from_wire_async(
-                &mut socket,
+                Some(&mut socket),
                 &mut read_buffer,
                 self.max_pdu_length,
                 self.strict,
@@ -1673,7 +1673,7 @@ where
                         presentation_contexts,
                         requestor_max_pdu_length: peer_max_pdu_length,
                         acceptor_max_pdu_length: self.max_pdu_length,
-                        socket,
+                        socket: Some(socket),
                         client_ae_title: peer_ae_title,
                         write_buffer,
                         strict: self.strict,
@@ -1697,7 +1697,7 @@ where
                     } else {
                         // No PDU to send means it's our turn to close the socket
                         // (this is most likely in response to an A-ABORT request)
-                        let _ = socket.shutdown().await;
+                        drop(socket);
                     }
                     Err(err)
                 }
@@ -1727,8 +1727,9 @@ pub struct AsyncServerAssociation<S> {
     requestor_max_pdu_length: u32,
     /// The maximum PDU length that this application entity is expecting to receive
     acceptor_max_pdu_length: u32,
-    /// The TCP stream to the other DICOM node
-    socket: S,
+    /// The TCP stream to the other DICOM node, or `None` if the socket was
+    /// closed by this application entity.
+    socket: Option<S>,
     /// The application entity title of the other DICOM node
     client_ae_title: String,
     /// The AE title the calling client used.
@@ -1818,11 +1819,11 @@ impl<S> AsyncAssociation<S> for AsyncServerAssociation<S>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
 {
-    fn inner_stream(&mut self) -> &mut S {
+    fn inner_stream(&mut self) -> &mut Option<S> {
         &mut self.socket
     }
 
-    fn get_mut(&mut self) -> (&mut S, &mut BytesMut, &mut Vec<u8>) {
+    fn get_mut(&mut self) -> (&mut Option<S>, &mut BytesMut, &mut Vec<u8>) {
         let Self {
             socket,
             read_buffer,
@@ -1837,14 +1838,15 @@ where
         let write_timeout = self.write_timeout;
         let max_pdu = self.requestor_max_pdu_length;
         let (socket, _, write_buffer) = self.get_mut();
-        super::write_pdu_to_wire_async(socket, write_buffer, msg, max_pdu, write_timeout)
+
+        super::write_pdu_to_wire_async(socket.as_mut(), write_buffer, msg, max_pdu, write_timeout)
     }
 
     /// Read a PDU message from the other intervenient.
     async fn receive(&mut self) -> Result<Pdu> {
         super::timeout(self.read_timeout, async {
             super::read_pdu_from_wire_async(
-                &mut self.socket,
+                self.socket.as_mut(),
                 &mut self.read_buffer,
                 self.acceptor_max_pdu_length,
                 self.strict,
@@ -1852,11 +1854,6 @@ where
             .await
         })
         .await
-    }
-
-    async fn close(&mut self) -> std::io::Result<()> {
-        use tokio::io::AsyncWriteExt;
-        self.socket.shutdown().await
     }
 }
 
@@ -1956,7 +1953,7 @@ mod tests {
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
             let pdu = read_pdu_from_wire_async(
-                &mut socket,
+                Some(&mut socket),
                 &mut read_buffer,
                 self.max_pdu_length,
                 self.strict,
@@ -1988,7 +1985,7 @@ mod tests {
                 presentation_contexts,
                 requestor_max_pdu_length: peer_max_pdu_length,
                 acceptor_max_pdu_length: self.max_pdu_length,
-                socket,
+                socket: Some(socket),
                 client_ae_title: peer_ae_title,
                 write_buffer: buffer,
                 strict: self.strict,
@@ -2061,7 +2058,7 @@ mod tests {
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
             let msg = read_pdu_from_wire_async(
-                &mut socket,
+                Some(&mut socket),
                 &mut read_buffer,
                 self.max_pdu_length,
                 self.strict,
@@ -2091,7 +2088,7 @@ mod tests {
                 presentation_contexts,
                 requestor_max_pdu_length: peer_max_pdu_length,
                 acceptor_max_pdu_length: self.max_pdu_length,
-                socket,
+                socket: Some(socket),
                 client_ae_title: peer_ae_title,
                 write_buffer,
                 strict: self.strict,

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -1916,6 +1916,14 @@ where
         })
         .await
     }
+
+    fn write_timeout(&self) -> Option<Duration> {
+        self.write_timeout
+    }
+
+    fn read_timeout(&self) -> Option<Duration> {
+        self.read_timeout
+    }
 }
 
 #[cfg(test)]

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{io::Write, net::TcpStream};
 
-use crate::association::private::SyncAssociationSealed;
 use crate::association::{
     AbortedSnafu, Association, CloseSocket, MissingAbstractSyntaxSnafu, RejectedSnafu,
     SendPduSnafu, SocketOptions, SyncAssociation, UnexpectedPduSnafu, UnknownPduSnafu,
@@ -1349,10 +1348,23 @@ where
     }
 }
 
-impl<S> SyncAssociationSealed<S> for ServerAssociation<S>
+impl<S> SyncAssociation<S> for ServerAssociation<S>
 where
     S: std::io::Read + std::io::Write + CloseSocket,
 {
+    fn inner_stream(&mut self) -> &mut S {
+        &mut self.socket
+    }
+
+    fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
+        let Self {
+            socket,
+            read_buffer,
+            ..
+        } = self;
+        (socket, read_buffer)
+    }
+
     fn send(&mut self, pdu: &Pdu) -> Result<()> {
         self.write_buffer.clear();
         encode_pdu(
@@ -1376,24 +1388,6 @@ where
 
     fn close(&mut self) -> std::io::Result<()> {
         self.socket.close()
-    }
-}
-
-impl<S> SyncAssociation<S> for ServerAssociation<S>
-where
-    S: std::io::Read + std::io::Write + CloseSocket,
-{
-    fn inner_stream(&mut self) -> &mut S {
-        &mut self.socket
-    }
-
-    fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
-        let Self {
-            socket,
-            read_buffer,
-            ..
-        } = self;
-        (socket, read_buffer)
     }
 }
 
@@ -1737,10 +1731,23 @@ where
 }
 
 #[cfg(feature = "async")]
-impl<S> crate::association::private::AsyncAssociationSealed<S> for AsyncServerAssociation<S>
+impl<S> crate::association::AsyncAssociation<S> for AsyncServerAssociation<S>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
 {
+    fn inner_stream(&mut self) -> &mut S {
+        &mut self.socket
+    }
+
+    fn get_mut(&mut self) -> (&mut S, &mut bytes::BytesMut) {
+        let Self {
+            socket,
+            read_buffer,
+            ..
+        } = self;
+        (socket, read_buffer)
+    }
+
     /// Send a PDU message to the other intervenient.
     async fn send(&mut self, msg: &Pdu) -> Result<()> {
         use tokio::io::AsyncWriteExt;
@@ -1776,25 +1783,6 @@ where
     async fn close(&mut self) -> std::io::Result<()> {
         use tokio::io::AsyncWriteExt;
         self.socket.shutdown().await
-    }
-}
-
-#[cfg(feature = "async")]
-impl<S> crate::association::AsyncAssociation<S> for AsyncServerAssociation<S>
-where
-    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
-{
-    fn inner_stream(&mut self) -> &mut S {
-        &mut self.socket
-    }
-
-    fn get_mut(&mut self) -> (&mut S, &mut bytes::BytesMut) {
-        let Self {
-            socket,
-            read_buffer,
-            ..
-        } = self;
-        (socket, read_buffer)
     }
 }
 

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -1523,92 +1523,121 @@ where
             MissingAbstractSyntaxSnafu
         );
         let read_timeout = self.socket_options.read_timeout;
-        let task = async {
-            let mut read_buffer = BytesMut::with_capacity(
-                (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
-            );
-            let pdu = match super::read_pdu_from_wire_async(
+        let write_timeout = self.socket_options.write_timeout;
+        let mut read_buffer = BytesMut::with_capacity(
+            (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
+        );
+        let pdu = match super::timeout(
+            read_timeout,
+            super::read_pdu_from_wire_async(
                 Some(&mut socket),
                 &mut read_buffer,
                 self.max_pdu_length,
                 self.strict,
-            )
-            .await
-            {
-                Ok(pdu) => pdu,
-                Err(e) => {
-                    // Attempt to check if the failure was because the client sent a TLS stream
-                    #[cfg(feature = "async-tls")]
-                    {
-                        // `read_pdu_from_wire_async` pulls bytes off the socket
-                        // and accumulates into `read_buffer`, so we need to use that in
-                        // `accept_tls_async`
+            ),
+        )
+        .await
+        {
+            Ok(msg) => msg,
+            Err(err) => {
+                // This covers "ARTIM timer expired" (socket read timeout)
+                // and "Transport connection closed".
+                // Action AA-2 or AA-5: Close connection or do nothing,
+                // then return to Sta1
+                // (the connection may already be closed but we close it
+                // nevertheless).
+                drop(socket);
+                #[cfg(feature = "async-tls")]
+                {
+                    // `read_pdu_from_wire_async` pulls bytes off the socket
+                    // and accumulates into `read_buffer`, so we need to use that in
+                    // `accept_tls_async`
 
-                        // NOTE: `accept_tls_async` may attempt to write to the cursor if
-                        // an `AcceptedAlert` is generated, this should be fine since the
-                        // client does not need to receive that alert message
-                        let cursor = std::io::Cursor::new(read_buffer.to_vec());
-                        if accept_tls_async(cursor).await.is_ok() {
-                            return super::TlsNotSupportedSnafu.fail();
-                        }
+                    // NOTE: `accept_tls_async` may attempt to write to the cursor if
+                    // an `AcceptedAlert` is generated, this should be fine since the
+                    // client does not need to receive that alert message
+                    let cursor = std::io::Cursor::new(read_buffer.to_vec());
+                    if accept_tls_async(cursor).await.is_ok() {
+                        return super::TlsNotSupportedSnafu.fail();
                     }
-                    return Err(e);
                 }
-            };
-
-            let mut write_buffer: Vec<u8> =
-                Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
-            match self.process_a_association_rq(pdu) {
-                Ok((
-                    pdu,
-                    NegotiatedOptions {
-                        user_variables,
-                        presentation_contexts,
-                        peer_max_pdu_length,
-                        peer_ae_title,
-                    },
-                    called_ae_title,
-                )) => {
-                    write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                    socket
-                        .write_all(&write_buffer)
-                        .await
-                        .context(WireSendSnafu)?;
-                    Ok(AsyncServerAssociation {
-                        presentation_contexts,
-                        requestor_max_pdu_length: peer_max_pdu_length,
-                        acceptor_max_pdu_length: self.max_pdu_length,
-                        socket: Some(socket),
-                        client_ae_title: peer_ae_title,
-                        write_buffer,
-                        strict: self.strict,
-                        read_buffer,
-                        read_timeout: self.socket_options.read_timeout,
-                        write_timeout: self.socket_options.write_timeout,
-                        finalization_timeout: self.finalization_timeout,
-                        user_variables,
-                        called_ae_title,
-                    })
-                }
-                Err((pdu, err)) => {
-                    if let Some(pdu) = pdu {
-                        // Send the rejection/abort PDU and switch to Sta13
-                        write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                        socket
-                            .write_all(&write_buffer)
-                            .await
-                            .context(WireSendSnafu)?;
-                        // TODO: Async Sta13 implementation
-                    } else {
-                        // No PDU to send means it's our turn to close the socket
-                        // (this is most likely in response to an A-ABORT request)
-                        drop(socket);
-                    }
-                    Err(err)
-                }
+                return Err(err);
             }
         };
-        super::timeout(read_timeout, task).await
+
+        let mut write_buffer: Vec<u8> =
+            Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
+        match self.process_a_association_rq(pdu) {
+            Ok((
+                pdu,
+                NegotiatedOptions {
+                    user_variables,
+                    presentation_contexts,
+                    peer_max_pdu_length,
+                    peer_ae_title,
+                },
+                called_ae_title,
+            )) => {
+                // A-ASSOCIATE-RQ received, association accepted.
+                // The function `process_a_association_rq` has
+                // transitioned to state Sta3 and sends us (via
+                // returning Ok(_)) an "A-ASSOCIATE response
+                // primitive (accept)".
+                // Action AE-7: send A-ASSOCIATE-AC PDU. New state
+                // is Sta6 (association established, ready to send
+                // data).
+                write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
+                super::timeout(write_timeout, async {
+                    socket.write_all(&write_buffer).await.context(WireSendSnafu)
+                })
+                .await?;
+
+                Ok(AsyncServerAssociation {
+                    presentation_contexts,
+                    requestor_max_pdu_length: peer_max_pdu_length,
+                    acceptor_max_pdu_length: self.max_pdu_length,
+                    socket: Some(socket),
+                    client_ae_title: peer_ae_title,
+                    write_buffer,
+                    strict: self.strict,
+                    read_buffer,
+                    read_timeout: self.socket_options.read_timeout,
+                    write_timeout: self.socket_options.write_timeout,
+                    finalization_timeout: self.finalization_timeout,
+                    user_variables,
+                    called_ae_title,
+                })
+            }
+            Err((pdu, err)) => {
+                if let Some(pdu) = pdu {
+                    // Either the association was rejected and the PDU
+                    // is A-ASSOCIATE-RJ (action AE-6, send A-ASSOCIATE-RJ)
+                    // or an unexpected/unknown PDU was received (action
+                    // AA-1: send A-ABORT). Either way, new state is Sta13.
+                    // Send the rejection/abort PDU and switch to Sta13
+                    write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
+                    super::timeout(write_timeout, async {
+                        socket.write_all(&write_buffer).await.context(WireSendSnafu)
+                    })
+                    .await?;
+                    let mut some_socket = Some(socket);
+                    super::sta13_async(
+                        &mut some_socket,
+                        &mut read_buffer,
+                        &mut write_buffer,
+                        self.max_pdu_length,
+                        DEFAULT_MAX_PDU,
+                        self.finalization_timeout,
+                    )
+                    .await?;
+                } else {
+                    // No PDU to send means it's our turn to close the socket
+                    // (action AA-2: close socket, or AA-5: do nothing).
+                    drop(socket);
+                }
+                Err(err)
+            }
+        }
     }
 
     /// Negotiate an association with the given TCP stream.
@@ -1635,71 +1664,107 @@ where
             .ok_or_else(|| crate::association::TlsConfigMissingSnafu {}.build())?;
         let mut socket = handshake_tls_async(socket, tls_config.clone()).await?;
         let read_timeout = self.socket_options.read_timeout;
-        let task = async {
-            let mut read_buffer = BytesMut::with_capacity(
-                (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
-            );
-            let pdu = super::read_pdu_from_wire_async(
+        let write_timeout = self.socket_options.write_timeout;
+
+        let mut read_buffer = BytesMut::with_capacity(
+            (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
+        );
+        let pdu = match super::timeout(
+            read_timeout,
+            super::read_pdu_from_wire_async(
                 Some(&mut socket),
                 &mut read_buffer,
                 self.max_pdu_length,
                 self.strict,
-            )
-            .await?;
-
-            let mut write_buffer: Vec<u8> =
-                Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
-            match self.process_a_association_rq(pdu) {
-                Ok((
-                    pdu,
-                    NegotiatedOptions {
-                        user_variables,
-                        presentation_contexts,
-                        peer_max_pdu_length,
-                        peer_ae_title,
-                    },
-                    called_ae_title,
-                )) => {
-                    write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                    socket
-                        .write_all(&write_buffer)
-                        .await
-                        .context(WireSendSnafu)?;
-                    Ok(AsyncServerAssociation {
-                        presentation_contexts,
-                        requestor_max_pdu_length: peer_max_pdu_length,
-                        acceptor_max_pdu_length: self.max_pdu_length,
-                        socket: Some(socket),
-                        client_ae_title: peer_ae_title,
-                        write_buffer,
-                        strict: self.strict,
-                        read_buffer,
-                        read_timeout: self.socket_options.read_timeout,
-                        write_timeout: self.socket_options.write_timeout,
-                        finalization_timeout: self.finalization_timeout,
-                        user_variables,
-                        called_ae_title,
-                    })
-                }
-                Err((pdu, err)) => {
-                    if let Some(pdu) = pdu {
-                        // Send the rejection/abort PDU and switch to Sta13
-                        write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                        socket
-                            .write_all(&write_buffer)
-                            .await
-                            .context(WireSendSnafu)?;
-                        // TODO: Async Sta13 implementation
-                    } else {
-                        // No PDU to send means it's our turn to close the socket
-                        // (this is most likely in response to an A-ABORT request)
-                        drop(socket);
-                    }
-                    Err(err)
-                }
+            ),
+        )
+        .await
+        {
+            Ok(msg) => msg,
+            Err(err) => {
+                // This covers "ARTIM timer expired" (socket read timeout)
+                // and "Transport connection closed".
+                // Action AA-2 or AA-5: Close connection or do nothing,
+                // then return to Sta1
+                // (the connection may already be closed but we close it
+                // nevertheless).
+                drop(socket);
+                return Err(err);
             }
         };
-        super::timeout(read_timeout, task).await
+
+        let mut write_buffer: Vec<u8> =
+            Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
+        match self.process_a_association_rq(pdu) {
+            Ok((
+                pdu,
+                NegotiatedOptions {
+                    user_variables,
+                    presentation_contexts,
+                    peer_max_pdu_length,
+                    peer_ae_title,
+                },
+                called_ae_title,
+            )) => {
+                // A-ASSOCIATE-RQ received, association accepted.
+                // The function `process_a_association_rq` has
+                // transitioned to state Sta3 and sends us (via
+                // returning Ok(_)) an "A-ASSOCIATE response
+                // primitive (accept)".
+                // Action AE-7: send A-ASSOCIATE-AC PDU. New state
+                // is Sta6 (association established, ready to send
+                // data).
+                write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
+                super::timeout(write_timeout, async {
+                    socket.write_all(&write_buffer).await.context(WireSendSnafu)
+                })
+                .await?;
+                Ok(AsyncServerAssociation {
+                    presentation_contexts,
+                    requestor_max_pdu_length: peer_max_pdu_length,
+                    acceptor_max_pdu_length: self.max_pdu_length,
+                    socket: Some(socket),
+                    client_ae_title: peer_ae_title,
+                    write_buffer,
+                    strict: self.strict,
+                    read_buffer,
+                    read_timeout: self.socket_options.read_timeout,
+                    write_timeout: self.socket_options.write_timeout,
+                    finalization_timeout: self.finalization_timeout,
+                    user_variables,
+                    called_ae_title,
+                })
+            }
+            Err((pdu, err)) => {
+                if let Some(pdu) = pdu {
+                    // Either the association was rejected and the PDU
+                    // is A-ASSOCIATE-RJ (action AE-6, send A-ASSOCIATE-RJ)
+                    // or an unexpected/unknown PDU was received (action
+                    // AA-1: send A-ABORT). Either way, new state is Sta13.
+                    // Send the rejection/abort PDU and switch to Sta13
+                    write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
+                    super::timeout(write_timeout, async {
+                        socket.write_all(&write_buffer).await.context(WireSendSnafu)
+                    })
+                    .await?;
+                    let mut some_socket = Some(socket);
+                    super::sta13_async(
+                        &mut some_socket,
+                        &mut read_buffer,
+                        &mut write_buffer,
+                        self.max_pdu_length,
+                        DEFAULT_MAX_PDU,
+                        self.finalization_timeout,
+                    )
+                    .await?;
+                } else {
+                    // No PDU to send means it's our turn to close the socket
+                    // (action AA-2: close socket, or AA-5: do nothing).
+                    drop(socket);
+                }
+                Err(err)
+            }
+        }
     }
 }
 

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -1313,57 +1313,6 @@ impl<S> ServerAssociation<S>
 where
     S: std::io::Read + std::io::Write + CloseSocket + SetReadTimeout,
 {
-    /// Send a PDU message to the other intervenient.
-    pub fn send(&mut self, msg: &Pdu) -> Result<()> {
-        SyncAssociation::send(self, msg)
-    }
-
-    /// Read a PDU message from the other intervenient.
-    pub fn receive(&mut self) -> Result<Pdu> {
-        SyncAssociation::receive(self)
-    }
-
-    /// Send a provider initiated abort message
-    /// and shut down the TCP connection,
-    /// terminating the association.
-    pub fn abort(self) -> Result<()> {
-        SyncAssociation::abort(self)
-    }
-
-    /// Prepare a P-Data writer for sending
-    /// one or more data item PDUs.
-    ///
-    /// Returns a writer which automatically
-    /// splits the inner data into separate PDUs if necessary.
-    pub fn send_pdata(
-        &mut self,
-        presentation_context_id: u8,
-    ) -> crate::association::pdata::PDataWriter<&mut S> {
-        SyncAssociation::send_pdata(self, presentation_context_id)
-    }
-
-    /// Prepare a P-Data reader for receiving
-    /// one or more data item PDUs.
-    ///
-    /// Returns a reader which automatically
-    /// receives more data PDUs once the bytes collected are consumed.
-    pub fn receive_pdata(&mut self) -> crate::association::pdata::PDataReader<'_, &mut S> {
-        SyncAssociation::receive_pdata(self)
-    }
-
-    /// Obtain access to the inner stream
-    /// connected to the association acceptor.
-    ///
-    /// This can be used to send the PDU in semantic fragments of the message,
-    /// thus using less memory.
-    ///
-    /// **Note:** reading and writing should be done with care
-    /// to avoid inconsistencies in the association state.
-    /// Do not call `send` and `receive` while not in a PDU boundary.
-    pub fn inner_stream(&mut self) -> &mut S {
-        SyncAssociation::inner_stream(self)
-    }
-
     /// Obtain the application entity title called by the client.
     pub fn called_ae_title(&self) -> &str {
         &self.called_ae_title

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -14,7 +14,7 @@ use std::{io::Write, net::TcpStream};
 use crate::association::{
     AbortedSnafu, Association, CloseSocket, MissingAbstractSyntaxSnafu, RejectedSnafu,
     SendPduSnafu, SocketOptions, SyncAssociation, UnexpectedPduSnafu, UnknownPduSnafu,
-    WireSendSnafu, encode_pdu, read_pdu_from_wire,
+    WireSendSnafu,
 };
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
@@ -1017,7 +1017,7 @@ where
         let mut read_buffer = BytesMut::with_capacity(
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
-        let msg = read_pdu_from_wire(
+        let msg = super::read_pdu_from_wire(
             &mut socket,
             &mut read_buffer,
             self.max_pdu_length,
@@ -1100,7 +1100,7 @@ where
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
 
-        let msg = read_pdu_from_wire(
+        let msg = super::read_pdu_from_wire(
             &mut tls_stream,
             &mut read_buffer,
             self.max_pdu_length,
@@ -1323,29 +1323,24 @@ where
         &mut self.socket
     }
 
-    fn get_mut(&mut self) -> (&mut S, &mut BytesMut) {
+    fn get_mut(&mut self) -> (&mut S, &mut BytesMut, &mut Vec<u8>) {
         let Self {
             socket,
             read_buffer,
+            write_buffer,
             ..
         } = self;
-        (socket, read_buffer)
+        (socket, read_buffer, write_buffer)
     }
 
     fn send(&mut self, pdu: &Pdu) -> Result<()> {
-        self.write_buffer.clear();
-        encode_pdu(
-            &mut self.write_buffer,
-            pdu,
-            self.requestor_max_pdu_length + PDU_HEADER_SIZE,
-        )?;
-        self.socket
-            .write_all(&self.write_buffer)
-            .context(WireSendSnafu)
+        let max_pdu = self.requestor_max_pdu_length;
+        let (socket, _, write_buffer) = self.get_mut();
+        super::write_pdu_to_wire(socket, write_buffer, pdu, max_pdu)
     }
 
     fn receive(&mut self) -> Result<Pdu> {
-        read_pdu_from_wire(
+        super::read_pdu_from_wire(
             &mut self.socket,
             &mut self.read_buffer,
             self.acceptor_max_pdu_length,
@@ -1714,31 +1709,22 @@ where
         &mut self.socket
     }
 
-    fn get_mut(&mut self) -> (&mut S, &mut bytes::BytesMut) {
+    fn get_mut(&mut self) -> (&mut S, &mut BytesMut, &mut Vec<u8>) {
         let Self {
             socket,
             read_buffer,
+            write_buffer,
             ..
         } = self;
-        (socket, read_buffer)
+        (socket, read_buffer, write_buffer)
     }
 
     /// Send a PDU message to the other intervenient.
-    async fn send(&mut self, msg: &Pdu) -> Result<()> {
-        use tokio::io::AsyncWriteExt;
-        self.write_buffer.clear();
-        super::timeout(self.write_timeout, async {
-            encode_pdu(
-                &mut self.write_buffer,
-                msg,
-                self.requestor_max_pdu_length + PDU_HEADER_SIZE,
-            )?;
-            self.socket
-                .write_all(&self.write_buffer)
-                .await
-                .context(WireSendSnafu)
-        })
-        .await
+    fn send(&mut self, msg: &Pdu) -> impl std::future::Future<Output = Result<()>> + Send {
+        let write_timeout = self.write_timeout;
+        let max_pdu = self.requestor_max_pdu_length;
+        let (socket, _, write_buffer) = self.get_mut();
+        super::write_pdu_to_wire_async(socket, write_buffer, msg, max_pdu, write_timeout)
     }
 
     /// Read a PDU message from the other intervenient.
@@ -1764,6 +1750,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::association::read_pdu_from_wire;
+    #[cfg(feature = "async")]
+    use crate::association::read_pdu_from_wire_async;
 
     #[test]
     fn test_choose_supported() {
@@ -1848,8 +1837,6 @@ mod tests {
             extra_pdus: Vec<Pdu>,
         ) -> Result<AsyncServerAssociation<tokio::net::TcpStream>> {
             use tokio::io::AsyncWriteExt;
-
-            use crate::association::read_pdu_from_wire_async;
 
             let mut read_buffer = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
@@ -1953,8 +1940,6 @@ mod tests {
             mut socket: tokio::net::TcpStream,
         ) -> Result<AsyncServerAssociation<tokio::net::TcpStream>> {
             use tokio::io::AsyncWriteExt;
-
-            use crate::association::read_pdu_from_wire_async;
 
             let mut read_buffer = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -39,10 +39,6 @@ use super::{Error, Result, uid::trim_uid};
 #[cfg(feature = "async")]
 use crate::association::AsyncAssociation;
 
-// stray module from 0.9.0, remove in 0.10.0
-#[deprecated(since = "0.9.1")]
-pub mod non_blocking {}
-
 #[cfg(feature = "sync-tls")]
 pub type TlsStream = rustls::StreamOwned<rustls::ServerConnection, std::net::TcpStream>;
 #[cfg(feature = "async-tls")]
@@ -1211,40 +1207,6 @@ pub struct ServerAssociation<S> {
     user_variables: Vec<UserVariableItem>,
 }
 
-// compatibility filler, remove in 0.10.0
-impl<S> ServerAssociation<S> {
-    /// Obtain a view of the negotiated presentation contexts.
-    pub fn presentation_contexts(&self) -> &[PresentationContextNegotiated] {
-        &self.presentation_contexts
-    }
-
-    /// Retrieve the maximum PDU length
-    /// that the association acceptor is expecting to receive.
-    pub fn acceptor_max_pdu_length(&self) -> u32 {
-        self.acceptor_max_pdu_length
-    }
-
-    /// Retrieve the maximum PDU length
-    /// that the association requestor is expecting to receive.
-    pub fn requestor_max_pdu_length(&self) -> u32 {
-        self.requestor_max_pdu_length
-    }
-
-    /// Obtain the remote DICOM node's application entity title.
-    #[deprecated(
-        since = "0.9.1",
-        note = "Call `peer_ae_title` from trait `Association`"
-    )]
-    pub fn client_ae_title(&self) -> &str {
-        &self.client_ae_title
-    }
-
-    /// Obtain the application entity title called by the client.
-    pub fn called_ae_title(&self) -> &str {
-        &self.called_ae_title
-    }
-}
-
 impl<S> ServerAssociation<S>
 where
     S: std::io::Read + std::io::Write + CloseSocket,
@@ -1298,6 +1260,11 @@ where
     /// Do not call `send` and `receive` while not in a PDU boundary.
     pub fn inner_stream(&mut self) -> &mut S {
         SyncAssociation::inner_stream(self)
+    }
+
+    /// Obtain the application entity title called by the client.
+    pub fn called_ae_title(&self) -> &str {
+        &self.called_ae_title
     }
 }
 
@@ -1687,6 +1654,14 @@ pub struct AsyncServerAssociation<S> {
 }
 
 #[cfg(feature = "async")]
+impl<S> AsyncServerAssociation<S> {
+    /// Obtain the application entity title called by the client.
+    pub fn called_ae_title(&self) -> &str {
+        &self.called_ae_title
+    }
+}
+
+#[cfg(feature = "async")]
 impl<S> Association for AsyncServerAssociation<S>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
@@ -1731,7 +1706,7 @@ where
 }
 
 #[cfg(feature = "async")]
-impl<S> crate::association::AsyncAssociation<S> for AsyncServerAssociation<S>
+impl<S> AsyncAssociation<S> for AsyncServerAssociation<S>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
 {
@@ -1783,112 +1758,6 @@ where
     async fn close(&mut self) -> std::io::Result<()> {
         use tokio::io::AsyncWriteExt;
         self.socket.shutdown().await
-    }
-}
-
-// compatibility filler, remove in 0.10.0
-#[cfg(feature = "async")]
-impl<S> AsyncServerAssociation<S> {
-    /// Obtain a view of the negotiated presentation contexts.
-    pub fn presentation_contexts(&self) -> &[PresentationContextNegotiated] {
-        &self.presentation_contexts
-    }
-
-    /// Retrieve the maximum PDU length
-    /// that the association acceptor is expecting to receive.
-    pub fn acceptor_max_pdu_length(&self) -> u32 {
-        self.acceptor_max_pdu_length
-    }
-
-    /// Retrieve the maximum PDU length
-    /// that the association requestor is expecting to receive.
-    pub fn requestor_max_pdu_length(&self) -> u32 {
-        self.requestor_max_pdu_length
-    }
-
-    /// Obtain the remote DICOM node's application entity title.
-    #[deprecated(
-        since = "0.9.1",
-        note = "Call `peer_ae_title` from trait `Association`"
-    )]
-    pub fn client_ae_title(&self) -> &str {
-        &self.client_ae_title
-    }
-
-    /// Obtain the application entity title called by the client.
-    pub fn called_ae_title(&self) -> &str {
-        &self.called_ae_title
-    }
-}
-
-// compatibility filler, remove in 0.10.0
-#[cfg(feature = "async")]
-impl<S> AsyncServerAssociation<S>
-where
-    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
-{
-    /// Send a PDU message to the other intervenient.
-    pub async fn send(&mut self, msg: &Pdu) -> Result<()> {
-        AsyncAssociation::send(self, msg).await
-    }
-
-    /// Read a PDU message from the other intervenient.
-    pub async fn receive(&mut self) -> Result<Pdu> {
-        AsyncAssociation::receive(self).await
-    }
-
-    /// Iniate a graceful release of the association.
-    ///
-    /// A DIMSE A-RELEASE transaction is initiated by this application entity,
-    /// and the underlying socket is closed once settled.
-    ///
-    /// Note that implementers of this trait
-    /// do not try to release the association on [`Drop`],
-    /// so remember to call `release` explicitly
-    /// at the end of all DIMSE transactions.
-    pub async fn release(self) -> Result<()> {
-        AsyncAssociation::release(self).await
-    }
-
-    /// Send a provider initiated abort message
-    /// and shut down the TCP connection,
-    /// terminating the association.
-    pub async fn abort(self) -> Result<()> {
-        AsyncAssociation::abort(self).await
-    }
-
-    /// Prepare a P-Data writer for sending
-    /// one or more data item PDUs.
-    ///
-    /// Returns a writer which automatically
-    /// splits the inner data into separate PDUs if necessary.
-    pub fn send_pdata(
-        &mut self,
-        presentation_context_id: u8,
-    ) -> crate::association::pdata::non_blocking::AsyncPDataWriter<&mut S> {
-        AsyncAssociation::send_pdata(self, presentation_context_id)
-    }
-
-    /// Prepare a P-Data reader for receiving
-    /// one or more data item PDUs.
-    ///
-    /// Returns a reader which automatically
-    /// receives more data PDUs once the bytes collected are consumed.
-    pub fn receive_pdata(&mut self) -> crate::association::pdata::PDataReader<'_, &mut S> {
-        AsyncAssociation::receive_pdata(self)
-    }
-
-    /// Obtain access to the inner stream
-    /// connected to the association acceptor.
-    ///
-    /// This can be used to send the PDU in semantic fragments of the message,
-    /// thus using less memory.
-    ///
-    /// **Note:** reading and writing should be done with care
-    /// to avoid inconsistencies in the association state.
-    /// Do not call `send` and `receive` while not in a PDU boundary.
-    pub fn inner_stream(&mut self) -> &mut S {
-        AsyncAssociation::inner_stream(self)
     }
 }
 

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -1022,7 +1022,12 @@ where
     }
 
     /// Negotiate an association with the given TCP stream.
-    /// In case of an `Err` return value, the socket is closed.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// is entered in state Sta2 (transport connection open,
+    /// waiting for A-ASSOCIATE-RQ). If the return value is `Ok`,
+    /// the new state is Sta6 (ready to send/receive data);
+    /// if it is `Err`, the new state is Sta1 (connection closed).
     pub fn establish(&self, mut socket: TcpStream) -> Result<ServerAssociation<TcpStream>> {
         ensure!(
             !self.abstract_syntax_uids.is_empty() || self.promiscuous,
@@ -1084,6 +1089,14 @@ where
                 },
                 called_ae_title,
             )) => {
+                // A-ASSOCIATE-RQ received, association accepted.
+                // The function `process_a_association_rq` has
+                // transitioned to state Sta3 and sends us (via
+                // returning Ok(_)) an "A-ASSOCIATE response
+                // primitive (accept)".
+                // Action AE-7: send A-ASSOCIATE-AC PDU. New state
+                // is Sta6 (association established, ready to send
+                // data).
                 write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                 socket.write_all(&write_buffer).context(WireSendSnafu)?;
                 Ok(ServerAssociation {
@@ -1102,6 +1115,10 @@ where
             }
             Err((pdu, err)) => {
                 if let Some(pdu) = pdu {
+                    // Either the association was rejected and the PDU
+                    // is A-ASSOCIATE-RJ (action AE-6, send A-ASSOCIATE-RJ)
+                    // or an unexpected/unknown PDU was received (action
+                    // AA-1: send A-ABORT). Either way, new state is Sta13.
                     // Send the rejection/abort PDU and switch to Sta13
                     write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                     socket.write_all(&write_buffer).context(WireSendSnafu)?;
@@ -1116,7 +1133,7 @@ where
                     )?;
                 } else {
                     // No PDU to send means it's our turn to close the socket
-                    // (this is most likely in response to an A-ABORT request)
+                    // (action AA-2: close socket, or AA-5: do nothing).
                     let _ = socket.close();
                 }
                 Err(err)
@@ -1125,6 +1142,12 @@ where
     }
 
     /// Negotiate an association with the given TCP stream using TLS.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// is entered in state Sta2 (transport connection open,
+    /// waiting for A-ASSOCIATE-RQ). If the return value is `Ok`,
+    /// the new state is Sta6 (ready to send/receive data);
+    /// if it is `Err`, the new state is Sta1 (connection closed).
     #[cfg(feature = "sync-tls")]
     pub fn establish_tls(&self, mut socket: TcpStream) -> Result<ServerAssociation<TlsStream>> {
         ensure!(
@@ -1168,6 +1191,14 @@ where
                 },
                 called_ae_title,
             )) => {
+                // A-ASSOCIATE-RQ received, association accepted.
+                // The function `process_a_association_rq` has
+                // transitioned to state Sta3 and sends us (via
+                // returning Ok(_)) an "A-ASSOCIATE response
+                // primitive (accept)".
+                // Action AE-7: send A-ASSOCIATE-AC PDU. New state
+                // is Sta6 (association established, ready to send
+                // data).
                 write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                 tls_stream.write_all(&write_buffer).context(WireSendSnafu)?;
                 Ok(ServerAssociation {
@@ -1186,6 +1217,10 @@ where
             }
             Err((pdu, err)) => {
                 if let Some(pdu) = pdu {
+                    // Either the association was rejected and the PDU
+                    // is A-ASSOCIATE-RJ (action AE-6, send A-ASSOCIATE-RJ)
+                    // or an unexpected/unknown PDU was received (action
+                    // AA-1: send A-ABORT). Either way, new state is Sta13.
                     // Send the rejection/abort PDU and switch to Sta13
                     write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
                     tls_stream.write_all(&write_buffer).context(WireSendSnafu)?;
@@ -1200,7 +1235,7 @@ where
                     )?;
                 } else {
                     // No PDU to send means it's our turn to close the socket
-                    // (this is most likely in response to an A-ABORT request)
+                    // (action AA-2: close socket, or AA-5: do nothing).
                     let _ = tls_stream.close();
                 }
                 Err(err)
@@ -1523,6 +1558,12 @@ where
     N: Negotiation,
 {
     /// Negotiate an association with the given TCP stream.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// is entered in state Sta2 (transport connection open,
+    /// waiting for A-ASSOCIATE-RQ). If the return value is `Ok`,
+    /// the new state is Sta6 (ready to send/receive data);
+    /// if it is `Err`, the new state is Sta1 (connection closed).
     pub async fn establish_async(
         &self,
         mut socket: tokio::net::TcpStream,
@@ -1622,6 +1663,12 @@ where
     }
 
     /// Negotiate an association with the given TCP stream.
+    ///
+    /// In the DIMSE Association State Machine, this method
+    /// is entered in state Sta2 (transport connection open,
+    /// waiting for A-ASSOCIATE-RQ). If the return value is `Ok`,
+    /// the new state is Sta6 (ready to send/receive data);
+    /// if it is `Err`, the new state is Sta1 (connection closed).
     #[cfg(feature = "async-tls")]
     pub async fn establish_tls_async(
         &self,

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -805,7 +805,8 @@ where
     fn process_a_association_rq(
         &self,
         msg: Pdu,
-    ) -> std::result::Result<(Pdu, NegotiatedOptions, String), (Pdu, Error)> {
+    ) -> std::result::Result<(Pdu, NegotiatedOptions, String), (Option<Pdu>, Error)> {
+        // Entered in state Sta2
         match msg {
             Pdu::AssociationRQ(AssociationRQ {
                 protocol_version,
@@ -815,6 +816,13 @@ where
                 presentation_contexts,
                 user_variables,
             }) => {
+                // Action AE-6; we always switch to Sta3 at this point,
+                // because we consider that the Service Provider deems
+                // it as acceptable.
+                // The various checks will result in action AE-8
+                // (send A-ASSOCIATE-RJ) if failed,
+                // or in action AE-7 (send A-ASSOCIATE-AC) if accepted.
+                // Since we're not receiving, other actions are not possible.
                 if protocol_version != self.protocol_version {
                     let association_rj = AssociationRJ {
                         result: AssociationRJResult::Permanent,
@@ -823,7 +831,7 @@ where
                         ),
                     };
                     let pdu = Pdu::AssociationRJ(association_rj.clone());
-                    return Err((pdu, RejectedSnafu { association_rj }.build()));
+                    return Err((Some(pdu), RejectedSnafu { association_rj }.build()));
                 }
 
                 if application_context_name != self.application_context_name {
@@ -834,7 +842,7 @@ where
                         ),
                     };
                     let pdu = Pdu::AssociationRJ(association_rj.clone());
-                    return Err((pdu, RejectedSnafu { association_rj }.build()));
+                    return Err((Some(pdu), RejectedSnafu { association_rj }.build()));
                 }
 
                 // User variables resulting from the negotiation are stored here
@@ -926,7 +934,7 @@ where
                             source: AssociationRJSource::ServiceUser(reason),
                         };
                         let pdu = Pdu::AssociationRJ(association_rj.clone());
-                        Err((pdu, RejectedSnafu { association_rj }.build()))
+                        Err((Some(pdu), RejectedSnafu { association_rj }.build()))
                     })?;
 
                 let presentation_contexts_negotiated: Vec<_> = presentation_contexts
@@ -989,31 +997,32 @@ where
                     called_ae_title,
                 ))
             }
-            Pdu::ReleaseRQ => Err((Pdu::ReleaseRP, AbortedSnafu.build())),
-            pdu @ Pdu::AssociationAC { .. }
+            Pdu::AbortRQ { .. } => Err((None, AbortedSnafu {}.build())),
+            pdu @ Pdu::ReleaseRQ
+            | pdu @ Pdu::AssociationAC { .. }
             | pdu @ Pdu::AssociationRJ { .. }
             | pdu @ Pdu::PData { .. }
-            | pdu @ Pdu::ReleaseRP
-            | pdu @ Pdu::AbortRQ { .. } => Err((
-                Pdu::AbortRQ {
+            | pdu @ Pdu::ReleaseRP => Err((
+                Some(Pdu::AbortRQ {
                     source: AbortRQSource::ServiceProvider(
                         AbortRQServiceProviderReason::UnexpectedPdu,
                     ),
-                },
+                }),
                 UnexpectedPduSnafu { pdu }.build(),
             )),
             pdu @ Pdu::Unknown { .. } => Err((
-                Pdu::AbortRQ {
+                Some(Pdu::AbortRQ {
                     source: AbortRQSource::ServiceProvider(
                         AbortRQServiceProviderReason::UnrecognizedPdu,
                     ),
-                },
+                }),
                 UnknownPduSnafu { pdu }.build(),
             )),
         }
     }
 
     /// Negotiate an association with the given TCP stream.
+    /// In case of an `Err` return value, the socket is closed.
     pub fn establish(&self, mut socket: TcpStream) -> Result<ServerAssociation<TcpStream>> {
         ensure!(
             !self.abstract_syntax_uids.is_empty() || self.promiscuous,
@@ -1030,27 +1039,38 @@ where
         let mut read_buffer = BytesMut::with_capacity(
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
-        let msg = super::read_pdu_from_wire(
+        let msg = match super::read_pdu_from_wire(
             &mut socket,
             &mut read_buffer,
             self.max_pdu_length,
             self.strict,
-        );
-        // If we're compiling with the sync-tls feature, check to see if the error
-        // may have been caused by the client associating with TLS but the server
-        // not being run with TLS support
-        #[cfg(feature = "sync-tls")]
-        let msg = msg.map_err(|e| {
-            // read_pdu_from_wire consumes bytes on the socket, but puts them into read_buffer
-            let mut cursor = std::io::Cursor::new(read_buffer.to_vec());
-            if let Ok(Ok(_)) = accept_tls(&mut cursor) {
-                // If the connection was accepted, return an error, TLS
-                // client attempting to connect with non-TLS server
-                return super::TlsNotSupportedSnafu.build();
+        ) {
+            Ok(msg) => msg,
+            Err(err) => {
+                // This covers "ARTIM timer expired" (socket read timeout)
+                // and "Transport connection closed".
+                // Action AA-2 or AA-5: Close connection or do nothing,
+                // then return to Sta1 (the connection may already be closed
+                // but we close it nevertheless).
+                let _ = socket.close();
+                // If we're compiling with the sync-tls feature, check to see if the error
+                // may have been caused by the client associating with TLS but the server
+                // not being run with TLS support
+                #[cfg(feature = "sync-tls")]
+                {
+                    // read_pdu_from_wire consumes bytes on the socket, but puts them into
+                    // read_buffer
+                    let mut cursor = std::io::Cursor::new(read_buffer.to_vec());
+                    if let Ok(Ok(_)) = accept_tls(&mut cursor) {
+                        // If the connection was accepted, return an error, TLS
+                        // client attempting to connect with non-TLS server
+                        return super::TlsNotSupportedSnafu.fail();
+                    }
+                }
+
+                return Err(err);
             }
-            e
-        });
-        let msg = msg?;
+        };
         let mut write_buffer: Vec<u8> =
             Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
         match self.process_a_association_rq(msg) {
@@ -1072,18 +1092,33 @@ where
                     acceptor_max_pdu_length: self.max_pdu_length,
                     socket,
                     client_ae_title: peer_ae_title,
+                    read_buffer,
                     write_buffer,
                     strict: self.strict,
                     finalization_timeout: self.finalization_timeout,
-                    read_buffer,
                     user_variables,
                     called_ae_title,
                 })
             }
             Err((pdu, err)) => {
-                // send the rejection/abort PDU
-                write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                socket.write_all(&write_buffer).context(WireSendSnafu)?;
+                if let Some(pdu) = pdu {
+                    // Send the rejection/abort PDU and switch to Sta13
+                    write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
+                    socket.write_all(&write_buffer).context(WireSendSnafu)?;
+
+                    super::sta13(
+                        &mut socket,
+                        &mut read_buffer,
+                        &mut write_buffer,
+                        self.max_pdu_length,
+                        DEFAULT_MAX_PDU,
+                        self.finalization_timeout,
+                    )?;
+                } else {
+                    // No PDU to send means it's our turn to close the socket
+                    // (this is most likely in response to an A-ABORT request)
+                    let _ = socket.close();
+                }
                 Err(err)
             }
         }
@@ -1150,9 +1185,24 @@ where
                 })
             }
             Err((pdu, err)) => {
-                // send the rejection/abort PDU
-                write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                tls_stream.write_all(&write_buffer).context(WireSendSnafu)?;
+                if let Some(pdu) = pdu {
+                    // Send the rejection/abort PDU and switch to Sta13
+                    write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
+                    tls_stream.write_all(&write_buffer).context(WireSendSnafu)?;
+
+                    super::sta13(
+                        &mut tls_stream,
+                        &mut read_buffer,
+                        &mut write_buffer,
+                        self.max_pdu_length,
+                        DEFAULT_MAX_PDU,
+                        self.finalization_timeout,
+                    )?;
+                } else {
+                    // No PDU to send means it's our turn to close the socket
+                    // (this is most likely in response to an A-ABORT request)
+                    let _ = tls_stream.close();
+                }
                 Err(err)
             }
         }
@@ -1551,12 +1601,19 @@ where
                     })
                 }
                 Err((pdu, err)) => {
-                    // send the rejection/abort PDU
-                    write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                    socket
-                        .write_all(&write_buffer)
-                        .await
-                        .context(WireSendSnafu)?;
+                    if let Some(pdu) = pdu {
+                        // Send the rejection/abort PDU and switch to Sta13
+                        write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
+                        socket
+                            .write_all(&write_buffer)
+                            .await
+                            .context(WireSendSnafu)?;
+                        // TODO: Async Sta13 implementation
+                    } else {
+                        // No PDU to send means it's our turn to close the socket
+                        // (this is most likely in response to an A-ABORT request)
+                        let _ = socket.shutdown().await;
+                    }
                     Err(err)
                 }
             }
@@ -1629,12 +1686,19 @@ where
                     })
                 }
                 Err((pdu, err)) => {
-                    // send the rejection/abort PDU
-                    write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
-                    socket
-                        .write_all(&write_buffer)
-                        .await
-                        .context(WireSendSnafu)?;
+                    if let Some(pdu) = pdu {
+                        // Send the rejection/abort PDU and switch to Sta13
+                        write_pdu(&mut write_buffer, &pdu).context(SendPduSnafu)?;
+                        socket
+                            .write_all(&write_buffer)
+                            .await
+                            .context(WireSendSnafu)?;
+                        // TODO: Async Sta13 implementation
+                    } else {
+                        // No PDU to send means it's our turn to close the socket
+                        // (this is most likely in response to an A-ABORT request)
+                        let _ = socket.shutdown().await;
+                    }
                     Err(err)
                 }
             }

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -12,9 +12,9 @@ use std::time::Duration;
 use std::{io::Write, net::TcpStream};
 
 use crate::association::{
-    AbortedSnafu, Association, CloseSocket, MissingAbstractSyntaxSnafu, RejectedSnafu,
-    SendPduSnafu, SocketOptions, SyncAssociation, UnexpectedPduSnafu, UnknownPduSnafu,
-    WireSendSnafu,
+    AbortedSnafu, Association, CloseSocket, DEFAULT_FINALIZATION_TIMEOUT,
+    MissingAbstractSyntaxSnafu, RejectedSnafu, SendPduSnafu, SetReadTimeout, SocketOptions,
+    SyncAssociation, UnexpectedPduSnafu, UnknownPduSnafu, WireSendSnafu,
 };
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
@@ -553,6 +553,8 @@ pub struct ServerAssociationOptions<'a, A, N> {
     strict: bool,
     /// whether to accept unknown abstract syntaxes
     promiscuous: bool,
+    /// Timeout to wait for the peer to close the connection
+    finalization_timeout: Duration,
     /// extended negotiation handler
     negotiation: N,
     /// Options for the underlying TCP socket
@@ -574,6 +576,7 @@ impl Default for ServerAssociationOptions<'_, AcceptAny, DefaultNegotiation> {
             max_pdu_length: DEFAULT_MAX_PDU,
             strict: true,
             promiscuous: false,
+            finalization_timeout: Duration::from_secs_f32(DEFAULT_FINALIZATION_TIMEOUT),
             negotiation: DefaultNegotiation,
             socket_options: SocketOptions::default(),
             #[cfg(feature = "sync-tls")]
@@ -628,6 +631,7 @@ where
             max_pdu_length,
             strict,
             promiscuous,
+            finalization_timeout,
             ae_access_control: _,
             negotiation,
             socket_options,
@@ -645,6 +649,7 @@ where
             max_pdu_length,
             strict,
             promiscuous,
+            finalization_timeout,
             negotiation,
             socket_options,
             #[cfg(feature = "sync-tls")]
@@ -733,6 +738,12 @@ where
         }
     }
 
+    /// Set the timeout for the peer to close the socket
+    pub fn finalization_timeout(mut self, timeout: Duration) -> Self {
+        self.finalization_timeout = timeout;
+        self
+    }
+
     /// Set the extended negotiation handler
     pub fn with_negotiation<NN>(self, negotiation: NN) -> ServerAssociationOptions<'a, A, NN>
     where
@@ -748,6 +759,7 @@ where
             max_pdu_length,
             strict,
             promiscuous,
+            finalization_timeout,
             negotiation: _,
             socket_options,
             #[cfg(feature = "sync-tls")]
@@ -764,6 +776,7 @@ where
             max_pdu_length,
             strict,
             promiscuous,
+            finalization_timeout,
             negotiation,
             socket_options,
             #[cfg(feature = "sync-tls")]
@@ -1061,6 +1074,7 @@ where
                     client_ae_title: peer_ae_title,
                     write_buffer,
                     strict: self.strict,
+                    finalization_timeout: self.finalization_timeout,
                     read_buffer,
                     user_variables,
                     called_ae_title,
@@ -1129,6 +1143,7 @@ where
                     client_ae_title: peer_ae_title,
                     write_buffer,
                     strict: self.strict,
+                    finalization_timeout: self.finalization_timeout,
                     read_buffer,
                     user_variables,
                     called_ae_title,
@@ -1201,6 +1216,8 @@ pub struct ServerAssociation<S> {
     write_buffer: Vec<u8>,
     /// whether to receive PDUs in strict mode
     strict: bool,
+    /// Timeout to wait for the peer to close the connection
+    finalization_timeout: Duration,
     /// Read buffer from the socket
     read_buffer: bytes::BytesMut,
     /// User variables received from the peer
@@ -1209,7 +1226,7 @@ pub struct ServerAssociation<S> {
 
 impl<S> ServerAssociation<S>
 where
-    S: std::io::Read + std::io::Write + CloseSocket,
+    S: std::io::Read + std::io::Write + CloseSocket + SetReadTimeout,
 {
     /// Send a PDU message to the other intervenient.
     pub fn send(&mut self, msg: &Pdu) -> Result<()> {
@@ -1270,7 +1287,7 @@ where
 
 impl<S> Association for ServerAssociation<S>
 where
-    S: std::io::Read + std::io::Write + CloseSocket,
+    S: std::io::Read + std::io::Write + CloseSocket + SetReadTimeout,
 {
     /// Obtain a view of the negotiated presentation contexts.
     fn presentation_contexts(&self) -> &[PresentationContextNegotiated] {
@@ -1306,6 +1323,18 @@ where
         &self.client_ae_title
     }
 
+    /// Retrieve the association finalization timeout defined
+    /// for this association.
+    fn finalization_timeout(&self) -> Duration {
+        self.finalization_timeout
+    }
+
+    /// Change the association finalization timeout defined
+    /// for this association.
+    fn set_finalization_timeout(&mut self, timeout: Duration) {
+        self.finalization_timeout = timeout;
+    }
+
     /// Retrieve the user variables that were taken from the server.
     ///
     /// It usually contains the maximum PDU length,
@@ -1317,7 +1346,7 @@ where
 
 impl<S> SyncAssociation<S> for ServerAssociation<S>
 where
-    S: std::io::Read + std::io::Write + CloseSocket,
+    S: std::io::Read + std::io::Write + CloseSocket + SetReadTimeout,
 {
     fn inner_stream(&mut self) -> &mut S {
         &mut self.socket
@@ -1512,6 +1541,7 @@ where
                         read_buffer,
                         read_timeout: self.socket_options.read_timeout,
                         write_timeout: self.socket_options.write_timeout,
+                        finalization_timeout: self.finalization_timeout,
                         user_variables,
                         called_ae_title,
                     })
@@ -1589,6 +1619,7 @@ where
                         read_buffer,
                         read_timeout: self.socket_options.read_timeout,
                         write_timeout: self.socket_options.write_timeout,
+                        finalization_timeout: self.finalization_timeout,
                         user_variables,
                         called_ae_title,
                     })
@@ -1644,6 +1675,8 @@ pub struct AsyncServerAssociation<S> {
     read_timeout: Option<std::time::Duration>,
     /// Timeout for individual send operations
     write_timeout: Option<std::time::Duration>,
+    /// Timeout to wait for the peer to close the connection
+    finalization_timeout: Duration,
     /// User variables received from the peer
     user_variables: Vec<UserVariableItem>,
 }
@@ -1693,6 +1726,18 @@ where
     /// Obtain the remote DICOM node's application entity title.
     fn peer_ae_title(&self) -> &str {
         &self.client_ae_title
+    }
+
+    /// Retrieve the association finalization timeout defined
+    /// for this association.
+    fn finalization_timeout(&self) -> Duration {
+        self.finalization_timeout
+    }
+
+    /// Change the association finalization timeout defined
+    /// for this association.
+    fn set_finalization_timeout(&mut self, timeout: Duration) {
+        self.finalization_timeout = timeout;
     }
 
     fn user_variables(&self) -> &[UserVariableItem] {
@@ -1824,6 +1869,7 @@ mod tests {
                 write_buffer,
                 read_buffer,
                 strict: self.strict,
+                finalization_timeout: self.finalization_timeout,
                 user_variables,
                 called_ae_title,
             })
@@ -1884,6 +1930,7 @@ mod tests {
                 user_variables,
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
+                finalization_timeout: self.finalization_timeout,
                 called_ae_title,
             })
         }
@@ -1928,6 +1975,7 @@ mod tests {
                 write_buffer,
                 strict: self.strict,
                 read_buffer,
+                finalization_timeout: self.finalization_timeout,
                 user_variables,
                 called_ae_title,
             })
@@ -1982,6 +2030,7 @@ mod tests {
                 read_buffer,
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,
+                finalization_timeout: self.finalization_timeout,
                 user_variables,
                 called_ae_title,
             })

--- a/ul/src/association/tests.rs
+++ b/ul/src/association/tests.rs
@@ -37,7 +37,7 @@ mod successive_pdus_during_client_association {
     use super::*;
     use crate::{
         ClientAssociationOptions, Pdu,
-        pdu::{AbortRQServiceProviderReason, AbortRQSource, PDataValue, PDataValueType},
+        pdu::{AbortRQSource, PDataValue, PDataValueType},
     };
 
     use crate::association::server::*;
@@ -419,9 +419,7 @@ mod successive_pdus_during_client_association {
         assert_eq!(
             received_pdu,
             Pdu::AbortRQ {
-                source: AbortRQSource::ServiceProvider(
-                    AbortRQServiceProviderReason::ReasonNotSpecified
-                ),
+                source: AbortRQSource::ServiceUser,
             }
         );
 

--- a/ul/src/association/tests.rs
+++ b/ul/src/association/tests.rs
@@ -1,7 +1,11 @@
+use crate::association::SyncAssociation;
 use dicom_core::{DataElement, VR, dicom_value};
 use dicom_dictionary_std::{tags, uids::VERIFICATION};
 use dicom_object::InMemDicomObject;
 use dicom_transfer_syntax_registry::entries::IMPLICIT_VR_LITTLE_ENDIAN;
+
+#[cfg(feature = "async")]
+use crate::association::AsyncAssociation;
 
 // Helper funtion to create a C-ECHO command
 fn create_c_echo_command(message_id: u16) -> Vec<u8> {

--- a/ul/src/association/tests.rs
+++ b/ul/src/association/tests.rs
@@ -426,7 +426,7 @@ mod successive_pdus_during_client_association {
         );
 
         // Currently receive() doesn't handle aborts; we need to close the assoc ourselves
-        association.close().await.unwrap();
+        association.close();
 
         // Wait until server has finished
         server_handle.await.unwrap();

--- a/ul/src/association/tests.rs
+++ b/ul/src/association/tests.rs
@@ -315,7 +315,11 @@ mod successive_pdus_during_client_association {
             let association = server_options
                 .establish_with_extra_pdus(stream, vec![echo_pdu])
                 .unwrap();
-            association
+
+            // Give time for the TCP buffers to flush, otherwise the kernel
+            // may send them in the same transmission and spoil the test
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            association.abort().unwrap();
         });
         // Give server time to start
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -330,19 +334,20 @@ mod successive_pdus_during_client_association {
         // This should succeed in establishing the association despite multiple PDUs
         let mut association = scu_options.broken_establish(server_addr.into()).unwrap();
 
-        // Initiate abort server side
-        server_handle.join().unwrap().abort().unwrap();
-
         // Client should not have anything to receive, only receives abort Rq
         let received_pdu = association.receive().unwrap();
         assert_eq!(
             received_pdu,
             Pdu::AbortRQ {
-                source: AbortRQSource::ServiceProvider(
-                    AbortRQServiceProviderReason::ReasonNotSpecified
-                )
+                source: AbortRQSource::ServiceUser,
             }
         );
+
+        // Currently receive() doesn't handle aborts; we need to close the assoc ourselves
+        association.close().unwrap();
+
+        // Wait until server has finished
+        server_handle.join().unwrap();
 
         // Client cannot receive the PDU that was sent during association
         // Clean shutdown
@@ -383,7 +388,11 @@ mod successive_pdus_during_client_association {
                 .establish_with_extra_pdus_async(stream, vec![echo_pdu])
                 .await
                 .unwrap();
-            association
+
+            // Give time for the TCP buffers to flush, otherwise the kernel
+            // may send them in the same transmission and spoil the test
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            association.abort().await.unwrap();
         });
 
         // Give server time to start
@@ -401,10 +410,8 @@ mod successive_pdus_during_client_association {
             .broken_establish_async(server_addr.into())
             .await
             .unwrap();
-        // Initiate abort server-side
-        server_handle.await.unwrap().abort().await.unwrap();
 
-        // Client should be able to receive the release request that was sent consecutively
+        // Client should be able to receive the abort request that was sent consecutively
         let received_pdu = association
             .receive()
             .await
@@ -414,11 +421,16 @@ mod successive_pdus_during_client_association {
             Pdu::AbortRQ {
                 source: AbortRQSource::ServiceProvider(
                     AbortRQServiceProviderReason::ReasonNotSpecified
-                )
+                ),
             }
         );
 
-        // Client cannot receive the PDU that was sent during association
+        // Currently receive() doesn't handle aborts; we need to close the assoc ourselves
+        association.close().await.unwrap();
+
+        // Wait until server has finished
+        server_handle.await.unwrap();
+
         // Clean shutdown
         drop(association);
     }

--- a/ul/tests/association.rs
+++ b/ul/tests/association.rs
@@ -1,4 +1,5 @@
 use dicom_dictionary_std::uids::{self, VERIFICATION};
+use dicom_ul::association::SyncAssociation;
 use dicom_ul::{ClientAssociationOptions, Pdu, ServerAssociationOptions};
 use rstest::rstest;
 use std::time::Instant;

--- a/ul/tests/association_echo.rs
+++ b/ul/tests/association_echo.rs
@@ -1,9 +1,7 @@
-#[cfg(feature = "async")]
-use dicom_ul::association::AsyncServerAssociation;
 use dicom_ul::{
     ServerAssociation,
     association::{
-        Association, Error,
+        Association, Error, SyncAssociation,
         client::ClientAssociationOptions,
         server::{Negotiation, ServerAssociationOptions},
     },
@@ -13,11 +11,13 @@ use dicom_ul::{
     },
 };
 use std::io::Write;
+use std::net::SocketAddr;
+
+#[cfg(feature = "async")]
+use dicom_ul::association::{AsyncAssociation, AsyncServerAssociation};
 
 #[cfg(feature = "async")]
 use tokio::io::AsyncWriteExt;
-
-use std::net::SocketAddr;
 
 // Check rather arbitrary maximum PDU lengths, also different for server and client
 const HI_PDU_LEN: usize = 7890;

--- a/ul/tests/association_promiscuous.rs
+++ b/ul/tests/association_promiscuous.rs
@@ -27,6 +27,7 @@ const ULTRASOUND_IMAGE_STORAGE_RAW: &str = "1.2.840.10008.5.1.4.1.1.6.1\0";
 fn spawn_scp(
     abstract_syntax_uids: &'static [&str],
     promiscuous: bool,
+    check_pc: bool,
 ) -> Result<(
     std::thread::JoinHandle<Result<ServerAssociation<std::net::TcpStream>>>,
     SocketAddr,
@@ -45,20 +46,25 @@ fn spawn_scp(
     let handle = std::thread::spawn(move || {
         let (stream, _addr) = listener.accept()?;
         let mut association = options.establish(stream)?;
-        assert_eq!(
-            association.presentation_contexts(),
-            &[PresentationContextNegotiated {
-                id: 1,
-                reason: PresentationContextResultReason::Acceptance,
-                transfer_syntax: IMPLICIT_VR_LE.to_string(),
-                abstract_syntax: MR_IMAGE_STORAGE.to_string(),
-            }]
-        );
+        if check_pc {
+            assert_eq!(
+                association.presentation_contexts(),
+                &[PresentationContextNegotiated {
+                    id: 1,
+                    reason: PresentationContextResultReason::Acceptance,
+                    transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                    abstract_syntax: MR_IMAGE_STORAGE.to_string(),
+                }]
+            );
 
-        let pdu = association.receive()?;
-        assert_eq!(pdu, Pdu::ReleaseRQ);
-        association.send(&Pdu::ReleaseRP)?;
-
+            let pdu = association.receive()?;
+            assert_eq!(pdu, Pdu::ReleaseRQ);
+            association.send(&Pdu::ReleaseRP)?;
+        } else {
+            // Silently close the association
+            let _ = association.receive();
+            let _ = association.close();
+        }
         Ok(association)
     });
 
@@ -69,6 +75,7 @@ fn spawn_scp(
 async fn spawn_scp_async(
     abstract_syntax_uids: &'static [&str],
     promiscuous: bool,
+    check_pc: bool,
 ) -> Result<(
     tokio::task::JoinHandle<Result<AsyncServerAssociation<tokio::net::TcpStream>>>,
     SocketAddr,
@@ -87,19 +94,24 @@ async fn spawn_scp_async(
     let handle = tokio::spawn(async move {
         let (stream, _addr) = listener.accept().await?;
         let mut association = options.establish_async(stream).await?;
-        assert_eq!(
-            association.presentation_contexts(),
-            &[PresentationContextNegotiated {
-                id: 1,
-                reason: PresentationContextResultReason::Acceptance,
-                transfer_syntax: IMPLICIT_VR_LE.to_string(),
-                abstract_syntax: MR_IMAGE_STORAGE.to_string(),
-            }]
-        );
+        if check_pc {
+            assert_eq!(
+                association.presentation_contexts(),
+                &[PresentationContextNegotiated {
+                    id: 1,
+                    reason: PresentationContextResultReason::Acceptance,
+                    transfer_syntax: IMPLICIT_VR_LE.to_string(),
+                    abstract_syntax: MR_IMAGE_STORAGE.to_string(),
+                }]
+            );
 
-        let pdu = association.receive().await?;
-        assert_eq!(pdu, Pdu::ReleaseRQ);
-        association.send(&Pdu::ReleaseRP).await?;
+            let pdu = association.receive().await?;
+            assert_eq!(pdu, Pdu::ReleaseRQ);
+            association.send(&Pdu::ReleaseRP).await?;
+        } else {
+            let _ = association.receive().await;
+            association.close().await.unwrap();
+        }
 
         Ok(association)
     });
@@ -110,7 +122,7 @@ async fn spawn_scp_async(
 #[test]
 fn scu_scp_association_promiscuous_enabled() {
     // SCP is set to promiscuous mode - all abstract syntaxes are accepted
-    let (scp_handle, scp_addr) = spawn_scp(&[], true).unwrap();
+    let (scp_handle, scp_addr) = spawn_scp(&[], true, true).unwrap();
 
     let association = ClientAssociationOptions::new()
         .calling_ae_title(SCU_AE_TITLE)
@@ -155,7 +167,7 @@ fn scu_scp_association_promiscuous_enabled() {
 #[tokio::test(flavor = "multi_thread")]
 async fn scu_scp_association_promiscuous_enabled_async() {
     // SCP is set to promiscuous mode - all abstract syntaxes are accepted
-    let (scp_handle, scp_addr) = spawn_scp_async(&[], true).await.unwrap();
+    let (scp_handle, scp_addr) = spawn_scp_async(&[], true, true).await.unwrap();
 
     let association = ClientAssociationOptions::new()
         .calling_ae_title(SCU_AE_TITLE)
@@ -201,7 +213,7 @@ async fn scu_scp_association_promiscuous_enabled_async() {
 #[test]
 fn scu_scp_association_promiscuous_disabled() {
     // SCP only accepts Ultrasound Image Storage
-    let (_scu_handle, scp_addr) = spawn_scp(&[ULTRASOUND_IMAGE_STORAGE_RAW], false).unwrap();
+    let (_scu_handle, scp_addr) = spawn_scp(&[ULTRASOUND_IMAGE_STORAGE_RAW], false, false).unwrap();
 
     let association = ClientAssociationOptions::new()
         .calling_ae_title(SCU_AE_TITLE)
@@ -220,7 +232,7 @@ fn scu_scp_association_promiscuous_disabled() {
 #[tokio::test(flavor = "multi_thread")]
 async fn scu_scp_association_promiscuous_disabled_async() {
     // SCP only accepts Ultrasound Image Storage
-    let (_scu_handle, scp_addr) = spawn_scp_async(&[ULTRASOUND_IMAGE_STORAGE_RAW], false)
+    let (_scu_handle, scp_addr) = spawn_scp_async(&[ULTRASOUND_IMAGE_STORAGE_RAW], false, false)
         .await
         .unwrap();
 

--- a/ul/tests/association_promiscuous.rs
+++ b/ul/tests/association_promiscuous.rs
@@ -110,7 +110,7 @@ async fn spawn_scp_async(
             association.send(&Pdu::ReleaseRP).await?;
         } else {
             let _ = association.receive().await;
-            association.close().await.unwrap();
+            association.close();
         }
 
         Ok(association)

--- a/ul/tests/association_promiscuous.rs
+++ b/ul/tests/association_promiscuous.rs
@@ -1,8 +1,9 @@
 use std::net::SocketAddr;
 
-#[cfg(feature = "async")]
-use dicom_ul::association::AsyncServerAssociation;
 use dicom_ul::association::Error::NoAcceptedPresentationContexts;
+use dicom_ul::association::{Association, SyncAssociation};
+#[cfg(feature = "async")]
+use dicom_ul::association::{AsyncAssociation, AsyncServerAssociation};
 use dicom_ul::pdu::PresentationContextResultReason::Acceptance;
 use dicom_ul::pdu::{
     DEFAULT_MAX_PDU, PresentationContextNegotiated, PresentationContextResultReason,

--- a/ul/tests/association_store.rs
+++ b/ul/tests/association_store.rs
@@ -1,5 +1,6 @@
+use dicom_ul::association::{Association, SyncAssociation};
 #[cfg(feature = "async")]
-use dicom_ul::association::AsyncServerAssociation;
+use dicom_ul::association::{AsyncAssociation, AsyncServerAssociation};
 use dicom_ul::{
     ServerAssociation,
     association::client::ClientAssociationOptions,

--- a/ul/tests/association_store_uncompressed.rs
+++ b/ul/tests/association_store_uncompressed.rs
@@ -2,10 +2,10 @@
 //! which only accepts uncompressed transfer syntaxes
 
 #[cfg(feature = "async")]
-use dicom_ul::association::AsyncServerAssociation;
+use dicom_ul::association::{AsyncAssociation, AsyncServerAssociation};
 use dicom_ul::{
-    ServerAssociation,
-    association::client::ClientAssociationOptions,
+    ClientAssociationOptions, ServerAssociation,
+    association::{Association, SyncAssociation},
     pdu::{Pdu, PresentationContextNegotiated, PresentationContextResultReason},
 };
 use std::net::SocketAddr;

--- a/ul/tests/association_tls.rs
+++ b/ul/tests/association_tls.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "async-tls")]
+use dicom_ul::association::AsyncAssociation;
 #[cfg(feature = "sync-tls")]
-use dicom_ul::association::Association;
+use dicom_ul::association::{Association, SyncAssociation};
 #[cfg(feature = "sync-tls")]
 use std::sync::Arc;
 


### PR DESCRIPTION
This PR implements the behaviour of the DIMSE Association State Machine as defined in [PS3.8 (2025d) section 9.2.3]( https://dicom.nema.org/medical/dicom/2025d/output/html/part08.html). Due to the complexity of the task, it's divided into multiple stages:

- [x] Cleanups and refactors (4 commits)
- For sync operation:
  - [x] Implement handling of state Sta13 from the state machine
  - [x] Implement correct behaviour for `abort()`
  - [x] Implement correct behaviour for `release()`
  - [x] Implement correct behaviour for association establishment (`establish_*()`)
  - [ ] Implement correct behaviour for `send()` and `receive()`
  - [ ] Maybe change the socket to be an `Option` for consistency with the async version (see below)
- For async operation:
  - [x] Implement handling of state Sta13 from the state machine
  - [x] Change the socket to be an `Option` so that it can be dropped to close the connection, as tokio doesn't provide means to shut down both sides of the stream.
  - [x] Implement correct behaviour for `abort()`
  - [x] Implement correct behaviour for `release()`
  - [x] Implement correct behaviour for association establishment (`establish_*()`)
  - [ ] Implement correct behaviour for `send()` and `receive()`
- [x] Fix unit tests
- [ ] Discuss `send()` parameter type and `receive()` Ok return value
- [ ] Discuss `send()` and `receive()` error return values; decide what to do about `send()` when it returns `SendTooLongPdu`
- [ ] Discuss what to do about `PDataReader` when the incoming PDU is not a P-DATA one
- [ ] Add `finalization_timeout` option to tools, along the lines of #792
- [ ] Add new tests

This is intended to address #714; along the way it fixes ERR_7 from #768. It already addresses a minor concern I expressed in https://github.com/Enet4/dicom-rs/pull/728#issuecomment-4215116827.

This is not yet ready for review. In particular the API (the type of the payload) for `send()` and `receive()` needs to be discussed, and some of the changes may be controversial, like the new possibility of a panic in `send_pdata()` and `receive_pdata()`.

So, as discussed in https://github.com/Enet4/dicom-rs/issues/714#issuecomment-3664462480 (point 3), the idea is to make `send()` and `receive()` deal with P-DATA-TF PDUs only. There are several ways to accomplish this:

- Make `send()` accept a generic Pdu as now, but return an error if the variant passed is not `Pdu::PData`, and make `receive()` only able to return `Pdu::PData`. This would be the most backwards-compatible change, but given the big changes in the API, it seems like a more type-restricted approach would be in order.
- Make a new type, e.g. `PDataTf`, and make `Pdu::PData` be `Pdu::PData(PDataTf)` instead of `Pdu::PData { data: Vec<PDataValue> }` as it is now. `send()` and `receive()` would accept/return `PDataTf`. How `PDataTf` is defined may be subject to discussion; I'd say `Vec<PDataValue>`, but due to the presence of a `data` field in `Pdu::PData`, someone may argue that `struct PDataTf { data: Vec<PDataValue> }` is preferable.
- Just pass/return `Vec<PDataValue>`.

Opinions on the overall approach taken in this PR, as well as on the decision for `send()` and `receive()`, would be appreciated.

**AI disclosure:** This PR contains no AI-generated code.