### PR TITLE
Validate fixed PDU lengths and encoded item length overflow

### DIFF
--- a/storescp/src/main.rs
+++ b/storescp/src/main.rs
@@ -31,6 +31,9 @@ struct App {
     /// Enforce max pdu length
     #[arg(short = 's', long = "strict")]
     strict: bool,
+    /// Reject trailing bytes in fixed-length PDUs
+    #[arg(long)]
+    reject_trailing_fixed_pdu_bytes: bool,
     /// Only accept native/uncompressed transfer syntaxes
     #[arg(long)]
     uncompressed_only: bool,

--- a/storescp/src/store_async.rs
+++ b/storescp/src/store_async.rs
@@ -22,6 +22,7 @@ pub(crate) async fn run_store_async(
         verbose,
         calling_ae_title,
         strict,
+        reject_trailing_fixed_pdu_bytes,
         uncompressed_only,
         promiscuous,
         max_pdu_length,
@@ -38,6 +39,7 @@ pub(crate) async fn run_store_async(
         .accept_any()
         .ae_title(calling_ae_title)
         .strict(*strict)
+        .allow_trailing_fixed_pdu_bytes(!*reject_trailing_fixed_pdu_bytes)
         .max_pdu_length(*max_pdu_length)
         .promiscuous(*promiscuous);
 

--- a/storescp/src/store_sync.rs
+++ b/storescp/src/store_sync.rs
@@ -19,6 +19,7 @@ pub(crate) fn run_store_sync(scu_stream: TcpStream, args: &App) -> Result<(), Wh
         verbose,
         calling_ae_title,
         strict,
+        reject_trailing_fixed_pdu_bytes,
         uncompressed_only,
         promiscuous,
         max_pdu_length,
@@ -35,6 +36,7 @@ pub(crate) fn run_store_sync(scu_stream: TcpStream, args: &App) -> Result<(), Wh
         .accept_any()
         .ae_title(calling_ae_title)
         .strict(*strict)
+        .allow_trailing_fixed_pdu_bytes(!*reject_trailing_fixed_pdu_bytes)
         .max_pdu_length(*max_pdu_length)
         .promiscuous(*promiscuous);
 

--- a/storescu/src/main.rs
+++ b/storescu/src/main.rs
@@ -53,6 +53,9 @@ struct App {
         value_parser(clap::value_parser!(u32).range(1018..))
     )]
     max_pdu_length: u32,
+    /// Reject trailing bytes in fixed-length PDUs
+    #[arg(long)]
+    reject_trailing_fixed_pdu_bytes: bool,
     /// fail if not all DICOM files can be transferred
     #[arg(long = "fail-first")]
     fail_first: bool,
@@ -187,6 +190,7 @@ pub(crate) fn get_scu_options<'a>(
     calling_ae_title: String,
     called_ae_title: Option<String>,
     max_pdu_length: u32,
+    reject_trailing_fixed_pdu_bytes: bool,
     username: Option<String>,
     password: Option<String>,
     kerberos_service_ticket: Option<String>,
@@ -197,7 +201,8 @@ pub(crate) fn get_scu_options<'a>(
 ) -> ClientAssociationOptions<'a> {
     let mut scu_init = ClientAssociationOptions::new()
         .calling_ae_title(calling_ae_title)
-        .max_pdu_length(max_pdu_length);
+        .max_pdu_length(max_pdu_length)
+        .allow_trailing_fixed_pdu_bytes(!reject_trailing_fixed_pdu_bytes);
 
     #[cfg(feature = "tls")]
     {
@@ -361,6 +366,7 @@ fn run(app: App) -> Result<(), Error> {
         calling_ae_title,
         called_ae_title,
         max_pdu_length,
+        reject_trailing_fixed_pdu_bytes,
         fail_first,
         mut never_transcode,
         ignore_sop_class,
@@ -398,6 +404,7 @@ fn run(app: App) -> Result<(), Error> {
         calling_ae_title,
         called_ae_title,
         max_pdu_length,
+        reject_trailing_fixed_pdu_bytes,
         username,
         password,
         kerberos_service_ticket,
@@ -464,6 +471,7 @@ async fn run_async() -> Result<(), Error> {
         calling_ae_title,
         called_ae_title,
         max_pdu_length,
+        reject_trailing_fixed_pdu_bytes,
         fail_first,
         mut never_transcode,
         ignore_sop_class,
@@ -538,6 +546,7 @@ async fn run_async() -> Result<(), Error> {
                 calling_ae_title,
                 called_ae_title,
                 max_pdu_length,
+                reject_trailing_fixed_pdu_bytes,
                 username,
                 password,
                 kerberos_service_ticket,

--- a/ul/src/association/client.rs
+++ b/ul/src/association/client.rs
@@ -18,13 +18,13 @@ use crate::{
     AeAddr, IMPLEMENTATION_CLASS_UID, IMPLEMENTATION_VERSION_NAME,
     association::{
         Association, NegotiatedOptions, SocketOptions, SyncAssociation, encode_pdu,
-        private::SyncAssociationSealed, read_pdu_from_wire,
+        private::SyncAssociationSealed, read_pdu_from_wire_with_options,
     },
     pdu::{
         AbortRQSource, AssociationAC, AssociationRQ, DEFAULT_MAX_PDU, LARGE_PDU_SIZE,
         MAXIMUM_PDU_SIZE, PDU_HEADER_SIZE, Pdu, PresentationContextNegotiated,
-        PresentationContextProposed, PresentationContextResultReason, RequestorRoles, UserIdentity,
-        UserIdentityType, UserVariableItem, write_pdu,
+        PresentationContextProposed, PresentationContextResultReason, ReadPduOptions,
+        RequestorRoles, UserIdentity, UserIdentityType, UserVariableItem, write_pdu,
     },
 };
 use snafu::{ResultExt, ensure};
@@ -264,6 +264,8 @@ pub struct ClientAssociationOptions<'a> {
     max_pdu_length: u32,
     /// whether to receive PDUs in strict mode
     strict: bool,
+    /// whether to accept trailing bytes in fixed-size PDU bodies
+    allow_trailing_fixed_pdu_bytes: bool,
     /// User identity username
     username: Option<Cow<'a, str>>,
     /// User identity password
@@ -302,6 +304,7 @@ impl Default for ClientAssociationOptions<'_> {
             protocol_version: 1,
             max_pdu_length: DEFAULT_MAX_PDU,
             strict: true,
+            allow_trailing_fixed_pdu_bytes: true,
             username: None,
             password: None,
             kerberos_service_ticket: None,
@@ -403,6 +406,14 @@ impl<'a> ClientAssociationOptions<'a> {
     /// surpass the negotiated maximum PDU length.
     pub fn strict(mut self, strict: bool) -> Self {
         self.strict = strict;
+        self
+    }
+
+    /// Set whether trailing bytes in fixed-size PDU bodies are accepted.
+    ///
+    /// The default is `true` for compatibility with previous releases.
+    pub fn allow_trailing_fixed_pdu_bytes(mut self, allow: bool) -> Self {
+        self.allow_trailing_fixed_pdu_bytes = allow;
         self
     }
 
@@ -931,7 +942,12 @@ impl<'a> ClientAssociationOptions<'a> {
         let mut buf = BytesMut::with_capacity(
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
-        let resp = read_pdu_from_wire(&mut socket, &mut buf, self.max_pdu_length, self.strict);
+        let resp = read_pdu_from_wire_with_options(
+            &mut socket,
+            &mut buf,
+            ReadPduOptions::new(self.max_pdu_length, self.strict)
+                .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
+        );
         // If we're in non-TLS mode and `read_pdu_from_wire` fails, it
         // could be because the server expects TLS but we sent a
         // plaintext request.  In that case, we make a best effort to
@@ -996,6 +1012,7 @@ impl<'a> ClientAssociationOptions<'a> {
                     socket,
                     write_buffer: buffer,
                     strict: self.strict,
+                    allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                     // Fixes #589, instead of creating a new buffer, we pass the existing buffer into the Association object.
                     read_buffer: buf,
                     read_timeout: self.socket_options.read_timeout,
@@ -1095,6 +1112,8 @@ pub struct ClientAssociation<S> {
     write_buffer: Vec<u8>,
     /// whether to receive PDUs in strict mode
     strict: bool,
+    /// whether to accept trailing bytes in fixed-size PDU bodies
+    allow_trailing_fixed_pdu_bytes: bool,
     /// Timeout for individual socket Reads
     read_timeout: Option<Duration>,
     /// Timeout for individual socket Writes.
@@ -1137,6 +1156,10 @@ where
     /// (the association acceptor) is expecting to receive.
     fn peer_max_pdu_length(&self) -> u32 {
         self.acceptor_max_pdu_length
+    }
+
+    fn allow_trailing_fixed_pdu_bytes(&self) -> bool {
+        self.allow_trailing_fixed_pdu_bytes
     }
 
     fn presentation_contexts(&self) -> &[PresentationContextNegotiated] {
@@ -1277,11 +1300,11 @@ where
 
     /// Read a PDU message from the other intervenient.
     fn receive(&mut self) -> Result<Pdu> {
-        read_pdu_from_wire(
+        read_pdu_from_wire_with_options(
             &mut self.socket,
             &mut self.read_buffer,
-            self.requestor_max_pdu_length,
-            self.strict,
+            ReadPduOptions::new(self.requestor_max_pdu_length, self.strict)
+                .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
         )
     }
 
@@ -1404,6 +1427,8 @@ pub struct AsyncClientAssociation<S> {
     write_buffer: Vec<u8>,
     /// whether to receive PDUs in strict mode
     strict: bool,
+    /// whether to accept trailing bytes in fixed-size PDU bodies
+    allow_trailing_fixed_pdu_bytes: bool,
     /// Timeout for individual socket Reads
     read_timeout: Option<Duration>,
     /// Timeout for individual socket Writes.
@@ -1449,11 +1474,11 @@ impl<'a> ClientAssociationOptions<'a> {
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
         let resp = super::timeout(self.socket_options.read_timeout, async {
-            super::read_pdu_from_wire_async(
+            super::read_pdu_from_wire_async_with_options(
                 &mut socket,
                 &mut read_buffer,
-                self.max_pdu_length,
-                self.strict,
+                ReadPduOptions::new(self.max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
             )
             .await
         })
@@ -1481,12 +1506,7 @@ impl<'a> ClientAssociationOptions<'a> {
                                 error!("Received TLS response to non-TLS request!");
                                 return super::TlsNotSupportedSnafu.fail();
                             }
-                            // if let rustls::Error::InappropriateMessage{..} = err {
-                            //     error!("Recieved TLS response to non-TLS request!");
-                            //     return super::TlsNotSupportedSnafu.fail()
-                            // }
-                            // Recieved a valid TLS message, means the server expects TLS
-                            return super::TlsNotSupportedSnafu.fail();
+                            return Err(e);
                         }
                     }
                 }
@@ -1524,6 +1544,7 @@ impl<'a> ClientAssociationOptions<'a> {
                     socket,
                     write_buffer,
                     strict: self.strict,
+                    allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                     // Fixes #589, instead of creating a new buffer, we pass the existing buffer into the Association object.
                     read_buffer,
                     read_timeout: self.socket_options.read_timeout,
@@ -1704,6 +1725,10 @@ impl<S> Association for AsyncClientAssociation<S> {
         self.acceptor_max_pdu_length
     }
 
+    fn allow_trailing_fixed_pdu_bytes(&self) -> bool {
+        self.allow_trailing_fixed_pdu_bytes
+    }
+
     fn presentation_contexts(&self) -> &[PresentationContextNegotiated] {
         &self.presentation_contexts
     }
@@ -1846,13 +1871,13 @@ where
     }
 
     async fn receive(&mut self) -> Result<Pdu> {
-        use crate::association::read_pdu_from_wire_async;
+        use crate::association::read_pdu_from_wire_async_with_options;
         super::timeout(self.read_timeout, async {
-            read_pdu_from_wire_async(
+            read_pdu_from_wire_async_with_options(
                 &mut self.socket,
                 &mut self.read_buffer,
-                self.requestor_max_pdu_length,
-                self.strict,
+                ReadPduOptions::new(self.requestor_max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
             )
             .await
         })
@@ -1888,7 +1913,7 @@ where
 mod tests {
     use super::*;
     #[cfg(feature = "async")]
-    use crate::association::read_pdu_from_wire_async;
+    use crate::association::read_pdu_from_wire_async_with_options;
     use std::io::Write;
 
     impl<'a> ClientAssociationOptions<'a> {
@@ -1918,11 +1943,11 @@ mod tests {
             let mut read_buffer = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let resp = read_pdu_from_wire(
+            let resp = read_pdu_from_wire_with_options(
                 &mut socket,
                 &mut read_buffer,
-                self.max_pdu_length,
-                self.strict,
+                ReadPduOptions::new(self.max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
             )?;
             let NegotiatedOptions {
                 presentation_contexts,
@@ -1939,6 +1964,7 @@ mod tests {
                 socket,
                 write_buffer,
                 strict: self.strict,
+                allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                 // Fixes #589, instead of creating a new buffer, we pass the existing buffer into the Association object.
                 read_buffer,
                 read_timeout: self.socket_options.read_timeout,
@@ -1978,9 +2004,13 @@ mod tests {
             let mut buf = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let resp =
-                read_pdu_from_wire_async(&mut socket, &mut buf, self.max_pdu_length, self.strict)
-                    .await?;
+            let resp = read_pdu_from_wire_async_with_options(
+                &mut socket,
+                &mut buf,
+                ReadPduOptions::new(self.max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
+            )
+            .await?;
             let NegotiatedOptions {
                 presentation_contexts,
                 peer_max_pdu_length,
@@ -1996,6 +2026,7 @@ mod tests {
                 socket,
                 write_buffer: buffer,
                 strict: self.strict,
+                allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                 // Fixes #589, instead of creating a new buffer, we pass the existing buffer into the Association object.
                 read_buffer: buf,
                 read_timeout: self.socket_options.read_timeout,
@@ -2027,7 +2058,12 @@ mod tests {
             let mut buf = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let resp = read_pdu_from_wire(&mut socket, &mut buf, self.max_pdu_length, self.strict)?;
+            let resp = read_pdu_from_wire_with_options(
+                &mut socket,
+                &mut buf,
+                ReadPduOptions::new(self.max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
+            )?;
             let NegotiatedOptions {
                 presentation_contexts,
                 peer_max_pdu_length,
@@ -2043,6 +2079,7 @@ mod tests {
                 socket,
                 write_buffer: buffer,
                 strict: self.strict,
+                allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                 read_buffer: BytesMut::with_capacity(
                     (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
                 ),
@@ -2079,9 +2116,13 @@ mod tests {
             let mut buf = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let resp =
-                read_pdu_from_wire_async(&mut socket, &mut buf, self.max_pdu_length, self.strict)
-                    .await?;
+            let resp = read_pdu_from_wire_async_with_options(
+                &mut socket,
+                &mut buf,
+                ReadPduOptions::new(self.max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
+            )
+            .await?;
             let NegotiatedOptions {
                 presentation_contexts,
                 peer_max_pdu_length,
@@ -2097,6 +2138,7 @@ mod tests {
                 socket,
                 write_buffer: buffer,
                 strict: self.strict,
+                allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                 read_buffer: BytesMut::with_capacity(
                     (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
                 ),

--- a/ul/src/association/mod.rs
+++ b/ul/src/association/mod.rs
@@ -46,8 +46,8 @@ use snafu::{ResultExt, Snafu, ensure};
 use crate::{
     Pdu,
     pdu::{
-        self, AssociationRJ, PresentationContextNegotiated, ReadPduSnafu, RequestorRoles,
-        UserVariableItem,
+        self, AssociationRJ, PresentationContextNegotiated, ReadPduOptions, ReadPduSnafu,
+        RequestorRoles, UserVariableItem,
     },
     write_pdu,
 };
@@ -292,6 +292,13 @@ pub trait Association {
     /// for client objects.
     fn peer_max_pdu_length(&self) -> u32;
 
+    /// Whether to accept trailing bytes in fixed-size PDU bodies.
+    ///
+    /// This defaults to `true` for compatibility with previous releases.
+    fn allow_trailing_fixed_pdu_bytes(&self) -> bool {
+        true
+    }
+
     /// Obtain a view of the negotiated presentation contexts.
     fn presentation_contexts(&self) -> &[PresentationContextNegotiated];
 
@@ -530,8 +537,10 @@ pub trait SyncAssociation<S: std::io::Read + std::io::Write + CloseSocket>:
     /// receives more data PDUs once the bytes collected are consumed.
     fn receive_pdata(&mut self) -> PDataReader<'_, &mut S> {
         let max_pdu_length = self.local_max_pdu_length();
+        let allow_trailing_fixed_pdu_bytes = self.allow_trailing_fixed_pdu_bytes();
         let (socket, read_buffer) = self.get_mut();
         PDataReader::new(socket, max_pdu_length, read_buffer)
+            .allow_trailing_fixed_pdu_bytes(allow_trailing_fixed_pdu_bytes)
     }
 }
 
@@ -613,8 +622,10 @@ pub trait AsyncAssociation<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unp
     /// receives more data PDUs once the bytes collected are consumed.
     fn receive_pdata(&mut self) -> PDataReader<'_, &mut S> {
         let max_pdu_length = self.local_max_pdu_length();
+        let allow_trailing_fixed_pdu_bytes = self.allow_trailing_fixed_pdu_bytes();
         let (socket, read_buffer) = self.get_mut();
         PDataReader::new(socket, max_pdu_length, read_buffer)
+            .allow_trailing_fixed_pdu_bytes(allow_trailing_fixed_pdu_bytes)
     }
 }
 
@@ -660,11 +671,31 @@ pub fn read_pdu_from_wire<R>(
 where
     R: Read,
 {
+    read_pdu_from_wire_with_options(
+        reader,
+        read_buffer,
+        ReadPduOptions::new(max_pdu_length, strict),
+    )
+}
+
+/// Helper function to get a PDU from a reader using explicit parser options.
+///
+/// Chunks of data are read into `read_buffer`,
+/// which should be passed in subsequent calls
+/// to receive more PDUs from the same stream.
+pub fn read_pdu_from_wire_with_options<R>(
+    reader: &mut R,
+    read_buffer: &mut BytesMut,
+    options: ReadPduOptions,
+) -> Result<Pdu>
+where
+    R: Read,
+{
     let mut reader = BufReader::new(reader);
     let msg = loop {
         let mut buf = Cursor::new(&read_buffer[..]);
         // try to read a PDU according to what's in the buffer
-        match pdu::read_pdu(&mut buf, max_pdu_length, strict).context(ReceivePduSnafu)? {
+        match pdu::read_pdu_with_options(&mut buf, options).context(ReceivePduSnafu)? {
             Some(pdu) => {
                 read_buffer.advance(buf.position() as usize);
                 break pdu;
@@ -699,12 +730,31 @@ pub async fn read_pdu_from_wire_async<R: tokio::io::AsyncRead + Unpin>(
     max_pdu_length: u32,
     strict: bool,
 ) -> Result<Pdu> {
+    read_pdu_from_wire_async_with_options(
+        reader,
+        read_buffer,
+        ReadPduOptions::new(max_pdu_length, strict),
+    )
+    .await
+}
+
+/// Helper function to get a PDU from an async reader using explicit parser options.
+///
+/// Chunks of data are read into `read_buffer`,
+/// which should be passed in subsequent calls
+/// to receive more PDUs from the same stream.
+#[cfg(feature = "async")]
+pub async fn read_pdu_from_wire_async_with_options<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut R,
+    read_buffer: &mut BytesMut,
+    options: ReadPduOptions,
+) -> Result<Pdu> {
     use tokio::io::AsyncReadExt;
     // receive response
 
     let msg = loop {
         let mut buf = Cursor::new(&read_buffer[..]);
-        match pdu::read_pdu(&mut buf, max_pdu_length, strict).context(ReceivePduSnafu)? {
+        match pdu::read_pdu_with_options(&mut buf, options).context(ReceivePduSnafu)? {
             Some(pdu) => {
                 read_buffer.advance(buf.position() as usize);
                 break pdu;

--- a/ul/src/association/pdata.rs
+++ b/ul/src/association/pdata.rs
@@ -8,8 +8,9 @@ use tracing::warn;
 
 use crate::{
     Pdu,
-    pdu::{LARGE_PDU_SIZE, PDU_HEADER_SIZE, PDV_HEADER_SIZE},
-    read_pdu,
+    pdu::{
+        LARGE_PDU_SIZE, PDU_HEADER_SIZE, PDV_HEADER_SIZE, ReadPduOptions, read_pdu_with_options,
+    },
 };
 
 /// Combined size of PDU header and one PDV header, as usize, for convenience
@@ -247,6 +248,7 @@ pub struct PDataReader<'a, R> {
     stream: R,
     presentation_context_id: Option<u8>,
     max_pdu_length: u32,
+    allow_trailing_fixed_pdu_bytes: bool,
     last_pdu: bool,
     read_buffer: &'a mut BytesMut,
 }
@@ -260,9 +262,18 @@ impl<'a, R> PDataReader<'a, R> {
             stream,
             presentation_context_id: None,
             max_pdu_length,
+            allow_trailing_fixed_pdu_bytes: true,
             last_pdu: false,
             read_buffer: remaining,
         }
+    }
+
+    /// Set whether trailing bytes in fixed-size PDU bodies are accepted.
+    ///
+    /// The default is `true` for compatibility with previous releases.
+    pub fn allow_trailing_fixed_pdu_bytes(mut self, allow: bool) -> Self {
+        self.allow_trailing_fixed_pdu_bytes = allow;
+        self
     }
 
     /// Declare no intention to read more PDUs from the remote node.
@@ -288,11 +299,11 @@ where
             }
 
             let mut reader = BufReader::new(&mut self.stream);
+            let options = ReadPduOptions::new(self.max_pdu_length, false)
+                .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes);
             let msg = loop {
                 let mut buf = Cursor::new(&self.read_buffer[..]);
-                match read_pdu(&mut buf, self.max_pdu_length, false)
-                    .map_err(std::io::Error::other)?
-                {
+                match read_pdu_with_options(&mut buf, options).map_err(std::io::Error::other)? {
                     Some(pdu) => {
                         self.read_buffer.advance(buf.position() as usize);
                         break pdu;
@@ -356,8 +367,7 @@ pub mod non_blocking {
 
     use crate::{
         Pdu,
-        pdu::{PDU_HEADER_SIZE, PDV_HEADER_SIZE},
-        read_pdu,
+        pdu::{PDU_HEADER_SIZE, PDV_HEADER_SIZE, ReadPduOptions, read_pdu_with_options},
     };
 
     pub use super::PDataReader;
@@ -673,14 +683,15 @@ pub mod non_blocking {
                     ref mut stream,
                     ref mut read_buffer,
                     max_pdu_length,
+                    allow_trailing_fixed_pdu_bytes,
                     ..
                 } = &mut *self;
                 let mut reader = BufReader::new(stream);
+                let options = ReadPduOptions::new(max_pdu_length, false)
+                    .allow_trailing_fixed_pdu_bytes(allow_trailing_fixed_pdu_bytes);
                 let msg = loop {
                     let mut buf = Cursor::new(&read_buffer[..]);
-                    match read_pdu(&mut buf, max_pdu_length, false)
-                        .map_err(std::io::Error::other)?
-                    {
+                    match read_pdu_with_options(&mut buf, options).map_err(std::io::Error::other)? {
                         Some(pdu) => {
                             read_buffer.advance(buf.position() as usize);
                             break pdu;

--- a/ul/src/association/server.rs
+++ b/ul/src/association/server.rs
@@ -15,7 +15,7 @@ use crate::association::private::SyncAssociationSealed;
 use crate::association::{
     AbortedSnafu, Association, CloseSocket, MissingAbstractSyntaxSnafu, RejectedSnafu,
     SendPduSnafu, SocketOptions, SyncAssociation, UnexpectedPduSnafu, UnknownPduSnafu,
-    WireSendSnafu, encode_pdu, read_pdu_from_wire,
+    WireSendSnafu, encode_pdu, read_pdu_from_wire_with_options,
 };
 use dicom_encoding::transfer_syntax::TransferSyntaxIndex;
 use dicom_transfer_syntax_registry::TransferSyntaxRegistry;
@@ -29,7 +29,7 @@ use crate::{
         AbortRQServiceProviderReason, AbortRQSource, AssociationAC, AssociationRJ,
         AssociationRJResult, AssociationRJServiceUserReason, AssociationRJSource, AssociationRQ,
         DEFAULT_MAX_PDU, PDU_HEADER_SIZE, Pdu, PresentationContextResult,
-        PresentationContextResultReason, UserIdentity, UserVariableItem, write_pdu,
+        PresentationContextResultReason, ReadPduOptions, UserIdentity, UserVariableItem, write_pdu,
     },
 };
 #[cfg(feature = "sync-tls")]
@@ -556,6 +556,8 @@ pub struct ServerAssociationOptions<'a, A, N> {
     max_pdu_length: u32,
     /// whether to receive PDUs in strict mode
     strict: bool,
+    /// whether to accept trailing bytes in fixed-size PDU bodies
+    allow_trailing_fixed_pdu_bytes: bool,
     /// whether to accept unknown abstract syntaxes
     promiscuous: bool,
     /// extended negotiation handler
@@ -578,6 +580,7 @@ impl Default for ServerAssociationOptions<'_, AcceptAny, DefaultNegotiation> {
             protocol_version: 1,
             max_pdu_length: DEFAULT_MAX_PDU,
             strict: true,
+            allow_trailing_fixed_pdu_bytes: true,
             promiscuous: false,
             negotiation: DefaultNegotiation,
             socket_options: SocketOptions::default(),
@@ -632,6 +635,7 @@ where
             protocol_version,
             max_pdu_length,
             strict,
+            allow_trailing_fixed_pdu_bytes,
             promiscuous,
             ae_access_control: _,
             negotiation,
@@ -649,6 +653,7 @@ where
             protocol_version,
             max_pdu_length,
             strict,
+            allow_trailing_fixed_pdu_bytes,
             promiscuous,
             negotiation,
             socket_options,
@@ -705,6 +710,14 @@ where
         self
     }
 
+    /// Set whether trailing bytes in fixed-size PDU bodies are accepted.
+    ///
+    /// The default is `true` for compatibility with previous releases.
+    pub fn allow_trailing_fixed_pdu_bytes(mut self, allow: bool) -> Self {
+        self.allow_trailing_fixed_pdu_bytes = allow;
+        self
+    }
+
     /// Override promiscuous mode:
     /// whether to accept unknown abstract syntaxes.
     pub fn promiscuous(mut self, promiscuous: bool) -> Self {
@@ -752,6 +765,7 @@ where
             protocol_version,
             max_pdu_length,
             strict,
+            allow_trailing_fixed_pdu_bytes,
             promiscuous,
             negotiation: _,
             socket_options,
@@ -768,6 +782,7 @@ where
             protocol_version,
             max_pdu_length,
             strict,
+            allow_trailing_fixed_pdu_bytes,
             promiscuous,
             negotiation,
             socket_options,
@@ -1022,11 +1037,11 @@ where
         let mut read_buffer = BytesMut::with_capacity(
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
-        let msg = read_pdu_from_wire(
+        let msg = read_pdu_from_wire_with_options(
             &mut socket,
             &mut read_buffer,
-            self.max_pdu_length,
-            self.strict,
+            ReadPduOptions::new(self.max_pdu_length, self.strict)
+                .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
         );
         // If we're compiling with the sync-tls feature, check to see if the error
         // may have been caused by the client associating with TLS but the server
@@ -1066,6 +1081,7 @@ where
                     client_ae_title: peer_ae_title,
                     write_buffer,
                     strict: self.strict,
+                    allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                     read_buffer,
                     user_variables,
                     called_ae_title,
@@ -1105,11 +1121,11 @@ where
             (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
         );
 
-        let msg = read_pdu_from_wire(
+        let msg = read_pdu_from_wire_with_options(
             &mut tls_stream,
             &mut read_buffer,
-            self.max_pdu_length,
-            self.strict,
+            ReadPduOptions::new(self.max_pdu_length, self.strict)
+                .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
         )?;
         let mut write_buffer: Vec<u8> =
             Vec::with_capacity((DEFAULT_MAX_PDU + PDU_HEADER_SIZE) as usize);
@@ -1134,6 +1150,7 @@ where
                     client_ae_title: peer_ae_title,
                     write_buffer,
                     strict: self.strict,
+                    allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                     read_buffer,
                     user_variables,
                     called_ae_title,
@@ -1206,6 +1223,8 @@ pub struct ServerAssociation<S> {
     write_buffer: Vec<u8>,
     /// whether to receive PDUs in strict mode
     strict: bool,
+    /// whether to accept trailing bytes in fixed-size PDU bodies
+    allow_trailing_fixed_pdu_bytes: bool,
     /// Read buffer from the socket
     read_buffer: bytes::BytesMut,
     /// User variables received from the peer
@@ -1335,6 +1354,10 @@ where
         self.requestor_max_pdu_length
     }
 
+    fn allow_trailing_fixed_pdu_bytes(&self) -> bool {
+        self.allow_trailing_fixed_pdu_bytes
+    }
+
     /// Obtain the remote DICOM node's application entity title.
     fn peer_ae_title(&self) -> &str {
         &self.client_ae_title
@@ -1366,11 +1389,11 @@ where
     }
 
     fn receive(&mut self) -> Result<Pdu> {
-        read_pdu_from_wire(
+        read_pdu_from_wire_with_options(
             &mut self.socket,
             &mut self.read_buffer,
-            self.acceptor_max_pdu_length,
-            self.strict,
+            ReadPduOptions::new(self.acceptor_max_pdu_length, self.strict)
+                .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
         )
     }
 
@@ -1498,11 +1521,11 @@ where
             let mut read_buffer = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let pdu = match super::read_pdu_from_wire_async(
+            let pdu = match super::read_pdu_from_wire_async_with_options(
                 &mut socket,
                 &mut read_buffer,
-                self.max_pdu_length,
-                self.strict,
+                ReadPduOptions::new(self.max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
             )
             .await
             {
@@ -1553,6 +1576,7 @@ where
                         client_ae_title: peer_ae_title,
                         write_buffer,
                         strict: self.strict,
+                        allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                         read_buffer,
                         read_timeout: self.socket_options.read_timeout,
                         write_timeout: self.socket_options.write_timeout,
@@ -1596,11 +1620,11 @@ where
             let mut read_buffer = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let pdu = super::read_pdu_from_wire_async(
+            let pdu = super::read_pdu_from_wire_async_with_options(
                 &mut socket,
                 &mut read_buffer,
-                self.max_pdu_length,
-                self.strict,
+                ReadPduOptions::new(self.max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
             )
             .await?;
 
@@ -1630,6 +1654,7 @@ where
                         client_ae_title: peer_ae_title,
                         write_buffer,
                         strict: self.strict,
+                        allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                         read_buffer,
                         read_timeout: self.socket_options.read_timeout,
                         write_timeout: self.socket_options.write_timeout,
@@ -1682,6 +1707,8 @@ pub struct AsyncServerAssociation<S> {
     write_buffer: Vec<u8>,
     /// whether to receive PDUs in strict mode
     strict: bool,
+    /// whether to accept trailing bytes in fixed-size PDU bodies
+    allow_trailing_fixed_pdu_bytes: bool,
     /// Read buffer from the socket
     read_buffer: bytes::BytesMut,
     /// Timeout for individual receive operations
@@ -1719,6 +1746,10 @@ where
     /// (the association requestor) is expecting to receive.
     fn peer_max_pdu_length(&self) -> u32 {
         self.requestor_max_pdu_length
+    }
+
+    fn allow_trailing_fixed_pdu_bytes(&self) -> bool {
+        self.allow_trailing_fixed_pdu_bytes
     }
 
     /// Obtain a view of the negotiated presentation contexts.
@@ -1762,11 +1793,11 @@ where
     /// Read a PDU message from the other intervenient.
     async fn receive(&mut self) -> Result<Pdu> {
         super::timeout(self.read_timeout, async {
-            super::read_pdu_from_wire_async(
+            super::read_pdu_from_wire_async_with_options(
                 &mut self.socket,
                 &mut self.read_buffer,
-                self.acceptor_max_pdu_length,
-                self.strict,
+                ReadPduOptions::new(self.acceptor_max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
             )
             .await
         })
@@ -1942,11 +1973,11 @@ mod tests {
             let mut read_buffer = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let pdu = read_pdu_from_wire(
+            let pdu = read_pdu_from_wire_with_options(
                 &mut socket,
                 &mut read_buffer,
-                self.max_pdu_length,
-                self.strict,
+                ReadPduOptions::new(self.max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
             )?;
             let (
                 pdu,
@@ -1978,6 +2009,7 @@ mod tests {
                 write_buffer,
                 read_buffer,
                 strict: self.strict,
+                allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                 user_variables,
                 called_ae_title,
             })
@@ -1992,16 +2024,16 @@ mod tests {
         ) -> Result<AsyncServerAssociation<tokio::net::TcpStream>> {
             use tokio::io::AsyncWriteExt;
 
-            use crate::association::read_pdu_from_wire_async;
+            use crate::association::read_pdu_from_wire_async_with_options;
 
             let mut read_buffer = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let pdu = read_pdu_from_wire_async(
+            let pdu = read_pdu_from_wire_async_with_options(
                 &mut socket,
                 &mut read_buffer,
-                self.max_pdu_length,
-                self.strict,
+                ReadPduOptions::new(self.max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
             )
             .await?;
             let (
@@ -2034,6 +2066,7 @@ mod tests {
                 client_ae_title: peer_ae_title,
                 write_buffer: buffer,
                 strict: self.strict,
+                allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                 read_buffer: BytesMut::with_capacity(
                     (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
                 ),
@@ -2052,11 +2085,11 @@ mod tests {
             let mut read_buffer = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let msg = read_pdu_from_wire(
+            let msg = read_pdu_from_wire_with_options(
                 &mut socket,
                 &mut read_buffer,
-                self.max_pdu_length,
-                self.strict,
+                ReadPduOptions::new(self.max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
             )?;
             let (
                 pdu,
@@ -2083,6 +2116,7 @@ mod tests {
                 client_ae_title: peer_ae_title,
                 write_buffer,
                 strict: self.strict,
+                allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                 read_buffer,
                 user_variables,
                 called_ae_title,
@@ -2097,16 +2131,16 @@ mod tests {
         ) -> Result<AsyncServerAssociation<tokio::net::TcpStream>> {
             use tokio::io::AsyncWriteExt;
 
-            use crate::association::read_pdu_from_wire_async;
+            use crate::association::read_pdu_from_wire_async_with_options;
 
             let mut read_buffer = BytesMut::with_capacity(
                 (self.max_pdu_length.min(LARGE_PDU_SIZE) + PDU_HEADER_SIZE) as usize,
             );
-            let msg = read_pdu_from_wire_async(
+            let msg = read_pdu_from_wire_async_with_options(
                 &mut socket,
                 &mut read_buffer,
-                self.max_pdu_length,
-                self.strict,
+                ReadPduOptions::new(self.max_pdu_length, self.strict)
+                    .allow_trailing_fixed_pdu_bytes(self.allow_trailing_fixed_pdu_bytes),
             )
             .await?;
             let (
@@ -2137,6 +2171,7 @@ mod tests {
                 client_ae_title: peer_ae_title,
                 write_buffer,
                 strict: self.strict,
+                allow_trailing_fixed_pdu_bytes: self.allow_trailing_fixed_pdu_bytes,
                 read_buffer,
                 read_timeout: self.socket_options.read_timeout,
                 write_timeout: self.socket_options.write_timeout,

--- a/ul/src/lib.rs
+++ b/ul/src/lib.rs
@@ -56,6 +56,4 @@ pub const IMPLEMENTATION_VERSION_NAME: &str = "DICOM-rs 0.10.0";
 pub use address::{AeAddr, FullAeAddr};
 pub use association::client::{ClientAssociation, ClientAssociationOptions};
 pub use association::server::{ServerAssociation, ServerAssociationOptions};
-pub use pdu::Pdu;
-pub use pdu::read_pdu;
-pub use pdu::write_pdu;
+pub use pdu::{Pdu, ReadPduOptions, read_pdu, read_pdu_with_options, write_pdu};

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -85,6 +85,18 @@ pub enum WriteError {
         reason: &'static str,
         backtrace: Backtrace,
     },
+
+    #[snafu(display(
+        "Encoded length {} exceeds maximum {} for {} length field",
+        length,
+        maximum_length,
+        length_field
+    ))]
+    EncodedLengthOverflow {
+        length: usize,
+        maximum_length: usize,
+        length_field: &'static str,
+    },
 }
 
 #[derive(Debug, Snafu)]
@@ -127,6 +139,18 @@ pub enum ReadError {
     ShortSopClassExtendedNegotiationItemLength {
         length: u32,
         sop_class_uid_length: u16,
+    },
+
+    #[snafu(display(
+        "Invalid fixed PDU length {} for PDU type {} (expected {})",
+        pdu_length,
+        pdu_type,
+        expected_length
+    ))]
+    InvalidFixedPduLength {
+        pdu_type: u8,
+        pdu_length: u32,
+        expected_length: u32,
     },
 
     #[snafu(display("Could not read {} reserved bytes", bytes))]

--- a/ul/src/pdu/mod.rs
+++ b/ul/src/pdu/mod.rs
@@ -9,7 +9,7 @@ pub mod writer;
 
 use std::fmt::Display;
 
-pub use reader::read_pdu;
+pub use reader::{ReadPduOptions, read_pdu, read_pdu_with_options};
 use snafu::{Backtrace, Snafu};
 pub use writer::{WriteChunkError, write_pdu};
 

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -39,7 +39,14 @@ pub fn read_pdu(mut buf: impl Buf, max_pdu_length: u32, strict: bool) -> Result<
             max_pdu_length,
         }
     );
-
+    ensure!(
+        !matches!(pdu_type, 0x03 | 0x05 | 0x06 | 0x07) || pdu_length == 4,
+        InvalidFixedPduLengthSnafu {
+            pdu_type,
+            pdu_length,
+            expected_length: 4_u32,
+        }
+    );
     if buf.remaining() < pdu_length as usize {
         return Ok(None);
     }

--- a/ul/src/pdu/reader.rs
+++ b/ul/src/pdu/reader.rs
@@ -9,8 +9,78 @@ pub type Error = crate::pdu::ReadError;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Options controlling PDU parsing.
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub struct ReadPduOptions {
+    /// The maximum accepted PDU length.
+    pub max_pdu_length: u32,
+
+    /// Whether to enforce the maximum PDU length.
+    pub strict: bool,
+
+    /// Whether fixed-length PDUs may contain bytes after their defined body.
+    ///
+    /// This defaults to `true` for compatibility with the historical behavior
+    /// of [`read_pdu`].
+    pub allow_trailing_fixed_pdu_bytes: bool,
+}
+
+impl Default for ReadPduOptions {
+    fn default() -> Self {
+        Self {
+            max_pdu_length: super::DEFAULT_MAX_PDU,
+            strict: true,
+            allow_trailing_fixed_pdu_bytes: true,
+        }
+    }
+}
+
+impl ReadPduOptions {
+    /// Create a new set of PDU reader options.
+    pub fn new(max_pdu_length: u32, strict: bool) -> Self {
+        Self {
+            max_pdu_length,
+            strict,
+            allow_trailing_fixed_pdu_bytes: true,
+        }
+    }
+
+    /// Set the maximum accepted PDU length.
+    pub fn max_pdu_length(mut self, max_pdu_length: u32) -> Self {
+        self.max_pdu_length = max_pdu_length;
+        self
+    }
+
+    /// Set whether to enforce the maximum PDU length.
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+
+    /// Set whether fixed-length PDUs may contain trailing bytes.
+    pub fn allow_trailing_fixed_pdu_bytes(mut self, allow_trailing_fixed_pdu_bytes: bool) -> Self {
+        self.allow_trailing_fixed_pdu_bytes = allow_trailing_fixed_pdu_bytes;
+        self
+    }
+}
+
 /// Read a PDU from the given byte buffer.
-pub fn read_pdu(mut buf: impl Buf, max_pdu_length: u32, strict: bool) -> Result<Option<Pdu>> {
+///
+/// This retains the historical behavior of accepting trailing bytes in
+/// fixed-length PDUs. Use [`read_pdu_with_options`] to reject those bytes.
+pub fn read_pdu(buf: impl Buf, max_pdu_length: u32, strict: bool) -> Result<Option<Pdu>> {
+    read_pdu_with_options(buf, ReadPduOptions::new(max_pdu_length, strict))
+}
+
+/// Read a PDU from the given byte buffer with the supplied options.
+pub fn read_pdu_with_options(mut buf: impl Buf, options: ReadPduOptions) -> Result<Option<Pdu>> {
+    let ReadPduOptions {
+        max_pdu_length,
+        strict,
+        allow_trailing_fixed_pdu_bytes,
+    } = options;
+
     ensure!(
         (super::MINIMUM_PDU_SIZE..=super::MAXIMUM_PDU_SIZE).contains(&max_pdu_length),
         InvalidMaxPduSnafu { max_pdu_length },
@@ -39,18 +109,41 @@ pub fn read_pdu(mut buf: impl Buf, max_pdu_length: u32, strict: bool) -> Result<
             max_pdu_length,
         }
     );
-    ensure!(
-        !matches!(pdu_type, 0x03 | 0x05 | 0x06 | 0x07) || pdu_length == 4,
-        InvalidFixedPduLengthSnafu {
-            pdu_type,
-            pdu_length,
-            expected_length: 4_u32,
-        }
-    );
+
+    let fixed_pdu_length = matches!(pdu_type, 0x03 | 0x05 | 0x06 | 0x07).then_some(4_u32);
+    if let Some(expected_length) = fixed_pdu_length {
+        ensure!(
+            pdu_length >= expected_length,
+            InvalidFixedPduLengthSnafu {
+                pdu_type,
+                pdu_length,
+                expected_length,
+            }
+        );
+        ensure!(
+            pdu_length == expected_length || allow_trailing_fixed_pdu_bytes,
+            InvalidFixedPduLengthSnafu {
+                pdu_type,
+                pdu_length,
+                expected_length,
+            }
+        );
+    }
+
     if buf.remaining() < pdu_length as usize {
         return Ok(None);
     }
     let mut bytes = buf.copy_to_bytes(pdu_length as usize);
+
+    if let Some(expected_length) = fixed_pdu_length {
+        if pdu_length > expected_length {
+            warn!(
+                pdu_type,
+                pdu_length, expected_length, "Ignoring trailing bytes in fixed-length PDU"
+            );
+        }
+    }
+
     let codec = DefaultCharacterSetCodec;
 
     match pdu_type {

--- a/ul/src/pdu/writer.rs
+++ b/ul/src/pdu/writer.rs
@@ -3,7 +3,7 @@ use crate::pdu::*;
 use byteordered::byteorder::{BigEndian, WriteBytesExt};
 use dicom_encoding::text::TextCodec;
 use snafu::{Backtrace, ResultExt, Snafu, ensure};
-use std::io::Write;
+use std::{convert::TryFrom, io::Write};
 
 pub type Error = crate::pdu::WriteError;
 
@@ -39,7 +39,15 @@ where
         .map_err(Box::from)
         .context(BuildChunkSnafu)?;
 
-    let length = data.len() as u32;
+    let length = u32::try_from(data.len())
+        .map_err(|_| {
+            Box::new(WriteError::EncodedLengthOverflow {
+                length: data.len(),
+                maximum_length: u32::MAX as usize,
+                length_field: "u32",
+            })
+        })
+        .context(BuildChunkSnafu)?;
     writer
         .write_u32::<BigEndian>(length)
         .context(WriteLengthSnafu)?;
@@ -58,7 +66,15 @@ where
         .map_err(Box::from)
         .context(BuildChunkSnafu)?;
 
-    let length = data.len() as u16;
+    let length = u16::try_from(data.len())
+        .map_err(|_| {
+            Box::new(WriteError::EncodedLengthOverflow {
+                length: data.len(),
+                maximum_length: u16::MAX as usize,
+                length_field: "u16",
+            })
+        })
+        .context(BuildChunkSnafu)?;
     writer
         .write_u16::<BigEndian>(length)
         .context(WriteLengthSnafu)?;


### PR DESCRIPTION
`read_pdu` did not enforce the required PDU-length value of 4 for A-ASSOCIATE-RJ, A-RELEASE-RQ, A-RELEASE-RP, and A-ABORT PDUs. Declared lengths below 4 already failed field-length validation, but lengths above 4 could be accepted: the decoder parsed the defined four bytes and discarded the additional bytes included in the declared PDU body. The chunk writers also converted encoded payload lengths with truncating `as u16`/`as u32` casts, so payloads exceeding the corresponding length field could produce a truncated length value while the complete payload was written.

DICOM PS3.8 specifies a PDU-length of `00000004H` for these PDUs (§9.3.4, §9.3.6, §9.3.7, §9.3.8) and defines variable PDU and item lengths as the number of bytes in their following content. This change rejects any other declared length for those fixed PDUs, replaces the length casts with checked conversions that report overflow, and adds the corresponding read and write error variants.
