### PR TITLE
Feature-gate TLS support in dicom-storescu and dicom-storescp

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
           cache: true
       # test project with default + extra features
       - if: matrix.rust == 'stable' || matrix.rust == 'beta'
-        run: cargo test --features image,ndarray,sop-class,rle,cli,jpegxl
+        run: cargo test --features image,ndarray,sop-class,rle,cli,jpegxl,tls
       # test dicom-pixeldata with openjp2
       - if: matrix.rust == 'stable' || matrix.rust == 'beta'
         run: cargo test -p dicom-pixeldata --features openjp2

--- a/app-common/Cargo.toml
+++ b/app-common/Cargo.toml
@@ -9,9 +9,13 @@ keywords = ["dicom", "cli"]
 version = "0.9.0"
 edition = "2024"
 
+[features]
+default = []
+tls = ["dep:rustls", "dep:rustls-native-certs"]
+
 [dependencies]
 clap = { version = "4.5.47", features = ["derive", "wrap_help"] }
-rustls = "0.23.31"
-rustls-native-certs = "0.8.1"
+rustls = { version = "0.23.31", optional = true }
+rustls-native-certs = { version = "0.8.1", optional = true }
 snafu = "0.9"
 tracing = "0.1.41"

--- a/app-common/src/lib.rs
+++ b/app-common/src/lib.rs
@@ -1,8 +1,12 @@
 use clap::Args;
+#[cfg(feature = "tls")]
 use rustls::{ClientConfig, ServerConfig, SupportedProtocolVersion, pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer, pem::PemObject}, server::WebPkiClientVerifier};
+#[cfg(feature = "tls")]
 use tracing::{debug, info};
-use std::{path::PathBuf, sync::Arc};
-use snafu::{Snafu, ResultExt};
+use std::path::PathBuf;
+#[cfg(feature = "tls")]
+use std::sync::Arc;
+use snafu::prelude::*;
 
 #[derive(Snafu, Debug)]
 pub enum MissingPemObject {
@@ -16,62 +20,79 @@ pub enum MissingPemObject {
 pub enum TlsError {
     #[snafu(display("IO error"))] 
     Io { source: std::io::Error },
+    #[cfg(feature = "tls")]
     #[snafu(display("PEM parse error in path: {}", path.as_ref().map(|p| p.display().to_string()).unwrap_or("unknown".into())))]
     PemParse { 
         source: rustls::pki_types::pem::Error,
         path: Option<PathBuf>,
      },
+    #[cfg(feature = "tls")]
     #[snafu(display("Rustls error"))]
     Rustls { source: rustls::Error },
 
+    #[cfg(feature = "tls")]
     #[snafu(display("Certificate verifier error"))]
     CertificateVerifier { source: rustls::client::VerifierBuilderError},
 
     #[snafu(display("Config error: {missing}"))]
+    #[cfg(feature = "tls")]
     Config { missing: MissingPemObject },
-}
 
+    /// the application was not built with TLS support
+    #[cfg(not(feature = "tls"))]
+    TlsSupportNotAvailable,
+}
 
 #[derive(Args, Debug)]
 pub struct TlsOptions {
     /// Enables mTLS (TLS for DICOM connections)
     #[arg(long = "tls", default_value = "false")]
+    #[arg(hide(cfg!(not(feature = "tls"))))]
     pub enabled: bool,
 
     /// Crypto provider to use, see documentation (https://docs.rs/rustls/latest/rustls/index.html) for details
     #[arg(long, value_enum, default_value_t = CryptoProvider::AwsLC, value_name = "provider")]
+    #[arg(hide(cfg!(not(feature = "tls"))))]
     pub crypto_provider: CryptoProvider,
 
     /// List of cipher suites to use. If not specified, the default cipher suites for the selected crypto provider will be used.
     #[arg(long, value_name = "cipher1,...")]
+    #[arg(hide(cfg!(not(feature = "tls"))))]
     pub cipher_suites: Option<Vec<String>>,
 
     /// TLS protocol versions to enable
     #[arg(long, value_enum, value_name = "version,...", default_values_t = vec![TLSProtocolVersion::TLS1_2, TLSProtocolVersion::TLS1_3])]
+    #[arg(hide(cfg!(not(feature = "tls"))))]
     pub protocol_versions: Vec<TLSProtocolVersion>,
 
     /// Path to private key file in PEM format
     #[arg(long, value_name = "/path/to/key.pem,...")]
+    #[arg(hide(cfg!(not(feature = "tls"))))]
     pub key: Option<PathBuf>,
 
     /// Path to certificate file in PEM format
     #[arg(long, value_name = "/path/to/cert.pem,...")]
+    #[arg(hide(cfg!(not(feature = "tls"))))]
     pub cert: Option<PathBuf>,
 
     /// Path to additional CA certificates (comma separated) in PEM format to add to the root store
     #[arg(long, value_name = "/path/to/cert.pem,...")]
+    #[arg(hide(cfg!(not(feature = "tls"))))]
     pub add_certs: Option<Vec<PathBuf>>,
 
     /// Add Certificate Revocation Lists (CRLs) to the server's certificate verifier
     #[arg(long, value_name = "/path/to/crl.pem,...")]
+    #[arg(hide(cfg!(not(feature = "tls"))))]
     pub add_crls: Option<Vec<PathBuf>>,
 
     /// Load certitificates from the system root store
     #[arg(long, action = clap::ArgAction::SetFalse)]
+    #[arg(hide(cfg!(not(feature = "tls"))))]
     pub system_roots: bool,
 
     /// How to handle peer certificates
     #[arg(long, value_enum, value_name = "opt", default_value_t = PeerCertOption::Require)]
+    #[arg(hide(cfg!(not(feature = "tls"))))]
     pub peer_cert: PeerCertOption,
 
 }
@@ -97,6 +118,7 @@ impl Default for TlsOptions {
 pub struct TlsAcceptorOptions {
     /// Allow unauthenticated clients (only valid for server)
     #[arg(long)]
+    #[arg(hide(cfg!(not(feature = "tls"))))]
     pub allow_unauthenticated: bool,
 }
 
@@ -137,7 +159,8 @@ pub enum PeerCertOption {
 }
 
 /// Show the supported cipher suites for the default crypto provider
-pub fn show_cipher_suites(){
+#[cfg(feature = "tls")]
+pub fn show_cipher_suites() {
     let provider = rustls::crypto::CryptoProvider::get_default().expect("No default crypto provider found");
     println!("Supported cipher suites: ");
     for suite in &provider.cipher_suites {
@@ -145,6 +168,15 @@ pub fn show_cipher_suites(){
     }
 }
 
+/// Show the supported cipher suites for the default crypto provider
+///
+/// This is a no-op with Cargo feature `tls` disabled.
+#[cfg(not(feature = "tls"))]
+pub fn show_cipher_suites() {
+    // no-op
+}
+
+#[cfg(feature = "tls")]
 impl TlsOptions{
     /// Build a root cert store from system roots and any additional certs
     fn root_cert_store(&self) -> Result<rustls::RootCertStore, TlsError> {
@@ -279,5 +311,4 @@ impl TlsOptions{
             }
         }
     }
-
 }

--- a/storescp/Cargo.toml
+++ b/storescp/Cargo.toml
@@ -10,11 +10,16 @@ categories = ["command-line-utilities"]
 keywords = ["dicom", "store"]
 readme = "README.md"
 
+[features]
+default = []
+# support DICOM over TLS
+tls = ["dicom-app-common/tls", "dicom-ul/async-tls"]
+
 [dependencies]
 clap = { version = "4.0.18", features = ["derive"] }
-dicom-app-common = { version = "0.9", path = "../app-common" }
+dicom-app-common = { version = "0.9", path = "../app-common", default-features = false}
 dicom-core = { path = '../core', version = "0.9.1" }
-dicom-ul = { path = '../ul', version = "0.9.1", features = ["async-tls"] }
+dicom-ul = { path = '../ul', version = "0.9.1", features = ["async"] }
 dicom-object = { path = '../object', version = "0.9.1" }
 dicom-encoding = { path = "../encoding/", version = "0.9.1" }
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.9" }

--- a/storescp/src/main.rs
+++ b/storescp/src/main.rs
@@ -124,6 +124,13 @@ fn main() {
     .unwrap_or_else(|e: Whatever| {
         eprintln!("[ERROR] {}", Report::from_error(e));
     });
+
+    #[cfg(not(feature = "tls"))]
+    if app.tls.enabled {
+        error!("{}", dicom_app_common::TlsError::TlsSupportNotAvailable);
+        std::process::exit(-2);
+    }
+
     if app.non_blocking {
         tokio::runtime::Builder::new_multi_thread()
             .enable_all()

--- a/storescp/src/store_async.rs
+++ b/storescp/src/store_async.rs
@@ -24,8 +24,10 @@ pub async fn run_store_async(
         out_dir,
         port: _,
         non_blocking: _,
+        #[cfg_attr(not(feature = "tls"), allow(unused_variables))]
         tls,
-        tls_acceptor
+        #[cfg_attr(not(feature = "tls"), allow(unused_variables))]
+        tls_acceptor,
     } = args;
 
 
@@ -51,10 +53,12 @@ pub async fn run_store_async(
     for uid in ABSTRACT_SYNTAXES {
         options = options.with_abstract_syntax(*uid);
     }
-    let (peer_addr, peer_title) = if tls.enabled {
+    let peer_addr = scu_stream.peer_addr().ok();
+
+    #[cfg(feature = "tls")]
+    if tls.enabled {
         let config = tls.server_config(tls_acceptor).whatever_context("Could not create TLS config")?;
         options = options.tls_config(config);
-        let peer_addr = scu_stream.peer_addr().ok();
         let association = options
             .establish_tls_async(scu_stream)
             .await
@@ -77,45 +81,46 @@ pub async fn run_store_async(
         );
         let peer_title = association.peer_ae_title().to_string();
         inner(association, *verbose, out_dir).await?;
-        (peer_addr, peer_title)
-    } else {
-        let peer_addr = scu_stream.peer_addr().ok();
-        let association = options
-            .establish_async(scu_stream)
-            .await
-            .whatever_context("could not establish association")?;
-        info!("New association from {}", association.peer_ae_title());
-        if args.verbose {
-            debug!(
-                "> Presentation contexts: {:?}",
-                association.presentation_contexts()
-            );
+
+        if let Some(peer_addr) = peer_addr {
+            info!("Dropping connection with {peer_title} ({peer_addr})");
+        } else {
+            info!("Dropping connection with {peer_title}");
         }
+
+        return Ok(());
+    }
+
+    let association = options
+        .establish_async(scu_stream)
+        .await
+        .whatever_context("could not establish association")?;
+    info!("New association from {}", association.peer_ae_title());
+    if args.verbose {
         debug!(
-            "#accepted_presentation_contexts={}, acceptor_max_pdu_length={}, requestor_max_pdu_length={}",
+            "> Presentation contexts: {:?}",
             association.presentation_contexts()
-                .iter()
-                .filter(|pc| pc.reason == PresentationContextResultReason::Acceptance)
-                .count(),
-            association.acceptor_max_pdu_length(),
-            association.requestor_max_pdu_length(),
         );
-        let peer_title = association.peer_ae_title().to_string();
-        inner(association, *verbose, out_dir).await?;
-        (peer_addr, peer_title)
-    };
+    }
+    debug!(
+        "#accepted_presentation_contexts={}, acceptor_max_pdu_length={}, requestor_max_pdu_length={}",
+        association.presentation_contexts()
+            .iter()
+            .filter(|pc| pc.reason == PresentationContextResultReason::Acceptance)
+            .count(),
+        association.acceptor_max_pdu_length(),
+        association.requestor_max_pdu_length(),
+    );
+    let peer_title = association.peer_ae_title().to_string();
+    inner(association, *verbose, out_dir).await?;
 
     if let Some(peer_addr) = peer_addr {
-        info!(
-            "Dropping connection with {} ({})",
-            peer_title,
-            peer_addr
-        );
+        info!("Dropping connection with {peer_title} ({peer_addr})");
     } else {
-        info!("Dropping connection with {}", peer_title);
+        info!("Dropping connection with {peer_title}");
     }
-    Ok(())
 
+    Ok(())
 }
 
 async fn inner<T>(mut association: AsyncServerAssociation<T>, verbose: bool, out_dir: &Path) -> Result<(), Whatever>

--- a/storescp/src/store_sync.rs
+++ b/storescp/src/store_sync.rs
@@ -21,7 +21,9 @@ pub fn run_store_sync(scu_stream: TcpStream, args: &App) -> Result<(), Whatever>
         out_dir,
         port: _,
         non_blocking: _,
+        #[cfg_attr(not(feature = "tls"), allow(unused_variables))]
         tls,
+        #[cfg_attr(not(feature = "tls"), allow(unused_variables))]
         tls_acceptor,
     } = &args;
 
@@ -48,10 +50,12 @@ pub fn run_store_sync(scu_stream: TcpStream, args: &App) -> Result<(), Whatever>
     for uid in ABSTRACT_SYNTAXES {
         options = options.with_abstract_syntax(*uid);
     }
-    let (peer_addr, peer_title) = if tls.enabled {
+    let peer_addr = scu_stream.peer_addr().ok();
+
+    #[cfg(feature = "tls")]
+    if tls.enabled {
         let config = tls.server_config(tls_acceptor).whatever_context("Could not create TLS config")?;
         options = options.tls_config(config);
-        let peer_addr = scu_stream.peer_addr().ok();
         let association = options
             .establish_tls(scu_stream)
             .whatever_context("could not establish association")?;
@@ -73,42 +77,42 @@ pub fn run_store_sync(scu_stream: TcpStream, args: &App) -> Result<(), Whatever>
         );
         let peer_title = association.peer_ae_title().to_string();
         inner(association, *verbose, out_dir)?;
-        (peer_addr, peer_title)
-    } else {
-        let peer_addr = scu_stream.peer_addr().ok();
-        let association = options
-            .establish(scu_stream)
-            .whatever_context("could not establish association")?;
-        info!("New association from {}", association.peer_ae_title());
-        if args.verbose {
-            debug!(
-                "> Presentation contexts: {:?}",
-                association.presentation_contexts()
-            );
-        }
-        debug!(
-            "#accepted_presentation_contexts={}, acceptor_max_pdu_length={}, requestor_max_pdu_length={}",
-            association.presentation_contexts()
-                .iter()
-                .filter(|pc| pc.reason == PresentationContextResultReason::Acceptance)
-                .count(),
-            association.acceptor_max_pdu_length(),
-            association.requestor_max_pdu_length(),
-        );
-        let peer_title = association.peer_ae_title().to_string();
-        inner(association, *verbose, out_dir)?;
-        (peer_addr, peer_title)
-    };
 
-    if let Some(peer_addr) = peer_addr {
-        info!(
-            "Dropping connection with {} ({})",
-            peer_title,
-            peer_addr
-        );
-    } else {
-        info!("Dropping connection with {}", peer_title);
+        if let Some(peer_addr) = peer_addr {
+            info!("Dropping connection with {peer_title} ({peer_addr})");
+        } else {
+            info!("Dropping connection with {peer_title}");
+        }
+        return Ok(());
     }
+
+    let association = options
+        .establish(scu_stream)
+        .whatever_context("could not establish association")?;
+    info!("New association from {}", association.peer_ae_title());
+    if args.verbose {
+        debug!(
+            "> Presentation contexts: {:?}",
+            association.presentation_contexts()
+        );
+    }
+    debug!(
+        "#accepted_presentation_contexts={}, acceptor_max_pdu_length={}, requestor_max_pdu_length={}",
+        association.presentation_contexts()
+            .iter()
+            .filter(|pc| pc.reason == PresentationContextResultReason::Acceptance)
+            .count(),
+        association.acceptor_max_pdu_length(),
+        association.requestor_max_pdu_length(),
+    );
+    let peer_title = association.peer_ae_title().to_string();
+    inner(association, *verbose, out_dir)?;
+    if let Some(peer_addr) = peer_addr {
+        info!("Dropping connection with {peer_title} ({peer_addr})");
+    } else {
+        info!("Dropping connection with {peer_title}");
+    }
+
     Ok(())
 
 }

--- a/storescu/Cargo.toml
+++ b/storescu/Cargo.toml
@@ -14,10 +14,12 @@ readme = "README.md"
 default = ["transcode"]
 # support DICOM transcoding
 transcode = ["dep:dicom-pixeldata"]
+# support DICOM over TLS
+tls = ["dicom-app-common/tls", "dicom-ul/async-tls", "dep:rustls", "dep:tokio-rustls"]
 
 [dependencies]
 clap = { version  = "4.0.18", features = ["derive"] }
-dicom-app-common = { version = "0.9", path = "../app-common" }
+dicom-app-common = { version = "0.9", path = "../app-common", default-features = false }
 dicom-core = { path = '../core', version = "0.9.1" }
 dicom-dictionary-std = { path = "../dictionary-std/", version = "0.9" }
 dicom-dump = { path = "../dump", version = "0.9.1", default-features = false }
@@ -25,14 +27,14 @@ dicom-encoding = { path = "../encoding/", version = "0.9.1" }
 dicom-object = { path = '../object', version = "0.9.1" }
 dicom-pixeldata = { path = "../pixeldata", version = "0.9.1", optional = true }
 dicom-transfer-syntax-registry = { path = "../transfer-syntax-registry/", version = "0.9.1" }
-dicom-ul = { path = '../ul', version = "0.9.1", features = ["async-tls"] }
+dicom-ul = { path = '../ul', version = "0.9.1", features = ["async"] }
 walkdir = "2.3.2"
 indicatif = "0.18"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 snafu = "0.9"
-rustls = "0.23.31"
-tokio-rustls = "0.26.3"
+rustls = { version = "0.23.31", optional = true }
+tokio-rustls = { version = "0.26.3", optional = true }
 
 [dependencies.tokio]
 version = "1.38.0"

--- a/storescu/src/main.rs
+++ b/storescu/src/main.rs
@@ -193,13 +193,19 @@ pub fn get_scu_options<'a>(
     saml_assertion: Option<String>,
     jwt: Option<String>,
     presentation_contexts: &'a HashSet<(String, String)>,
+    #[cfg(feature = "tls")]
     tls_options: rustls::ClientConfig,
 ) -> ClientAssociationOptions<'a> {
     let mut scu_init = ClientAssociationOptions::new()
         .calling_ae_title(calling_ae_title)
-        .max_pdu_length(max_pdu_length)
-        .server_name("localhost")
-        .tls_config(tls_options);
+        .max_pdu_length(max_pdu_length);
+
+    #[cfg(feature = "tls")]
+    {
+        scu_init = scu_init
+            .server_name("localhost").
+            tls_config(tls_options);
+    }
 
     for (storage_sop_class_uid, transfer_syntax) in presentation_contexts {
         scu_init = scu_init.with_presentation_context(storage_sop_class_uid, vec![transfer_syntax]);
@@ -358,6 +364,13 @@ fn run(app: App) -> Result<(), Error> {
         never_transcode = true;
     }
     let tls_enabled = tls.enabled;
+
+    #[cfg(not(feature = "tls"))]
+    if tls_enabled {
+        return Err(Error::Tls { source: dicom_app_common::TlsError::TlsSupportNotAvailable });
+    }
+
+    #[cfg(feature = "tls")]
     let config = tls.client_config()
         .context(TlsSnafu)?;
 
@@ -376,6 +389,7 @@ fn run(app: App) -> Result<(), Error> {
         saml_assertion,
         jwt,
         &presentation_contexts,
+        #[cfg(feature = "tls")]
         config
     );
     let progress_bar;
@@ -393,14 +407,15 @@ fn run(app: App) -> Result<(), Error> {
         progress_bar = None;
     }
 
+    #[cfg(feature = "tls")]
     if tls_enabled {
         let scu = scu_options.establish_with_tls(&addr).map_err(Box::from).context(ScuSnafu)?;
         store_sync::inner(scu, dicom_files, &progress_bar, fail_first, verbose, never_transcode, ignore_sop_class)?;
-
-    } else {
-        let scu = scu_options.establish_with(&addr).map_err(Box::from).context(ScuSnafu)?;
-        store_sync::inner(scu, dicom_files, &progress_bar, fail_first, verbose, never_transcode, ignore_sop_class)?;
+        return Ok(());
     }
+
+    let scu = scu_options.establish_with(&addr).map_err(Box::from).context(ScuSnafu)?;
+    store_sync::inner(scu, dicom_files, &progress_bar, fail_first, verbose, never_transcode, ignore_sop_class)?;
     Ok(())
 }
 
@@ -431,6 +446,12 @@ async fn run_async() -> Result<(), Error> {
     }
 
     let tls_enabled = tls.enabled;
+    #[cfg(not(feature = "tls"))]
+    if tls_enabled {
+        return Err(Error::Tls { source: dicom_app_common::TlsError::TlsSupportNotAvailable });
+    }
+
+    #[cfg(feature = "tls")]
     let config = tls.client_config()
         .context(TlsSnafu)?;
 
@@ -473,6 +494,7 @@ async fn run_async() -> Result<(), Error> {
         let password = password.clone();
         let called_ae_title = called_ae_title.clone();
         let calling_ae_title = calling_ae_title.clone();
+        #[cfg(feature = "tls")]
         let tls_config_clone = config.clone();
         tasks.spawn(async move {
             let scu_options = get_scu_options(
@@ -485,31 +507,17 @@ async fn run_async() -> Result<(), Error> {
                 saml_assertion,
                 jwt,
                 &pc,
+                #[cfg(feature = "tls")]
                 tls_config_clone
             );
+            #[cfg(feature = "tls")]
             if tls_enabled {
                 let scu = scu_options
                     .establish_with_async_tls(&addr)
                     .await
                     .map_err(Box::from)
                     .context(ScuSnafu)?;
-                store_async::inner(
-                    scu,
-                    d_files,
-                    pbx,
-                    never_transcode,
-                    fail_first,
-                    verbose,
-                    ignore_sop_class,
-                )
-                .await
-            } else {
-                let scu = scu_options
-                    .establish_with_async(&addr)
-                    .await
-                    .map_err(Box::from)
-                    .context(ScuSnafu)?;
-                store_async::inner(
+                return store_async::inner(
                     scu,
                     d_files,
                     pbx,
@@ -520,6 +528,21 @@ async fn run_async() -> Result<(), Error> {
                 )
                 .await
             }
+            let scu = scu_options
+                .establish_with_async(&addr)
+                .await
+                .map_err(Box::from)
+                .context(ScuSnafu)?;
+            store_async::inner(
+                scu,
+                d_files,
+                pbx,
+                never_transcode,
+                fail_first,
+                verbose,
+                ignore_sop_class,
+            )
+            .await
         });
     }
     while let Some(result) = tasks.join_next().await {

--- a/ul/Cargo.toml
+++ b/ul/Cargo.toml
@@ -63,11 +63,12 @@ rcgen = "0.14.4"
 rustls = "0.23.31"
 
 [features]
+default = []
 async = ["dep:tokio"]
 sync-tls = ["dep:rustls"]
-async-tls=["async", "sync-tls", "dep:tokio-rustls"]
-default = []
+async-tls = ["async", "sync-tls", "dep:tokio-rustls"]
+tls = ["sync-tls"]
 full = ["async-tls"]
 
 [package.metadata.docs.rs]
-features = ["async", "sync-tls", "async-tls"]
+features = ["async", "tls"]

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -28,6 +28,7 @@ use crate::{
     },
 };
 use snafu::{ResultExt, ensure};
+#[cfg(feature = "sync-tls")]
 use tracing::{debug, error};
 
 use super::{Result, uid::trim_uid};
@@ -925,38 +926,38 @@ impl<'a> ClientAssociationOptions<'a> {
         let mut buf = BytesMut::with_capacity(
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
-        let resp = read_pdu_from_wire(&mut socket, &mut buf, self.max_pdu_length, self.strict)
-            .map_err(|e| {
-                // If we're in non-TLS mode and `read_pdu_from_wire` fails, it
-                // could be because the server expects TLS but we sent a
-                // plaintext request.  In that case, we make a best effort to
-                // detect that and return a more specific error message.
-                #[cfg(feature = "sync-tls")]{
-                    let mut acceptor = rustls::server::Acceptor::default();
-                    let mut read = std::io::Cursor::new(buf.to_vec());
-                    let res = acceptor.read_tls(&mut read);
-                    if res.is_err() {
-                        return e;
+        let resp = read_pdu_from_wire(&mut socket, &mut buf, self.max_pdu_length, self.strict);
+        // If we're in non-TLS mode and `read_pdu_from_wire` fails, it
+        // could be because the server expects TLS but we sent a
+        // plaintext request.  In that case, we make a best effort to
+        // detect that and return a more specific error message.
+        #[cfg(feature = "sync-tls")]
+        let resp = resp.map_err(|e| {
+            let mut acceptor = rustls::server::Acceptor::default();
+            let mut read = std::io::Cursor::new(buf.to_vec());
+            let res = acceptor.read_tls(&mut read);
+            if res.is_err() {
+                return e;
+            }
+            match acceptor.accept() {
+                Ok(_) => {
+                    // This means the server responded with a valid TLS
+                    // state, but since we didn't originally send a TLS
+                    // ClientHello, that shouldn't be possible
+                    error!("Received TLS response to non-TLS request!");
+                    return super::TlsNotSupportedSnafu.build()
+                }
+                Err((err, _alert)) => {
+                    // Recieved a valid TLS message, means the server expects TLS
+                    if let rustls::Error::InappropriateMessage{..} = err {
+                        error!("Received TLS response to non-TLS request!");
+                        return super::TlsNotSupportedSnafu.build()
                     }
-                    match acceptor.accept() {
-                        Ok(_) => {
-                            // This means the server responded with a valid TLS
-                            // state, but since we didn't originally send a TLS
-                            // ClientHello, that shouldn't be possible
-                            error!("Received TLS response to non-TLS request!");
-                            return super::TlsNotSupportedSnafu.build()
-                        }
-                        Err((err, _alert)) => {
-                            // Recieved a valid TLS message, means the server expects TLS
-                            if let rustls::Error::InappropriateMessage{..} = err {
-                                error!("Received TLS response to non-TLS request!");
-                                return super::TlsNotSupportedSnafu.build()
-                            }
-                        }
-                    }
-                };
-                e
-            })?;
+                }
+            }
+            e
+        });
+        let resp = resp?;
         let negotiated_options = self.process_a_association_resp(resp, &pc_proposed);
         match negotiated_options {
             Err(e) => {

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -1012,22 +1012,22 @@ where
             &mut read_buffer,
             self.max_pdu_length,
             self.strict,
-        ).map_err(|e| {
-            // If we're compiling with the sync-tls feature, check to see if the error
-            // may have been caused by the client associating with TLS but the server
-            // not being run with TLS support
-            #[cfg(feature = "sync-tls")]
-            {
-                // read_pdu_from_wire consumes bytes on the socket, but puts them into read_buffer
-                let mut cursor = std::io::Cursor::new(read_buffer.to_vec());
-                if let Ok(Ok(_)) = accept_tls(&mut cursor){
-                    // If the connection was accepted, return an error, TLS
-                    // client attempting to connect with non-TLS server
-                    return super::TlsNotSupportedSnafu.build()
-                }
-            } 
+        );
+        // If we're compiling with the sync-tls feature, check to see if the error
+        // may have been caused by the client associating with TLS but the server
+        // not being run with TLS support
+        #[cfg(feature = "sync-tls")]
+        let msg = msg.map_err(|e| {
+            // read_pdu_from_wire consumes bytes on the socket, but puts them into read_buffer
+            let mut cursor = std::io::Cursor::new(read_buffer.to_vec());
+            if let Ok(Ok(_)) = accept_tls(&mut cursor){
+                // If the connection was accepted, return an error, TLS
+                // client attempting to connect with non-TLS server
+                return super::TlsNotSupportedSnafu.build()
+            }
             e
-        })?;
+        });
+        let msg = msg?;
         let mut write_buffer: Vec<u8> =
             Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
         match self.process_a_association_rq(msg) {

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -32,6 +32,7 @@ use crate::{
         PresentationContextResultReason, UserIdentity, UserVariableItem, write_pdu,
     },
 };
+#[cfg(feature = "sync-tls")]
 use tracing::{error, warn};
 
 use super::{Error, Result, uid::trim_uid};

--- a/ul/src/lib.rs
+++ b/ul/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! * `async`: Enables a fully asynchronous implementation of the upper layer protocol.
 //!   See [`ClientAssociationOptions`] and [`ServerAssociationOptions`] for details
-//! * `sync-tls`: Enables TLS support for synchronous associations.
+//! * `sync-tls` (or `tls`): Enables TLS support for synchronous associations.
 //! * `async-tls`: Enables TLS support for asynchronous associations.
 //!   Implies `async` and `sync-tls`.
 //! * `full`: Enables all capabilities: `async-tls`


### PR DESCRIPTION

This PR makes it possible to build the tools `storescu` and `storescp` without TLS support, and makes this the default behavior. To make it possible to do DICOM over TLS in `dicom-storescu` and `dicom-storescp` (`--tls` and other options), enable Cargo feature **"tls"**. Library crates (other than `dicom-app-common`) are unaffected.

### Summary

- add Cargo feature "tls" to dicom-app-common and affected tool packages
   - add also "tls" to dicom-ul as an alias to "sync-tls"
- [app-common] change TLS options to be hidden when Cargo feature "tls" is disabled
- [storescu] [storescp] only include rustls, rustls-native-certs, and tokio-rustls when "tls" feature is enabled
- [storescu] [storescp] add feature gating on TLS functionality
- [ci] include "tls" feature in the test project step where extra feature are included