### PR TITLE
feature flag: openjpeg-sys-threads

### DIFF
--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -54,7 +54,7 @@ charls = ["dep:charls"]
 charls-vcpkg = ["charls?/vcpkg"]
 
 # build OpenJPEG with multithreading,
-# implies "rayon"
+# implies "openjpeg-sys" and "rayon"
 openjpeg-sys-threads = ["rayon", "openjpeg-sys", "jpeg2k?/threads"]
 
 # multithreading for JPEG XL encoding

--- a/transfer-syntax-registry/Cargo.toml
+++ b/transfer-syntax-registry/Cargo.toml
@@ -55,7 +55,7 @@ charls-vcpkg = ["charls?/vcpkg"]
 
 # build OpenJPEG with multithreading,
 # implies "rayon"
-openjpeg-sys-threads = ["rayon", "jpeg2k?/threads"]
+openjpeg-sys-threads = ["rayon", "openjpeg-sys", "jpeg2k?/threads"]
 
 # multithreading for JPEG XL encoding
 zune-jpegxl-threads = ["zune-jpegxl?/threads"]


### PR DESCRIPTION
When the `openjpeg-sys-threads` feature is enabled, `openjpeg-sys` will be activated automatically now.
