### PR TITLE
Fix de/serialization of PN attributes

### DIFF
--- a/json/src/de/mod.rs
+++ b/json/src/de/mod.rs
@@ -468,7 +468,10 @@ mod tests {
                 "vr": "PN",
                 "Value": [
                   {
-                    "Alphabetic": "^Bob^^Dr."
+                    "Alphabetic": "^Bob^^Dr.",
+                  },
+                  {
+                    "Ideographic": "\u{6708}\u{91ce}^\u{3046}\u{3055}\u{304e}",
                   }
                 ]
             },

--- a/json/src/de/mod.rs
+++ b/json/src/de/mod.rs
@@ -471,7 +471,7 @@ mod tests {
                     "Alphabetic": "^Bob^^Dr.",
                   },
                   {
-                    "Ideographic": "\u{6708}\u{91ce}^\u{3046}\u{3055}\u{304e}",
+                    "Ideographic": "月野^うさぎ",
                   }
                 ]
             },

--- a/json/src/de/value.rs
+++ b/json/src/de/value.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct DicomJsonPerson {
-    #[serde(rename = "Alphabetic")]
+    #[serde(rename = "Alphabetic", default)]
     alphabetic: String,
     #[serde(rename = "Ideographic")]
     ideographic: Option<String>,

--- a/json/src/ser/value.rs
+++ b/json/src/ser/value.rs
@@ -195,13 +195,23 @@ impl Serialize for AsPersonNames<'_> {
 /// Should only used for the value representation PN.
 #[derive(Debug, Clone, Serialize)]
 pub struct PersonNameDef<'a> {
-    #[serde(rename = "Alphabetic")]
+    #[serde(rename = "Alphabetic", skip_serializing_if = "str::is_empty")]
     alphabetic: &'a str,
+    #[serde(rename = "Ideographic", skip_serializing_if = "str::is_empty")]
+    ideographic: &'a str,
+    #[serde(rename = "Phonetic", skip_serializing_if = "str::is_empty")]
+    phonetic: &'a str,
 }
 
 impl<'a> From<&'a str> for PersonNameDef<'a> {
     fn from(value: &'a str) -> Self {
-        PersonNameDef { alphabetic: value }
+        let mut parts = value.split('=');
+
+        PersonNameDef {
+            alphabetic: parts.next().unwrap_or(""),
+            ideographic: parts.next().unwrap_or(""),
+            phonetic: parts.next().unwrap_or(""),
+        }
     }
 }
 
@@ -274,5 +284,54 @@ mod tests {
         let v = dicom_value!(U64, [876543245678]);
         let json = serde_json::to_value(AsNumbers(&v)).unwrap();
         assert_eq!(json, json!(["876543245678"]),);
+    }
+
+    #[test]
+    fn serialize_names_with_ideographic_and_phonetic() {
+        let v = dicom_value!(
+            Strs,
+            [
+                "House^Gregory^^M.D.",
+                "Wang^XiaoDong=\u{738b}^\u{5c0f}\u{4e1c}=",
+                "Orl\u{e9}ans de Gallia^Charlotte^H\u{e9}l\u{e8}ne==\
+                \u{30aa}\u{30eb}\u{30ec}\u{30a2}\u{30f3}\u{30fb}\u{30c7}\
+                \u{30fb}\u{30ac}\u{30fc}\u{30ea}\u{30e4}^\u{30b7}\u{30e3}\
+                \u{30eb}\u{30ed}\u{30c3}\u{30c8}^\u{30a8}\u{30ec}\u{30fc}\u{30cc}",
+                "=\u{559c}\u{591a}\u{5ddd}^\u{6d77}\u{5922}=\u{30ad}\u{30bf}\
+                \u{30ac}\u{30ef}^\u{30de}\u{30ea}\u{30f3}",
+                "Mashiro^Moritaka^^^San=\u{771f}\u{57ce}^\u{6700}\u{9ad8}^^^\
+                \u{3055}\u{3093}=\u{30de}\u{30b7}\u{30ed}^\u{30e2}\u{30ea}\
+                \u{30bf}\u{30ab}^^^\u{3055}\u{3093}",
+            ]
+        );
+        let json = serde_json::to_value(AsPersonNames(&v)).unwrap();
+        assert_eq!(
+            json,
+            json!([
+                {
+                    "Alphabetic": "House^Gregory^^M.D.",
+                },
+                {
+                    "Alphabetic": "Wang^XiaoDong",
+                    "Ideographic": "\u{738b}^\u{5c0f}\u{4e1c}",
+                },
+                {
+                    "Alphabetic": "Orl\u{e9}ans de Gallia^Charlotte^H\u{e9}l\u{e8}ne",
+                    "Phonetic": "\u{30aa}\u{30eb}\u{30ec}\u{30a2}\u{30f3}\u{30fb}\u{30c7}\
+                    \u{30fb}\u{30ac}\u{30fc}\u{30ea}\u{30e4}^\u{30b7}\u{30e3}\
+                    \u{30eb}\u{30ed}\u{30c3}\u{30c8}^\u{30a8}\u{30ec}\u{30fc}\u{30cc}",
+                },
+                {
+                    "Ideographic": "\u{559c}\u{591a}\u{5ddd}^\u{6d77}\u{5922}",
+                    "Phonetic": "\u{30ad}\u{30bf}\u{30ac}\u{30ef}^\u{30de}\u{30ea}\u{30f3}",
+                },
+                {
+                    "Alphabetic": "Mashiro^Moritaka^^^San",
+                    "Ideographic": "\u{771f}\u{57ce}^\u{6700}\u{9ad8}^^^\u{3055}\u{3093}",
+                    "Phonetic": "\u{30de}\u{30b7}\u{30ed}^\u{30e2}\u{30ea}\u{30bf}\u{30ab}^^^\
+                    \u{3055}\u{3093}",
+                },
+            ])
+        );
     }
 }

--- a/json/src/ser/value.rs
+++ b/json/src/ser/value.rs
@@ -292,16 +292,10 @@ mod tests {
             Strs,
             [
                 "House^Gregory^^M.D.",
-                "Wang^XiaoDong=\u{738b}^\u{5c0f}\u{4e1c}=",
-                "Orl\u{e9}ans de Gallia^Charlotte^H\u{e9}l\u{e8}ne==\
-                \u{30aa}\u{30eb}\u{30ec}\u{30a2}\u{30f3}\u{30fb}\u{30c7}\
-                \u{30fb}\u{30ac}\u{30fc}\u{30ea}\u{30e4}^\u{30b7}\u{30e3}\
-                \u{30eb}\u{30ed}\u{30c3}\u{30c8}^\u{30a8}\u{30ec}\u{30fc}\u{30cc}",
-                "=\u{559c}\u{591a}\u{5ddd}^\u{6d77}\u{5922}=\u{30ad}\u{30bf}\
-                \u{30ac}\u{30ef}^\u{30de}\u{30ea}\u{30f3}",
-                "Mashiro^Moritaka^^^San=\u{771f}\u{57ce}^\u{6700}\u{9ad8}^^^\
-                \u{3055}\u{3093}=\u{30de}\u{30b7}\u{30ed}^\u{30e2}\u{30ea}\
-                \u{30bf}\u{30ab}^^^\u{3055}\u{3093}",
+                "Wang^XiaoDong=王^小东=",
+                "Orléans de Gallia^Charlotte^Hélène==オルレアン・デ・ガーリヤ^シャルロット^エレーヌ",
+                "=喜多川^海夢=キタガワ^マリン",
+                "Mashiro^Moritaka^^^San=真城^最高^^^さん=マシロ^モリタカ^^^さん"
             ]
         );
         let json = serde_json::to_value(AsPersonNames(&v)).unwrap();
@@ -313,23 +307,20 @@ mod tests {
                 },
                 {
                     "Alphabetic": "Wang^XiaoDong",
-                    "Ideographic": "\u{738b}^\u{5c0f}\u{4e1c}",
+                    "Ideographic": "王^小东",
                 },
                 {
-                    "Alphabetic": "Orl\u{e9}ans de Gallia^Charlotte^H\u{e9}l\u{e8}ne",
-                    "Phonetic": "\u{30aa}\u{30eb}\u{30ec}\u{30a2}\u{30f3}\u{30fb}\u{30c7}\
-                    \u{30fb}\u{30ac}\u{30fc}\u{30ea}\u{30e4}^\u{30b7}\u{30e3}\
-                    \u{30eb}\u{30ed}\u{30c3}\u{30c8}^\u{30a8}\u{30ec}\u{30fc}\u{30cc}",
+                    "Alphabetic": "Orléans de Gallia^Charlotte^Hélène",
+                    "Phonetic": "オルレアン・デ・ガーリヤ^シャルロット^エレーヌ",
                 },
                 {
-                    "Ideographic": "\u{559c}\u{591a}\u{5ddd}^\u{6d77}\u{5922}",
-                    "Phonetic": "\u{30ad}\u{30bf}\u{30ac}\u{30ef}^\u{30de}\u{30ea}\u{30f3}",
+                    "Ideographic": "喜多川^海夢",
+                    "Phonetic": "キタガワ^マリン",
                 },
                 {
                     "Alphabetic": "Mashiro^Moritaka^^^San",
-                    "Ideographic": "\u{771f}\u{57ce}^\u{6700}\u{9ad8}^^^\u{3055}\u{3093}",
-                    "Phonetic": "\u{30de}\u{30b7}\u{30ed}^\u{30e2}\u{30ea}\u{30bf}\u{30ab}^^^\
-                    \u{3055}\u{3093}",
+                    "Ideographic": "真城^最高^^^さん",
+                    "Phonetic": "マシロ^モリタカ^^^さん",
                 },
             ])
         );


### PR DESCRIPTION
Serialization did not take into account PN values with ideographic and/or phonetic fields.

Deserialization did not allow for a missing Alphabetic value, yet it's allowed by the standard. PS3.5 section 6.2, entry PN in table 6.2-1:
'Any component group may be absent, including the first component group. In this case, the person name may start with one or more "=" delimiters.'