### PR TITLE
[ts-registry] Update decoders and encoders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +317,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -893,7 +918,7 @@ dependencies = [
  "jxl-oxide",
  "lazy_static",
  "tracing",
- "zune-core 0.4.12",
+ "zune-core 0.5.1",
  "zune-jpegxl",
 ]
 
@@ -1492,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "jpeg-encoder"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b454d911ac55068f53495488d8ccd0646eaa540c033a28ee15b07838afafb01f"
+checksum = "0b0b36cbb4e6704f12f5b5d7b01dac593982c6550859ebd5a66fb15c9ea27fd5"
 
 [[package]]
 name = "jpeg2k"
@@ -1521,18 +1546,18 @@ dependencies = [
 
 [[package]]
 name = "jxl-bitstream"
-version = "0.5.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "116184a8c915e99b08c7a4abca038b05863980bbf9e433dc2883363853c99afe"
+checksum = "b480e752277e29eb4054f69546887a9b84656fe78c08f54ba5850ced98a378fe"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "jxl-coding"
-version = "0.5.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7ffdab0c48e989f23a8bd6113d88bd243ae45c7871e90cfdcb6997eacbfb2"
+checksum = "cd972bcd125e776f1eb241ac50e39f956095a1c2770c64736c968f8946bd9a3c"
 dependencies = [
  "jxl-bitstream",
  "tracing",
@@ -1540,13 +1565,14 @@ dependencies = [
 
 [[package]]
 name = "jxl-color"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4806c94be9e37c82e571684ad673af0a2e4049a74942c407034da6a087c4de7b"
+checksum = "f316b1358c1711755b3ee8e8cb5c4a1dad12e796233088a7a513440782de80b2"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
  "jxl-grid",
+ "jxl-image",
  "jxl-oxide-common",
  "jxl-threadpool",
  "tracing",
@@ -1554,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-frame"
-version = "0.11.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1649956cb002031108e1fa44e0e483a770e2e95f4544137788c32265db0b8c71"
+checksum = "2d967c6fd669c7c01060b5022d8835fa82fd46b06ffc98b549f17600a097c2b3"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -1571,31 +1597,48 @@ dependencies = [
 
 [[package]]
 name = "jxl-grid"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5739f02add3d5c00320140bec6f5a80fac4baa630f88fe4c6a55a0d719718ce3"
+checksum = "01671307879a033bfa52e6e8784b941aca770b3f3a7d33830b455b6844f793fb"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "jxl-image"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de3283303bb66b1742538f1a6947313596242598d6ddf325f301c2fbf01abd3"
+checksum = "c5f752d62577c702a94dbbce4045caf08cb58639e8a4d56464b40ecf33ffe565"
 dependencies = [
  "jxl-bitstream",
- "jxl-color",
  "jxl-grid",
  "jxl-oxide-common",
  "tracing",
 ]
 
 [[package]]
-name = "jxl-modular"
-version = "0.9.1"
+name = "jxl-jbr"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f2fd5a3346deda8169f6b26aa6c955c32bd275377b527415ef2e5f362e00ad"
+checksum = "e35d032bcec660647828527ff42c6f5776d2fd44b8357f9f6d9ac6dc07218e46"
+dependencies = [
+ "brotli-decompressor",
+ "jxl-bitstream",
+ "jxl-frame",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "jxl-vardct",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-modular"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2f045b24c738dd91d482be385512b512721ae08a671bd4b27bf1c47f215235"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -1607,15 +1650,17 @@ dependencies = [
 
 [[package]]
 name = "jxl-oxide"
-version = "0.10.2"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a42a404a09f4704e60ad102eb995ac074cad467df48631c1a1269b97eef3c5"
+checksum = "d36c662923f47586880211f3bc7c0d83fb3a9b410d278c7bde93450748abeef3"
 dependencies = [
+ "brotli-decompressor",
  "jxl-bitstream",
  "jxl-color",
  "jxl-frame",
  "jxl-grid",
  "jxl-image",
+ "jxl-jbr",
  "jxl-oxide-common",
  "jxl-render",
  "jxl-threadpool",
@@ -1624,19 +1669,20 @@ dependencies = [
 
 [[package]]
 name = "jxl-oxide-common"
-version = "0.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efb65a6ef812eae1083e5d2d1a4358bd74cf7e08d112f6e939a40003a6a9920"
+checksum = "b62394c5021b3a9e7e0dbb2d639d555d019090c9946c39f6d3b09d390db4157b"
 dependencies = [
  "jxl-bitstream",
 ]
 
 [[package]]
 name = "jxl-render"
-version = "0.10.1"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b7162076893570cdeaced01086893df132ff8b2eaf22d63ed3b066d9b88739"
+checksum = "d34386bfdb6a19b5a30cc9beb4d475d537422c31ae8c39bb69640fcce3fcaf19"
 dependencies = [
+ "bytemuck",
  "jxl-bitstream",
  "jxl-coding",
  "jxl-color",
@@ -1652,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-threadpool"
-version = "0.1.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9c78eaf899cce165e266300f9963d8d376d4ed95cf4d12dd7066f05542cd88"
+checksum = "25f15eb830aa77a7f21148d72e153562a26bfe570139bd4922eab1908dd499d3"
 dependencies = [
  "rayon",
  "rayon-core",
@@ -1663,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-vardct"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737b4a65897907c644329c8a54e042cefdec2989e482698eea150d463e475fe5"
+checksum = "ce72a18c6d3a47172ab6c479be2bdb56f22066b5d7092663f03b4490820b4511"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -3739,9 +3785,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpegxl"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ffee484384b15f99ed4768bfdb3fa186d63e1f8c3aafba1d6d141a7b9e3674"
+checksum = "cba11ecd07cc23351500e840ae03841b7e4997923ec8e4832ee3ae199ea0b6b4"
 dependencies = [
- "zune-core 0.4.12",
+ "zune-core 0.5.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "jpeg-encoder"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0b36cbb4e6704f12f5b5d7b01dac593982c6550859ebd5a66fb15c9ea27fd5"
+checksum = "b454d911ac55068f53495488d8ccd0646eaa540c033a28ee15b07838afafb01f"
 
 [[package]]
 name = "jpeg2k"

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -82,7 +82,7 @@ optional = true
 default-features = false
 
 [dependencies.jpeg-encoder]
-version = "0.7"
+version = ">=0.6.1,<0.8.0"
 optional = true
 
 [dependencies.charls]

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -82,7 +82,7 @@ optional = true
 default-features = false
 
 [dependencies.jpeg-encoder]
-version = "0.6"
+version = "0.7"
 optional = true
 
 [dependencies.charls]
@@ -91,18 +91,18 @@ optional = true
 features = ["static"]
 
 [dependencies.jxl-oxide]
-version = "0.10.2"
+version = "0.12.6"
 optional = true
 default-features = false
 
 [dependencies.zune-jpegxl]
-version = "0.4.0"
+version = "0.5"
 optional = true
 default-features = false
 features = ["std"]
 
 [dependencies.zune-core]
-version = "0.4.12"
+version = "0.5"
 optional = true
 default-features = false
 

--- a/transfer-syntax-registry/src/adapters/jpegxl.rs
+++ b/transfer-syntax-registry/src/adapters/jpegxl.rs
@@ -198,9 +198,6 @@ impl PixelDataWriter for JpegXlAdapter {
         let frame_size =
             cols as usize * rows as usize * samples_per_pixel as usize * bytes_per_sample;
 
-        // record dst length before encoding to know full jpeg size
-        let len_before = dst.len();
-
         // identify frame data using the frame index
         let pixeldata_uncompressed = &src
             .raw_pixel_data()
@@ -235,16 +232,13 @@ impl PixelDataWriter for JpegXlAdapter {
         options.set_effort(effort.map(|e| e + 27).unwrap_or(64));
         let encoder = JxlSimpleEncoder::new(frame_data, options);
 
-        let jxl = encoder
-            .encode()
-            .map_err(|e| format!("{e:?}"))
+        let bytes_written = encoder
+            .encode(dst)
             .whatever_context("Failed to encode JPEG XL data")?;
-
-        dst.extend_from_slice(&jxl);
 
         // provide attribute changes
         let mut changes = if quality != 100 {
-            let compressed_frame_size = dst.len() - len_before;
+            let compressed_frame_size = bytes_written;
             let compression_ratio = frame_size as f64 / compressed_frame_size as f64;
             let compression_ratio = format!("{compression_ratio:.6}");
             vec![

--- a/transfer-syntax-registry/tests/jpegxl.rs
+++ b/transfer-syntax-registry/tests/jpegxl.rs
@@ -262,3 +262,84 @@ fn write_and_read_jpeg_xl() {
     // compare pixels, lossless encoding should yield exactly the same data
     assert_eq!(samples, decoded, "pixel data mismatch");
 }
+
+/// writing to JPEG XL lossless multiple times
+/// should append each frame to the end of the output buffer
+#[cfg(feature = "zune-jpegxl")]
+#[test]
+fn write_append_jpeg_xl() {
+    let rows: u16 = 128;
+    let columns: u16 = 256;
+
+    // build some random RGB image
+    let mut samples = vec![0; rows as usize * columns as usize * 3];
+
+    // use linear congruence to make RGB noise
+    let mut seed = 0xcfcf_acab_u32;
+    let mut gen_sample = || {
+        let r = 4_294_967_291_u32;
+        let b = 67291_u32;
+        seed = seed.wrapping_mul(r).wrapping_add(b);
+        // grab a portion from the seed
+        (seed >> 7) as u8
+    };
+
+    let slab = 8;
+    for y in (0..rows as usize).step_by(slab) {
+        let scan_r = gen_sample();
+        let scan_g = gen_sample();
+        let scan_b = gen_sample();
+
+        for x in 0..columns as usize {
+            for k in 0..slab {
+                let offset = ((y + k) * columns as usize + x) * 3;
+                samples[offset] = scan_r;
+                samples[offset + 1] = scan_g;
+                samples[offset + 2] = scan_b;
+            }
+        }
+    }
+
+    // create test object of native encoding
+    let obj = TestDataObject {
+        // Explicit VR Little Endian
+        ts_uid: "1.2.840.10008.1.2.1".to_string(),
+        rows,
+        columns,
+        bits_allocated: 8,
+        bits_stored: 8,
+        samples_per_pixel: 3,
+        photometric_interpretation: "RGB",
+        number_of_frames: 1,
+        flat_pixel_data: Some(samples.clone()),
+        pixel_data_sequence: None,
+    };
+
+    // fetch adapters for JPEG XL lossless
+
+    let Codec::EncapsulatedPixelData(_, Some(writer)) = dicom_transfer_syntax_registry::entries::JPEG_XL_LOSSLESS.codec() else {
+        panic!("JPEG XL pixel data adapters not found")
+    };
+
+    let mut encoded = vec![];
+
+    let _ops = writer
+        .encode_frame(&obj, 0, EncodeOptions::default(), &mut encoded)
+        .expect("JPEG XL frame encoding failed");
+
+    let len_1 = encoded.len();
+    assert!(len_1 > 50);
+    let encoded_copy = encoded.clone();
+
+    // do it again
+
+    let _ops = writer
+        .encode_frame(&obj, 0, EncodeOptions::default(), &mut encoded)
+        .expect("JPEG XL frame encoding failed");
+
+    // expect _more_ data
+    assert!(encoded.len() > len_1 + 10);
+
+    // compare the first part of encoded data
+    assert_eq!(encoded[..len_1], encoded_copy, "encoded data mismatch");
+}


### PR DESCRIPTION
- jxl-oxide 0.12.6
- jpeg-encoder >=0.6.1,<0.8.0
- zune-jpegxl 0.5
