### PR TITLE
Fix invalid array declaration in encode_tag

### DIFF
--- a/encoding/src/encode/explicit_be.rs
+++ b/encoding/src/encode/explicit_be.rs
@@ -86,7 +86,7 @@ impl Encode for ExplicitVRBigEndianEncoder {
     where
         W: Write,
     {
-        let mut buf = [0u8, 4];
+        let mut buf = [0u8; 4];
         BigEndian::write_u16(&mut buf[..], tag.group());
         BigEndian::write_u16(&mut buf[2..], tag.element());
         to.write_all(&buf).context(WriteTagSnafu)

--- a/encoding/src/encode/explicit_le.rs
+++ b/encoding/src/encode/explicit_le.rs
@@ -85,7 +85,7 @@ impl Encode for ExplicitVRLittleEndianEncoder {
     where
         W: Write,
     {
-        let mut buf = [0u8, 4];
+        let mut buf = [0u8; 4];
         LittleEndian::write_u16(&mut buf[..], tag.group());
         LittleEndian::write_u16(&mut buf[2..], tag.element());
         to.write_all(&buf).context(WriteTagSnafu)

--- a/encoding/src/encode/implicit_le.rs
+++ b/encoding/src/encode/implicit_le.rs
@@ -85,7 +85,7 @@ impl Encode for ImplicitVRLittleEndianEncoder {
     where
         W: Write,
     {
-        let mut buf = [0u8, 4];
+        let mut buf = [0u8; 4];
         LittleEndian::write_u16(&mut buf[..], tag.group());
         LittleEndian::write_u16(&mut buf[2..], tag.element());
         to.write_all(&buf).context(WriteTagSnafu)


### PR DESCRIPTION
Previously array of 2 elements were created instead of 4 element array