### PR TITLE
Revise dicom-app-common library

### DIFF
--- a/app-common/src/lib.rs
+++ b/app-common/src/lib.rs
@@ -68,12 +68,12 @@ pub struct TlsOptions {
     pub crypto_provider: CryptoProvider,
 
     /// List of cipher suites to use. If not specified, the default cipher suites for the selected crypto provider will be used.
-    #[arg(long, value_name = "cipher1,...", use_value_delimiter(true))]
+    #[arg(long, value_name = "cipher1,...", value_delimiter(','))]
     #[arg(hide(cfg!(not(feature = "tls"))))]
     pub cipher_suites: Option<Vec<String>>,
 
     /// TLS protocol versions to enable
-    #[arg(long, value_enum, value_name = "version,...", use_value_delimiter(true), default_values_t = vec![TlsProtocolVersion::TLS1_2, TlsProtocolVersion::TLS1_3])]
+    #[arg(long, value_enum, value_name = "version,...", value_delimiter(','), default_values_t = vec![TlsProtocolVersion::TLS1_2, TlsProtocolVersion::TLS1_3])]
     #[arg(hide(cfg!(not(feature = "tls"))))]
     pub protocol_versions: Vec<TlsProtocolVersion>,
 
@@ -88,12 +88,12 @@ pub struct TlsOptions {
     pub cert: Option<PathBuf>,
 
     /// Path to additional CA certificates (comma separated) in PEM format to add to the root store
-    #[arg(long, value_name = "/path/to/cert.pem,...", use_value_delimiter(true))]
+    #[arg(long, value_name = "/path/to/cert.pem,...", value_delimiter(','))]
     #[arg(hide(cfg!(not(feature = "tls"))))]
     pub add_certs: Option<Vec<PathBuf>>,
 
     /// Add Certificate Revocation Lists (CRLs) to the server's certificate verifier
-    #[arg(long, value_name = "/path/to/crl.pem,...", use_value_delimiter(true))]
+    #[arg(long, value_name = "/path/to/crl.pem,...", value_delimiter(','))]
     #[arg(hide(cfg!(not(feature = "tls"))))]
     pub add_crls: Option<Vec<PathBuf>>,
 
@@ -164,7 +164,7 @@ pub enum TlsProtocolVersion {
 }
 
 /// Peer certificate handling options
-/// cl
+///
 /// Defines how the TLS connection should handle peer certificates.
 #[derive(clap::ValueEnum, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum PeerCertOption {
@@ -265,15 +265,13 @@ impl TlsOptions {
             CryptoProvider::AwsLC => rustls::crypto::aws_lc_rs::default_provider(),
         };
 
-        if self.peer_cert == PeerCertOption::Ignore {
-            tracing::warn!("It is dangerous to skip server peer certificate verification. Prefer registering trusted certificates instead.");
-        }
-
         let builder = ClientConfig::builder_with_provider(provider.into())
             .with_protocol_versions(self.protocol_versions().as_slice())
             .context(SetProtocolVersionsSnafu)?;
 
         let builder = if self.peer_cert == PeerCertOption::Ignore {
+            tracing::warn!("It is dangerous to skip server peer certificate verification. Prefer registering trusted certificates instead.");
+
             builder
                 .dangerous().with_custom_certificate_verifier(SkipServerCertVerification::new())
         } else {

--- a/app-common/src/lib.rs
+++ b/app-common/src/lib.rs
@@ -2,7 +2,7 @@ use clap::Args;
 #[cfg(feature = "tls")]
 use rustls::{ClientConfig, ServerConfig, SupportedProtocolVersion, pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer, pem::PemObject}, server::WebPkiClientVerifier};
 #[cfg(feature = "tls")]
-use tracing::{debug, info};
+use tracing::debug;
 use std::path::PathBuf;
 #[cfg(feature = "tls")]
 use std::sync::Arc;
@@ -16,23 +16,34 @@ pub enum MissingPemObject {
     PrivateKey,
 }
 
+/// An error which may occur during TLS initialization in applications
 #[derive(Snafu, Debug)]
+#[non_exhaustive]
 pub enum TlsError {
-    #[snafu(display("IO error"))] 
-    Io { source: std::io::Error },
     #[cfg(feature = "tls")]
     #[snafu(display("PEM parse error in path: {}", path.as_ref().map(|p| p.display().to_string()).unwrap_or("unknown".into())))]
-    PemParse { 
+    ParsePem { 
         source: rustls::pki_types::pem::Error,
         path: Option<PathBuf>,
-     },
+    },
+
+    /// Could not set up protocol versions
     #[cfg(feature = "tls")]
-    #[snafu(display("Rustls error"))]
-    Rustls { source: rustls::Error },
+    SetProtocolVersions {
+        source: rustls::Error,
+    },
+
+    /// Could not set certificate
+    #[cfg(feature = "tls")]
+    SetCertificate {
+        source: rustls::Error,
+    },
 
     #[cfg(feature = "tls")]
-    #[snafu(display("Certificate verifier error"))]
-    CertificateVerifier { source: rustls::client::VerifierBuilderError},
+    #[snafu(display("Could not build certificate verifier"))]
+    BuildCertificateVerifier {
+        source: rustls::client::VerifierBuilderError,
+    },
 
     #[snafu(display("Config error: {missing}"))]
     #[cfg(feature = "tls")]
@@ -43,6 +54,7 @@ pub enum TlsError {
     TlsSupportNotAvailable,
 }
 
+/// Application TLS options
 #[derive(Args, Debug)]
 pub struct TlsOptions {
     /// Enables mTLS (TLS for DICOM connections)
@@ -56,14 +68,14 @@ pub struct TlsOptions {
     pub crypto_provider: CryptoProvider,
 
     /// List of cipher suites to use. If not specified, the default cipher suites for the selected crypto provider will be used.
-    #[arg(long, value_name = "cipher1,...")]
+    #[arg(long, value_name = "cipher1,...", use_value_delimiter(true))]
     #[arg(hide(cfg!(not(feature = "tls"))))]
     pub cipher_suites: Option<Vec<String>>,
 
     /// TLS protocol versions to enable
-    #[arg(long, value_enum, value_name = "version,...", default_values_t = vec![TLSProtocolVersion::TLS1_2, TLSProtocolVersion::TLS1_3])]
+    #[arg(long, value_enum, value_name = "version,...", use_value_delimiter(true), default_values_t = vec![TlsProtocolVersion::TLS1_2, TlsProtocolVersion::TLS1_3])]
     #[arg(hide(cfg!(not(feature = "tls"))))]
-    pub protocol_versions: Vec<TLSProtocolVersion>,
+    pub protocol_versions: Vec<TlsProtocolVersion>,
 
     /// Path to private key file in PEM format
     #[arg(long, value_name = "/path/to/key.pem,...")]
@@ -76,25 +88,24 @@ pub struct TlsOptions {
     pub cert: Option<PathBuf>,
 
     /// Path to additional CA certificates (comma separated) in PEM format to add to the root store
-    #[arg(long, value_name = "/path/to/cert.pem,...")]
+    #[arg(long, value_name = "/path/to/cert.pem,...", use_value_delimiter(true))]
     #[arg(hide(cfg!(not(feature = "tls"))))]
     pub add_certs: Option<Vec<PathBuf>>,
 
     /// Add Certificate Revocation Lists (CRLs) to the server's certificate verifier
-    #[arg(long, value_name = "/path/to/crl.pem,...")]
+    #[arg(long, value_name = "/path/to/crl.pem,...", use_value_delimiter(true))]
     #[arg(hide(cfg!(not(feature = "tls"))))]
     pub add_crls: Option<Vec<PathBuf>>,
 
     /// Load certitificates from the system root store
-    #[arg(long, action = clap::ArgAction::SetFalse)]
+    #[arg(long)]
     #[arg(hide(cfg!(not(feature = "tls"))))]
     pub system_roots: bool,
 
-    /// How to handle peer certificates
+    /// How to handle certificates from peers
     #[arg(long, value_enum, value_name = "opt", default_value_t = PeerCertOption::Require)]
     #[arg(hide(cfg!(not(feature = "tls"))))]
     pub peer_cert: PeerCertOption,
-
 }
 
 impl Default for TlsOptions {
@@ -103,7 +114,7 @@ impl Default for TlsOptions {
             enabled: true,
             crypto_provider: CryptoProvider::AwsLC,
             cipher_suites: None,
-            protocol_versions: vec![TLSProtocolVersion::TLS1_2, TLSProtocolVersion::TLS1_3],
+            protocol_versions: vec![TlsProtocolVersion::TLS1_2, TlsProtocolVersion::TLS1_3],
             key: None,
             cert: None,
             add_certs: None,
@@ -114,6 +125,7 @@ impl Default for TlsOptions {
     }
 }
 
+/// Options which are only valid for servers or association acceptors
 #[derive(Args, Debug)]
 pub struct TlsAcceptorOptions {
     /// Allow unauthenticated clients (only valid for server)
@@ -123,34 +135,38 @@ pub struct TlsAcceptorOptions {
 }
 
 /// Crypto provider options
-/// 
+///
 /// See rustls 
 /// [Cryptograpy providers](https://docs.rs/rustls/latest/rustls/#cryptography-providers)
 /// for more details
-/// 
-/// Currently only AWS-LC is supported
+///
+/// Currently only AWS-LC is supported in DICOM-rs tools.
 #[non_exhaustive]
 #[derive(clap::ValueEnum, Clone, Debug)]
 pub enum CryptoProvider {
+    /// AWS-LC (via `aws-lc-rs`)
     AwsLC,
-    //RING
+    //Ring
 }
 
 /// TLS protocol version options
 /// 
 /// Subset of rustls 
-/// [ProtocolVersions](https://docs.rs/rustls/latest/rustls/enum.ProtocolVersion.html#variants) 
+/// [`ProtocolVersion`](https://docs.rs/rustls/latest/rustls/enum.ProtocolVersion.html#variants) 
 /// supported
 #[derive(clap::ValueEnum, Clone, Debug)]
-pub enum TLSProtocolVersion {
+#[non_exhaustive]
+pub enum TlsProtocolVersion {
+    /// TLS v1.2
     TLS1_2,
+    /// TLS v1.3
     TLS1_3,
 }
 
 /// Peer certificate handling options
-/// 
-/// Defines how the TLS connection should handle peer certificates
-#[derive(clap::ValueEnum, Clone, Debug)]
+/// cl
+/// Defines how the TLS connection should handle peer certificates.
+#[derive(clap::ValueEnum, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum PeerCertOption {
     /// Require the peer to present a valid certificate
     Require,
@@ -177,21 +193,24 @@ pub fn show_cipher_suites() {
 }
 
 #[cfg(feature = "tls")]
-impl TlsOptions{
+impl TlsOptions {
     /// Build a root cert store from system roots and any additional certs
     fn root_cert_store(&self) -> Result<rustls::RootCertStore, TlsError> {
         let mut root_store = rustls::RootCertStore::empty();
         // Load system roots unless disabled
-        if self.system_roots{
+        if self.system_roots {
             let system_roots = rustls_native_certs::load_native_certs();
+            debug!("Adding {} native certificates from system", system_roots.certs.len()); 
             root_store.add_parsable_certificates(system_roots.certs);
+        } else {
+            debug!("Not adding native certificates");
         }
         // Add any extra certs
         if let Some(certs) = &self.add_certs{
             let mut loaded_certs = Vec::new();
             for path in certs {
                 let cert = CertificateDer::from_pem_file(path)
-                    .with_context(|_| PemParseSnafu{path: path.clone()})?;
+                    .with_context(|_| ParsePemSnafu{path: path.clone()})?;
                 loaded_certs.push(cert);
             }
             root_store.add_parsable_certificates(loaded_certs);
@@ -205,9 +224,9 @@ impl TlsOptions{
         match self.cert.as_ref() {
             Some(path) => {
                 let certs = CertificateDer::pem_file_iter(path)
-                    .with_context(|_| PemParseSnafu{path: path.clone()})?
+                    .with_context(|_| ParsePemSnafu{path: path.clone()})?
                     .collect::<Result<Vec<_>, _>>()
-                    .with_context(|_| PemParseSnafu{path: path.clone()})?;
+                    .with_context(|_| ParsePemSnafu{path: path.clone()})?;
                 Ok(Some(certs))
             }
             None => Ok(None),
@@ -221,7 +240,7 @@ impl TlsOptions{
                 let mut loaded_crls = Vec::new();
                 for path in crls {
                     let crl = CertificateRevocationListDer::from_pem_file(path)
-                        .with_context(|_| PemParseSnafu{path: path.clone()})?;
+                        .with_context(|_| ParsePemSnafu{path: path.clone()})?;
                     loaded_crls.push(crl);
                 }
                 Ok(Some(loaded_crls))
@@ -233,8 +252,8 @@ impl TlsOptions{
     /// Map selected protocol versions to rustls types
     fn protocol_versions(&self) -> Vec<&'static SupportedProtocolVersion> {
         self.protocol_versions.iter().map(|v| match v {
-            TLSProtocolVersion::TLS1_2 => &rustls::version::TLS12,
-            TLSProtocolVersion::TLS1_3 => &rustls::version::TLS13
+            TlsProtocolVersion::TLS1_2 => &rustls::version::TLS12,
+            TlsProtocolVersion::TLS1_3 => &rustls::version::TLS13,
         }).collect()
     }
 
@@ -245,17 +264,29 @@ impl TlsOptions{
         let provider = match self.crypto_provider {
             CryptoProvider::AwsLC => rustls::crypto::aws_lc_rs::default_provider(),
         };
+
+        if self.peer_cert == PeerCertOption::Ignore {
+            tracing::warn!("It is dangerous to skip server peer certificate verification. Prefer registering trusted certificates instead.");
+        }
+
         let builder = ClientConfig::builder_with_provider(provider.into())
             .with_protocol_versions(self.protocol_versions().as_slice())
-            .context(RustlsSnafu)?
-            .with_root_certificates(self.root_cert_store()?);
+            .context(SetProtocolVersionsSnafu)?;
+
+        let builder = if self.peer_cert == PeerCertOption::Ignore {
+            builder
+                .dangerous().with_custom_certificate_verifier(SkipServerCertVerification::new())
+        } else {
+            builder.with_root_certificates(self.root_cert_store()?)
+        };
+
         match (self.certs()?, &self.key) {
             (Some(certs), Some(key)) => {
                 debug!("Using client certificate authentication");
                 let key = PrivateKeyDer::from_pem_file(key)
-                    .with_context(|_| PemParseSnafu{path: key.clone()})?;
+                    .with_context(|_| ParsePemSnafu{path: key.clone()})?;
                 let config = builder.with_client_auth_cert(certs, key)
-                    .context(RustlsSnafu)?;
+                    .context(SetCertificateSnafu)?;
                 Ok(config)
             }
             (Some(_), None) => {
@@ -277,7 +308,7 @@ impl TlsOptions{
         };
         let builder = ServerConfig::builder_with_provider(provider.clone())
             .with_protocol_versions(self.protocol_versions().as_slice())
-            .context(RustlsSnafu)?;
+            .context(SetProtocolVersionsSnafu)?;
         let builder = if let PeerCertOption::Ignore = self.peer_cert {
             builder.with_no_client_auth()
         } else {
@@ -288,19 +319,19 @@ impl TlsOptions{
                 cert_verifier = cert_verifier.with_crls(crl_paths);
             }
             if acceptor_options.allow_unauthenticated {
-                info!("Allowing unauthenticated clients");
+                debug!("Allowing unauthenticated clients");
                 cert_verifier = cert_verifier.allow_unauthenticated();
             }
             let cert_verifier = cert_verifier.build()
-                .context(CertificateVerifierSnafu)?;
+                .context(BuildCertificateVerifierSnafu)?;
             builder.with_client_cert_verifier(cert_verifier)
         };
         match (self.certs()?, &self.key) {
             (Some(certs), Some(key)) => {
                 let key = PrivateKeyDer::from_pem_file(key)
-                    .with_context(|_| PemParseSnafu{path: key.clone()})?;
+                    .with_context(|_| ParsePemSnafu { path: key.clone() })?;
                 let config = builder.with_single_cert(certs, key)
-                    .context(RustlsSnafu)?;
+                    .context(SetCertificateSnafu)?;
                 Ok(config)
             }
             (Some(_), None) => {
@@ -310,5 +341,70 @@ impl TlsOptions{
                 ConfigSnafu{ missing: MissingPemObject::Certificate }.fail()
             }
         }
+    }
+}
+
+#[cfg(feature = "tls")]
+#[derive(Debug)]
+struct SkipServerCertVerification;
+
+#[cfg(feature = "tls")]
+impl SkipServerCertVerification {
+    fn new() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(SkipServerCertVerification)
+    }
+}
+
+#[cfg(feature = "tls")]
+impl rustls::client::danger::ServerCertVerifier for SkipServerCertVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        use rustls::SignatureScheme::*;
+        vec![
+            RSA_PKCS1_SHA1,
+            ECDSA_SHA1_Legacy,
+            RSA_PKCS1_SHA256,
+            ECDSA_NISTP256_SHA256,
+            RSA_PKCS1_SHA384,
+            ECDSA_NISTP384_SHA384,
+            RSA_PKCS1_SHA512,
+            ECDSA_NISTP521_SHA512,
+            RSA_PSS_SHA256,
+            RSA_PSS_SHA384,
+            RSA_PSS_SHA512,
+            ED25519,
+            ED448,
+            ML_DSA_44,
+            ML_DSA_65,
+            ML_DSA_87,
+        ]
     }
 }

--- a/storescp/src/main.rs
+++ b/storescp/src/main.rs
@@ -115,8 +115,8 @@ fn main() {
             .with_max_level(Level::INFO)
             .with_env_filter(
                 EnvFilter::from_default_env()
-                    .add_directive("dicom_app_common=info".parse().unwrap())
-                    .add_directive(if app.verbose { "dicom_storescp=debug".parse().unwrap() } else { "dicom_storescp=info".parse().unwrap() })
+                    .add_directive(if app.verbose { "dicom_app_common=debug" } else { "dicom_app_common=info" }.parse().unwrap() )
+                    .add_directive(if app.verbose { "dicom_storescp=debug" } else { "dicom_storescp=info" }.parse().unwrap())
             )
             .finish(),
     )

--- a/storescu/src/main.rs
+++ b/storescu/src/main.rs
@@ -245,7 +245,8 @@ fn main() {
             .with_env_filter(
                 EnvFilter::from_default_env()
                     .add_directive("dicom_app_common=info".parse().unwrap())
-                    .add_directive(if app.verbose { "dicom_storescu=debug".parse().unwrap() } else { "dicom_storescu=info".parse().unwrap() })
+                    .add_directive(if app.verbose { "dicom_storescu=debug" } else { "dicom_storescu=info" }.parse().unwrap())
+                    .add_directive(if app.verbose { "dicom_app_common=debug" } else { "dicom_app_common=info" }.parse().unwrap())
             )
             .finish(),
     )


### PR DESCRIPTION
Just a few clean-ups and bug fixes here and there.

- Bring support for `PeerCert::Ignore` when setting up a TLS client, via a server certificate verifier that skips verification.
   - A warning is always raised in clients when this option is set, because one should rather add trusted certificates on this end.
- Rename `TLSProtocolVersion` to `TlsProtocolVersion`
- Fix system roots flag option, which had `ArgAction::SetFalse` when it should have been enabled on `--system-roots`
- Rename a few error type variants and split others
   - remove anti-pattern of Io and Rustls error wrappers, replace them with more informative variants
- make error type non-exhaustive
- enabled use of value delimiter in suitable args, so that comma-separated values would actually work
- Adjust documentation

- [storescp] [storescu] adjust log filters: add `dicom_app_common=debug` in verbose mode
