### PR TITLE
[json] Remove padding when serializing IS, DS

### DIFF
--- a/json/src/ser/value.rs
+++ b/json/src/ser/value.rs
@@ -66,8 +66,8 @@ impl Serialize for AsNumbers<'_> {
             PrimitiveValue::Time(_) => panic!("wrong impl: cannot encode Time as numbers"),
             PrimitiveValue::Tags(_) => panic!("wrong impl: cannot encode Tags as numbers"),
             // strings
-            PrimitiveValue::Strs(strings) => serializer.collect_seq(strings),
-            PrimitiveValue::Str(string) => serializer.collect_seq([string]),
+            PrimitiveValue::Strs(_) => serializer.collect_seq(&*self.0.to_multi_str()),
+            PrimitiveValue::Str(_) => serializer.collect_seq(&*self.0.to_multi_str()),
             // no risk of precision loss
             PrimitiveValue::U8(numbers) => serializer.collect_seq(numbers),
             PrimitiveValue::I16(numbers) => serializer.collect_seq(numbers),
@@ -262,7 +262,7 @@ mod tests {
         let json = serde_json::to_value(AsNumbers(&v)).unwrap();
         assert_eq!(json, json!([]));
 
-        let v = PrimitiveValue::from("5");
+        let v = PrimitiveValue::from("5 ");  // padded with a space to make length even
         let json = serde_json::to_value(AsNumbers(&v)).unwrap();
         assert_eq!(json, json!(["5"]),);
 

--- a/json/src/ser/value.rs
+++ b/json/src/ser/value.rs
@@ -262,9 +262,14 @@ mod tests {
         let json = serde_json::to_value(AsNumbers(&v)).unwrap();
         assert_eq!(json, json!([]));
 
-        let v = PrimitiveValue::from("5 ");  // padded with a space to make length even
+        // Check values that are space-padded to make the lengths even
+        let v = dicom_value!(Str, "5 ");
         let json = serde_json::to_value(AsNumbers(&v)).unwrap();
-        assert_eq!(json, json!(["5"]),);
+        assert_eq!(json, json!(["5"]));
+
+        let v = dicom_value!(Strs, ["5 ", "6 ", "-7"]);
+        let json = serde_json::to_value(AsNumbers(&v)).unwrap();
+        assert_eq!(json, json!(["5", "6", "-7"]));
 
         let v = dicom_value!(U16, [20, 40, 60]);
         let json = serde_json::to_value(AsNumbers(&v)).unwrap();


### PR DESCRIPTION
When values with a value representation of DS (decimal string) or IS (integer string) come from a DICOM file, if their length is odd, a padding space is appended. This is reflected in their `PrimitiveValue::Strs()` value.

Since the serialization took the raw value contained in `PrimitiveValue::Strs()`, the padding spaces were not eliminated when converting to JSON. However, JSON requires that no such padding is present. Therefore, this PR inserts the "cooked" value instead via `PrimitiveValue.to_multi_str()`.

The unit test did not detect that because the value was created without padding spaces, therefore it has been adjusted to have one, to make this issue apparent.