### PR TITLE
Fix DICOM UL AE title field length validation

### DIFF
--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -74,6 +74,17 @@ pub enum WriteError {
         #[snafu(backtrace)]
         source: dicom_encoding::text::EncodeTextError,
     },
+
+    #[snafu(display(
+        "Invalid fixed-size text field `{field}`: {reason} (encoded length {actual_length}, field length {length})"
+    ))]
+    InvalidFixedSizeTextField {
+        field: &'static str,
+        length: usize,
+        actual_length: usize,
+        reason: &'static str,
+        backtrace: Backtrace,
+    },
 }
 
 #[derive(Debug, Snafu)]

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -9,6 +9,8 @@ pub type Error = crate::pdu::WriteError;
 
 pub type Result<T> = std::result::Result<T, WriteError>;
 
+const AE_TITLE_FIELD_LENGTH: usize = 16;
+
 #[derive(Debug, Snafu)]
 pub enum WriteChunkError {
     #[snafu(display("Failed to build chunk"))]
@@ -66,6 +68,38 @@ where
     Ok(())
 }
 
+/// Encode an AE title for a fixed 16-byte association PDU field.
+///
+/// Rejects values that encode to all spaces or more than 16 bytes, and pads shorter
+/// encoded values with spaces to preserve the DICOM UL field layout.
+fn encode_ae_title(ae_title: &str, field: &'static str, codec: &dyn TextCodec) -> Result<Vec<u8>> {
+    let mut bytes = codec.encode(ae_title).context(EncodeFieldSnafu { field })?;
+
+    if bytes.iter().all(|&byte| byte == b' ') {
+        return InvalidFixedSizeTextFieldSnafu {
+            field,
+            length: AE_TITLE_FIELD_LENGTH,
+            actual_length: bytes.len(),
+            reason: "must contain at least one non-space character",
+        }
+        .fail();
+    }
+
+    if bytes.len() > AE_TITLE_FIELD_LENGTH {
+        return InvalidFixedSizeTextFieldSnafu {
+            field,
+            length: AE_TITLE_FIELD_LENGTH,
+            actual_length: bytes.len(),
+            reason: "exceeds fixed field length",
+        }
+        .fail();
+    }
+
+    bytes.resize(AE_TITLE_FIELD_LENGTH, b' ');
+
+    Ok(bytes)
+}
+
 pub fn write_pdu<W>(writer: &mut W, pdu: &Pdu) -> Result<()>
 where
     W: Write,
@@ -80,6 +114,11 @@ where
             presentation_contexts,
             user_variables,
         }) => {
+            let called_ae_title_bytes =
+                encode_ae_title(called_ae_title, "Called-AE-title", &codec)?;
+            let calling_ae_title_bytes =
+                encode_ae_title(calling_ae_title, "Calling-AE-title", &codec)?;
+
             // A-ASSOCIATE-RQ PDU Structure
 
             // 1 - PDU-type - 01H
@@ -116,28 +155,22 @@ where
                 // leading and trailing spaces (20H) being non-significant. The value made of 16
                 // spaces (20H) meaning "no Application Name specified" shall not be used. For a
                 // complete description of the use of this field, see Section 7.1.1.4.
-                let mut ae_title_bytes =
-                    codec.encode(called_ae_title).context(EncodeFieldSnafu {
+                writer
+                    .write_all(&called_ae_title_bytes)
+                    .context(WriteFieldSnafu {
                         field: "Called-AE-title",
                     })?;
-                ae_title_bytes.resize(16, b' ');
-                writer.write_all(&ae_title_bytes).context(WriteFieldSnafu {
-                    field: "Called-AE-title",
-                })?;
 
                 // 27-42 - Calling-AE-title - Source DICOM Application Name. It shall be encoded
                 // as 16 characters as defined by the ISO 646:1990-Basic G0 Set with leading and
                 // trailing spaces (20H) being non-significant. The value made of 16 spaces
                 // (20H) meaning "no Application Name specified" shall not be used. For a
                 // complete description of the use of this field, see Section 7.1.1.3.
-                let mut ae_title_bytes =
-                    codec.encode(calling_ae_title).context(EncodeFieldSnafu {
+                writer
+                    .write_all(&calling_ae_title_bytes)
+                    .context(WriteFieldSnafu {
                         field: "Calling-AE-title",
                     })?;
-                ae_title_bytes.resize(16, b' ');
-                writer.write_all(&ae_title_bytes).context(WriteFieldSnafu {
-                    field: "Called-AE-title",
-                })?;
 
                 // 43-74 - Reserved - This reserved field shall be sent with a value 00H for all
                 // bytes but not tested to this value when received
@@ -177,6 +210,11 @@ where
             presentation_contexts,
             user_variables,
         }) => {
+            let called_ae_title_bytes =
+                encode_ae_title(called_ae_title, "Called-AE-title", &codec)?;
+            let calling_ae_title_bytes =
+                encode_ae_title(calling_ae_title, "Calling-AE-title", &codec)?;
+
             // A-ASSOCIATE-AC PDU Structure
 
             // 1 - PDU-type - 02H
@@ -211,25 +249,19 @@ where
                 // 11-26 - Reserved - This reserved field shall be sent with a value identical to
                 // the value received in the same field of the A-ASSOCIATE-RQ PDU, but its value
                 // shall not be tested when received.
-                let mut ae_title_bytes =
-                    codec.encode(called_ae_title).context(EncodeFieldSnafu {
+                writer
+                    .write_all(&called_ae_title_bytes)
+                    .context(WriteFieldSnafu {
                         field: "Called-AE-title",
                     })?;
-                ae_title_bytes.resize(16, b' ');
-                writer.write_all(&ae_title_bytes).context(WriteFieldSnafu {
-                    field: "Called-AE-title",
-                })?;
                 // 27-42 - Reserved - This reserved field shall be sent with a value identical to
                 // the value received in the same field of the A-ASSOCIATE-RQ PDU, but its value
                 // shall not be tested when received.
-                let mut ae_title_bytes =
-                    codec.encode(calling_ae_title).context(EncodeFieldSnafu {
+                writer
+                    .write_all(&calling_ae_title_bytes)
+                    .context(WriteFieldSnafu {
                         field: "Calling-AE-title",
                     })?;
-                ae_title_bytes.resize(16, b' ');
-                writer.write_all(&ae_title_bytes).context(WriteFieldSnafu {
-                    field: "Calling-AE-title",
-                })?;
 
                 // 43-74 - Reserved - This reserved field shall be sent with a value identical to
                 // the value received in the same field of the A-ASSOCIATE-RQ PDU, but its value

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -70,8 +70,11 @@ where
 
 /// Encode an AE title for a fixed 16-byte association PDU field.
 ///
-/// Rejects values that encode to all spaces or more than 16 bytes, and pads shorter
-/// encoded values with spaces to preserve the DICOM UL field layout.
+/// Called-AE-title and Calling-AE-title fields are encoded as 16 characters
+/// using the ISO 646:1990 Basic G0 Set. Leading and trailing spaces are
+/// non-significant, and an all-space value means "no Application Name specified".
+/// Rejects values that encode to all spaces or more than 16 bytes, and pads
+/// shorter encoded values with spaces to preserve the DICOM UL field layout.
 fn encode_ae_title(ae_title: &str, field: &'static str, codec: &dyn TextCodec) -> Result<Vec<u8>> {
     let mut bytes = codec.encode(ae_title).context(EncodeFieldSnafu { field })?;
 
@@ -114,11 +117,6 @@ where
             presentation_contexts,
             user_variables,
         }) => {
-            let called_ae_title_bytes =
-                encode_ae_title(called_ae_title, "Called-AE-title", &codec)?;
-            let calling_ae_title_bytes =
-                encode_ae_title(calling_ae_title, "Calling-AE-title", &codec)?;
-
             // A-ASSOCIATE-RQ PDU Structure
 
             // 1 - PDU-type - 01H
@@ -150,22 +148,20 @@ where
                     .write_u16::<BigEndian>(0x00)
                     .context(WriteReservedSnafu { bytes: 2_u32 })?;
 
-                // 11-26 - Called-AE-title - Destination DICOM Application Name. It shall be
-                // encoded as 16 characters as defined by the ISO 646:1990-Basic G0 Set with
-                // leading and trailing spaces (20H) being non-significant. The value made of 16
-                // spaces (20H) meaning "no Application Name specified" shall not be used. For a
-                // complete description of the use of this field, see Section 7.1.1.4.
+                // 11-26 - Called-AE-title - Destination DICOM Application Name. For a complete
+                // description of the use of this field, see Section 7.1.1.4.
+                let called_ae_title_bytes =
+                    encode_ae_title(called_ae_title, "Called-AE-title", &codec)?;
                 writer
                     .write_all(&called_ae_title_bytes)
                     .context(WriteFieldSnafu {
                         field: "Called-AE-title",
                     })?;
 
-                // 27-42 - Calling-AE-title - Source DICOM Application Name. It shall be encoded
-                // as 16 characters as defined by the ISO 646:1990-Basic G0 Set with leading and
-                // trailing spaces (20H) being non-significant. The value made of 16 spaces
-                // (20H) meaning "no Application Name specified" shall not be used. For a
-                // complete description of the use of this field, see Section 7.1.1.3.
+                // 27-42 - Calling-AE-title - Source DICOM Application Name. For a complete
+                // description of the use of this field, see Section 7.1.1.3.
+                let calling_ae_title_bytes =
+                    encode_ae_title(calling_ae_title, "Calling-AE-title", &codec)?;
                 writer
                     .write_all(&calling_ae_title_bytes)
                     .context(WriteFieldSnafu {
@@ -210,11 +206,6 @@ where
             presentation_contexts,
             user_variables,
         }) => {
-            let called_ae_title_bytes =
-                encode_ae_title(called_ae_title, "Called-AE-title", &codec)?;
-            let calling_ae_title_bytes =
-                encode_ae_title(calling_ae_title, "Calling-AE-title", &codec)?;
-
             // A-ASSOCIATE-AC PDU Structure
 
             // 1 - PDU-type - 02H
@@ -249,6 +240,8 @@ where
                 // 11-26 - Reserved - This reserved field shall be sent with a value identical to
                 // the value received in the same field of the A-ASSOCIATE-RQ PDU, but its value
                 // shall not be tested when received.
+                let called_ae_title_bytes =
+                    encode_ae_title(called_ae_title, "Called-AE-title", &codec)?;
                 writer
                     .write_all(&called_ae_title_bytes)
                     .context(WriteFieldSnafu {
@@ -257,6 +250,8 @@ where
                 // 27-42 - Reserved - This reserved field shall be sent with a value identical to
                 // the value received in the same field of the A-ASSOCIATE-RQ PDU, but its value
                 // shall not be tested when received.
+                let calling_ae_title_bytes =
+                    encode_ae_title(calling_ae_title, "Calling-AE-title", &codec)?;
                 writer
                     .write_all(&calling_ae_title_bytes)
                     .context(WriteFieldSnafu {

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -73,12 +73,17 @@ where
 /// Called-AE-title and Calling-AE-title fields are encoded as 16 characters
 /// using the ISO 646:1990 Basic G0 Set. Leading and trailing spaces are
 /// non-significant, and an all-space value means "no Application Name specified".
-/// Rejects values that encode to all spaces or more than 16 bytes, and pads
-/// shorter encoded values with spaces to preserve the DICOM UL field layout.
-fn encode_ae_title(ae_title: &str, field: &'static str, codec: &dyn TextCodec) -> Result<Vec<u8>> {
+/// Rejects values longer than 16 bytes, optionally rejects all-space values, and
+/// pads shorter encoded values with spaces to preserve the DICOM UL field layout.
+fn encode_ae_title(
+    ae_title: &str,
+    field: &'static str,
+    codec: &dyn TextCodec,
+    validate_value: bool,
+) -> Result<Vec<u8>> {
     let mut bytes = codec.encode(ae_title).context(EncodeFieldSnafu { field })?;
 
-    if bytes.iter().all(|&byte| byte == b' ') {
+    if validate_value && bytes.iter().all(|&byte| byte == b' ') {
         return InvalidFixedSizeTextFieldSnafu {
             field,
             length: AE_TITLE_FIELD_LENGTH,
@@ -151,7 +156,7 @@ where
                 // 11-26 - Called-AE-title - Destination DICOM Application Name. For a complete
                 // description of the use of this field, see Section 7.1.1.4.
                 let called_ae_title_bytes =
-                    encode_ae_title(called_ae_title, "Called-AE-title", &codec)?;
+                    encode_ae_title(called_ae_title, "Called-AE-title", &codec, true)?;
                 writer
                     .write_all(&called_ae_title_bytes)
                     .context(WriteFieldSnafu {
@@ -161,7 +166,7 @@ where
                 // 27-42 - Calling-AE-title - Source DICOM Application Name. For a complete
                 // description of the use of this field, see Section 7.1.1.3.
                 let calling_ae_title_bytes =
-                    encode_ae_title(calling_ae_title, "Calling-AE-title", &codec)?;
+                    encode_ae_title(calling_ae_title, "Calling-AE-title", &codec, true)?;
                 writer
                     .write_all(&calling_ae_title_bytes)
                     .context(WriteFieldSnafu {
@@ -241,7 +246,7 @@ where
                 // the value received in the same field of the A-ASSOCIATE-RQ PDU, but its value
                 // shall not be tested when received.
                 let called_ae_title_bytes =
-                    encode_ae_title(called_ae_title, "Called-AE-title", &codec)?;
+                    encode_ae_title(called_ae_title, "Called-AE-title", &codec, false)?;
                 writer
                     .write_all(&called_ae_title_bytes)
                     .context(WriteFieldSnafu {
@@ -251,7 +256,7 @@ where
                 // the value received in the same field of the A-ASSOCIATE-RQ PDU, but its value
                 // shall not be tested when received.
                 let calling_ae_title_bytes =
-                    encode_ae_title(calling_ae_title, "Calling-AE-title", &codec)?;
+                    encode_ae_title(calling_ae_title, "Calling-AE-title", &codec, false)?;
                 writer
                     .write_all(&calling_ae_title_bytes)
                     .context(WriteFieldSnafu {

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -2,7 +2,7 @@
 use crate::pdu::*;
 use byteordered::byteorder::{BigEndian, WriteBytesExt};
 use dicom_encoding::text::TextCodec;
-use snafu::{Backtrace, ResultExt, Snafu};
+use snafu::{Backtrace, ResultExt, Snafu, ensure};
 use std::io::Write;
 
 pub type Error = crate::pdu::WriteError;
@@ -83,25 +83,25 @@ fn encode_ae_title(
 ) -> Result<Vec<u8>> {
     let mut bytes = codec.encode(ae_title).context(EncodeFieldSnafu { field })?;
 
-    if validate_value && bytes.iter().all(|&byte| byte == b' ') {
-        return InvalidFixedSizeTextFieldSnafu {
-            field,
-            length: AE_TITLE_FIELD_LENGTH,
-            actual_length: bytes.len(),
-            reason: "must contain at least one non-space character",
-        }
-        .fail();
-    }
-
-    if bytes.len() > AE_TITLE_FIELD_LENGTH {
-        return InvalidFixedSizeTextFieldSnafu {
+    ensure!(
+        bytes.len() <= AE_TITLE_FIELD_LENGTH,
+        InvalidFixedSizeTextFieldSnafu {
             field,
             length: AE_TITLE_FIELD_LENGTH,
             actual_length: bytes.len(),
             reason: "exceeds fixed field length",
         }
-        .fail();
-    }
+    );
+
+    ensure!(
+        !validate_value || bytes.iter().any(|&byte| byte != b' '),
+        InvalidFixedSizeTextFieldSnafu {
+            field,
+            length: AE_TITLE_FIELD_LENGTH,
+            actual_length: bytes.len(),
+            reason: "must contain at least one non-space character",
+        }
+    );
 
     bytes.resize(AE_TITLE_FIELD_LENGTH, b' ');
 


### PR DESCRIPTION
The A-ASSOCIATE writer encoded the Called/Calling AE titles and then called `resize(16, b' ')`. Invalid values slipped through: empty and all-space titles were written as the forbidden all-spaces field, and titles longer than 16 bytes were silently truncated.

DICOM PS3.8 §9.3.2 defines both as fixed 16-byte fields where the all-spaces value is not allowed. This adds a shared writer helper that pads valid shorter titles to 16 bytes and returns `WriteError::InvalidFixedSizeTextField` for empty, all-space, or overlong titles, used for both A-ASSOCIATE-RQ and A-ASSOCIATE-AC.