### PR TITLE
[ul] Revise some TLS client connectivity checks and improve association error type

### DIFF
--- a/scpproxy/src/main.rs
+++ b/scpproxy/src/main.rs
@@ -128,7 +128,7 @@ fn run(
                                     })
                                     .context(SendMessageSnafu)?;
                             }
-                            Err(dicom_ul::association::Error::ConnectionClosed) => {
+                            Err(dicom_ul::association::Error::ConnectionClosed { .. }) => {
                                 message_tx
                                     .send(ThreadMessage::Shutdown {
                                         initiator: ProviderType::Scu,
@@ -184,7 +184,7 @@ fn run(
                                     })
                                     .context(SendMessageSnafu)?;
                             }
-                            Err(dicom_ul::association::Error::ConnectionClosed) => {
+                            Err(dicom_ul::association::Error::ConnectionClosed { .. }) => {
                                 message_tx
                                     .send(ThreadMessage::Shutdown {
                                         initiator: ProviderType::Scp,

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -933,6 +933,12 @@ impl<'a> ClientAssociationOptions<'a> {
         // detect that and return a more specific error message.
         #[cfg(feature = "sync-tls")]
         let resp = resp.map_err(|e| {
+            // TLS config means that the client already expects TLS
+            if self.tls_config.is_some() {
+                return e;
+            }
+            // try to identify whether the server expects TLS
+            // (even though the client was not fully prepared for this)
             let mut acceptor = rustls::server::Acceptor::default();
             let mut read = std::io::Cursor::new(buf.to_vec());
             let res = acceptor.read_tls(&mut read);
@@ -948,7 +954,7 @@ impl<'a> ClientAssociationOptions<'a> {
                     return super::TlsNotSupportedSnafu.build()
                 }
                 Err((err, _alert)) => {
-                    // Recieved a valid TLS message, means the server expects TLS
+                    // Received a valid TLS message reporting that the server expects TLS
                     if let rustls::Error::InappropriateMessage{..} = err {
                         error!("Received TLS response to non-TLS request!");
                         return super::TlsNotSupportedSnafu.build()

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -85,14 +85,14 @@ pub enum Error {
     },
 
     /// failed to send association request
-    #[snafu(display("failed to send pdu: {}", source))]
+    #[snafu(display("failed to send pdu"))]
     SendPdu {
         #[snafu(backtrace)]
         source: crate::pdu::WriteError,
     },
 
     /// failed to receive association response
-    #[snafu(display("failed to receive pdu: {}", source))]
+    #[snafu(display("failed to receive pdu"))]
     ReceivePdu {
         #[snafu(backtrace)]
         source: crate::pdu::ReadError,
@@ -167,7 +167,9 @@ pub enum Error {
     SendTooLongPdu { length: usize, backtrace: Backtrace },
 
     #[snafu(display("connection closed by peer"))]
-    ConnectionClosed,
+    ConnectionClosed {
+        backtrace: Backtrace,
+    },
 
     /// TLS configuration is missing
     #[cfg(feature = "sync-tls")]
@@ -199,7 +201,7 @@ pub enum Error {
     },
     #[cfg(any(feature = "sync-tls", feature = "async-tls"))]
     #[snafu(display("TLS not enabled, but peer seems to be sending TLS data"))]
-    TlsNotSupported
+    TlsNotSupported,
 }
 /// Struct to hold negotiated options after association is accepted
 pub(crate) struct NegotiatedOptions {


### PR DESCRIPTION
### Summary

- I found that the storescu was tripping false positives and complaining about TLS not being enabled even when it was. The trick was to check whether TLS was enabled, and only then try to identify whether the server was expecting TLS while the client was expecting non-TLS.
- Tweak association Error type a bit
   - remove redundant source display of `SendPdu` and `ReceivePdu`
   - add backtrace to `ConnectionClosed`
   - Add trailing comma to `TlsNotSupported`