### PR TITLE
Remove Rayon as default feature from codec implementations and update Cargo feature set of pixeldata

### DIFF
--- a/pixeldata/Cargo.toml
+++ b/pixeldata/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["cli"]
 dicom-object = { path = "../object", version = "0.9.1" }
 dicom-core = { path = "../core", version = "0.9.1" }
 dicom-encoding = { path = "../encoding", version = "0.9.1" }
-dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry", version = "0.9.1" }
+dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry", version = "0.9.1", default-features = false }
 dicom-dictionary-std = { path = "../dictionary-std", version = "0.9" }
 snafu = "0.9"
 byteorder = "1.4.3"
@@ -61,8 +61,13 @@ native = ["dicom-transfer-syntax-registry/native", "jpeg", "rle", "deflate"]
 deflate = ['dicom-object/deflate', 'dicom-transfer-syntax-registry/deflate']
 # native JPEG codec implementation
 jpeg = ["dicom-transfer-syntax-registry/jpeg"]
-# native JPEG XL codec implementation
+# native JPEG XL decoding via jxl-oxide
+jxl-oxide = ["dicom-transfer-syntax-registry/jxl-oxide"]
+# native JPEG XL encoding via zune-jpegxl
+zune-jpegxl = ["dicom-transfer-syntax-registry/zune-jpegxl"]
+# native JPEG XL codec implementation (encoder and decoder)
 jpegxl = ["dicom-transfer-syntax-registry/jpegxl"]
+
 # native RLE lossless codec implementation
 rle = ["dicom-transfer-syntax-registry/rle"]
 # JPEG 2000 decoding via OpenJPEG static linking

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -79,6 +79,7 @@ default-features = false
 [dependencies.jpeg-decoder]
 version = "0.3.0"
 optional = true
+default-features = false
 
 [dependencies.jpeg-encoder]
 version = "0.6"
@@ -92,6 +93,7 @@ features = ["static"]
 [dependencies.jxl-oxide]
 version = "0.10.2"
 optional = true
+default-features = false
 
 [dependencies.zune-jpegxl]
 version = "0.4.0"


### PR DESCRIPTION
Resolves #784 and updates `dicom-pixeldata` with the features introduced in #717.

- [ts-registry] do not include default features of `jpeg-decoder` and `jxl-oxide`
   - makes it so that removing default features will no longer include rayon
   - note that rayon is still enabled by default, both in `dicom-transfer-syntax-registry` and  `dicom-pixeldata`
- [pixeldata] update Cargo feature set
   - exclude default features from dicom-transfer-syntax-registry
   - re-export features "jxl-oxide" and "zune-jpegxl" from dicom-transfer-syntax-registry