### PR TITLE
Add intra-doc links to core crate

### DIFF
--- a/core/src/dictionary/data_element.rs
+++ b/core/src/dictionary/data_element.rs
@@ -146,7 +146,7 @@ impl FromStr for TagRange {
 /// It is used by element dictionary entries to describe circumstances
 /// in which the real VR may depend on context.
 /// As an example, the _Pixel Data_ attribute
-/// can have a value representation of either [`OB`](VR::OB) or [`OW`](VR::OW).
+/// can have a value representation of either [`VR::OB`] or [`VR::OW`].
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum VirtualVr {
@@ -162,19 +162,19 @@ pub enum VirtualVr {
     /// (represented by a _Pixel Representation_ value of `1`),
     /// then values with this virtual VR
     /// should be interpreted as signed 16 bit integers
-    /// ([`SS`](VR::SS)),
+    /// ([`VR::SS`]),
     /// otherwise they should be interpreted as unsigned 16 bit integers
-    /// ([`US`](VR::US)).
+    /// ([`VR::US`]).
     Xs,
     /// Represents overlay data sample values.
     ///
-    /// It can be either [`OB`](VR::OB) or [`OW`](VR::OW).
+    /// It can be either [`VR::OB`] or [`VR::OW`].
     Ox,
     /// Represents pixel data sample value.
     ///
-    /// It can be either [`OB`](VR::OB) or [`OW`](VR::OW).
+    /// It can be either [`VR::OB`] or [`VR::OW`].
     Px,
-    /// Represents LUT data, which can be [`US`](VR::US) or [`OW`](VR::OW)
+    /// Represents LUT data, which can be [`VR::US`] or [`VR::OW`].
     Lt,
 }
 
@@ -198,10 +198,10 @@ impl VirtualVr {
     /// making a relaxed conversion if it cannot be
     /// accurately resolved without context.
     ///
-    /// - [`Xs`](VirtualVr::Xs) is relaxed to [`US`](VR::US)
-    /// - [`Ox`](VirtualVr::Ox) is relaxed to [`OW`](VR::OW)
-    /// - [`Px`](VirtualVr::Px) is relaxed to [`OW`](VR::OW)
-    /// - [`Lt`](VirtualVr::Lt) is relaxed to [`OW`](VR::OW)
+    /// - [`VirtualVr::Xs`] is relaxed to [`VR::US`]
+    /// - [`VirtualVr::Ox`] is relaxed to [`VR::OW`]
+    /// - [`VirtualVr::Px`] is relaxed to [`VR::OW`]
+    /// - [`VirtualVr::Lt`] is relaxed to [`VR::OW`]
     ///
     /// This method is ill-advised for uses where
     /// the corresponding attribute is important.
@@ -238,27 +238,27 @@ enum ParseSelectorErrorInner {
 /// to retrieve a record containing additional information about a data element,
 /// in one of the following ways:
 ///
-/// - By DICOM tag, via [`by_tag`][1];
-/// - By its keyword (also known as alias) via [`by_name`][2];
+/// - By DICOM tag, via [`by_tag`];
+/// - By its keyword (also known as alias) via [`by_name`];
 /// - By an expression which may either be a keyword
 ///   or a tag printed in one of its standard forms,
-///   using [`by_expr`][3].
+///   using [`by_expr`].
 ///
-/// These methods will return `None`
+/// These methods will return [`None`]
 /// when the tag or name is not recognized by the dictionary.
 ///
 /// In addition,
 /// the data element dictionary provides
 /// built-in DICOM tag and selector (path) parsers for convenience.
-/// [`parse_tag`][4] converts an arbitrary expression to a tag,
-/// whereas [`parse_selector`][5] produces an [attribute selector][6].
+/// [`parse_tag`] converts an arbitrary expression to a tag,
+/// whereas [`parse_selector`] produces an [AttributeSelector].
 ///
-/// [1]: DataDictionary::by_tag
-/// [2]: DataDictionary::by_name
-/// [3]: DataDictionary::by_expr
-/// [4]: DataDictionary::parse_tag
-/// [5]: DataDictionary::parse_selector
-/// [6]: crate::ops::AttributeSelector
+/// [`by_tag`]: Self::by_tag
+/// [`by_name`]: Self::by_name
+/// [`by_expr`]: Self::by_expr
+/// [`parse_tag`]: Self::parse_tag
+/// [`parse_selector`]: Self::parse_selector
+/// [`AttributeSelector`]: crate::ops::AttributeSelector
 pub trait DataDictionary {
     /// The type of the dictionary entry.
     type Entry: DataDictionaryEntry;
@@ -277,14 +277,15 @@ pub trait DataDictionary {
     /// slightly more expensive than by DICOM tag.
     /// If the parameter provided is a string literal
     /// (e.g. `"StudyInstanceUID"`),
-    /// then it may be better to use [`by_tag`][1]
+    /// then it may be better to use [`by_tag`]
     /// with a known tag constant
-    /// (such as [`tags::STUDY_INSTANCE_UID`][2]
-    /// from the [`dicom-dictionary-std`][3] crate).
+    /// (such as [`tags::STUDY_INSTANCE_UID`]
+    /// from the [`dicom-dictionary-std`] crate).
     ///
-    /// [1]: DataDictionary::by_tag
-    /// [2]: https://docs.rs/dicom-dictionary-std/0.5.0/dicom_dictionary_std/tags/constant.STUDY_INSTANCE_UID.html
-    /// [3]: https://docs.rs/dicom-dictionary-std/0.5.0
+    ///
+    /// [`by_tag`]: Self::by_tag
+    /// [`tags::STUDY_INSTANCE_UID`]: https://docs.rs/dicom-dictionary-std/latest/dicom_dictionary_std/tags/constant.STUDY_INSTANCE_UID.html
+    /// [`dicom-dictionary-std`]: https://docs.rs/dicom-dictionary-std/latest/dicom_dictionary_std/
     fn by_name(&self, name: &str) -> Option<&Self::Entry>;
 
     /// Fetch an entry by its alias or by DICOM tag expression.
@@ -303,7 +304,7 @@ pub trait DataDictionary {
     ///   an exact match (case sensitive) by DICOM tag keyword
     ///
     /// When failing to identify the intended syntax or the tag keyword,
-    /// `None` is returned.
+    /// [`None`] is returned.
     fn by_expr(&self, tag: &str) -> Option<&Self::Entry> {
         match tag.parse() {
             Ok(tag) => self.by_tag(tag),
@@ -327,7 +328,7 @@ pub trait DataDictionary {
     ///   an exact match (case sensitive) by DICOM tag keyword
     ///
     /// When failing to identify the intended syntax or the tag keyword,
-    /// `None` is returned.
+    /// [`None`] is returned.
     fn parse_tag(&self, tag: &str) -> Option<Tag> {
         tag.parse().ok().or_else(|| {
             // look for tag in standard data dictionary
@@ -335,20 +336,18 @@ pub trait DataDictionary {
         })
     }
 
-    /// Parse a string as an [attribute selector][1].
+    /// Parse a string as an [crate::ops::attribute selector].
     ///
     /// Attribute selectors are defined by the syntax
     /// `( «key»([«item»])? . )* «key» `
     /// where_`«key»`_ is either a DICOM tag or keyword
     /// as accepted by this dictionary
-    /// when calling the method [`parse_tag`](DataDictionary::parse_tag).
+    /// when calling the method [`parse_tag`].
     /// More details about the syntax can be found
-    /// in the documentation of [`AttributeSelector`][1].
+    /// in the documentation of [`AttributeSelector`].
     ///
     /// Returns an error if the string does not follow the given syntax,
     /// or one of the key components could not be resolved.
-    ///
-    /// [1]: crate::ops::AttributeSelector
     ///
     /// ### Examples of valid input:
     ///
@@ -360,6 +359,8 @@ pub trait DataDictionary {
     ///   _Code Value_ in first item of _Concept Code Sequence_
     /// - `SequenceOfUltrasoundRegions.RegionSpatialFormat`:
     ///   _Region Spatial Format_ in first item of _Sequence of Ultrasound Regions_
+    ///
+    /// [`parse_tag`]: Self::parse_tag
     fn parse_selector(&self, selector_text: &str) -> Result<AttributeSelector, ParseSelectorError> {
         let mut steps = crate::value::C::new();
         for part in selector_text.split('.') {

--- a/core/src/dictionary/mod.rs
+++ b/core/src/dictionary/mod.rs
@@ -1,6 +1,11 @@
 //! This module contains the concept of a DICOM data dictionary.
 //!
-//! The standard data dictionary is available in the [`dicom-dictionary-std`] crate.
+//! The standard data dictionary documentation is available in the latest
+//! version of
+//! [`dicom-dictionary-std`](https://docs.rs/dicom-dictionary-std).
+//!
+//! **Note:** The link above always points to the latest release.
+//! For older releases, select the appropriate documentation version tag.
 
 mod data_element;
 pub mod stub;

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -255,7 +255,7 @@ impl<I, P> DataElement<I, P> {
     /// - if the value is a pixel data fragment sequence,
     ///   the VR is set to `OB` and the length is reset to undefined;
     /// - if the value is primitive,
-    ///   the length is recalculated, leaving the VR as is.
+    ///   the length is recalculated, leaving the [`VR`] as is.
     ///
     /// If these rules do not result in a valid element,
     /// consider reconstructing the data element instead.
@@ -288,10 +288,12 @@ where
     /// If the value is textual,
     /// the byte length of that value encoded in UTF-8 is assumed.
     /// If you already have a length in this context,
-    /// prefer calling `new_with_len` instead.
+    /// prefer calling [`new_with_len`] instead.
     ///
     /// This method will not check whether the value representation is
     /// compatible with the given value.
+    ///
+    /// [`new_with_len`]: Self::new_with_len
     pub fn new<T>(tag: Tag, vr: VR, value: T) -> Self
     where
         T: Into<Value<I, P>>,
@@ -345,8 +347,8 @@ where
 
     /// Convert the full primitive value into raw bytes.
     ///
-    /// String values already encoded with the `Str` and `Strs` variants
-    /// are provided in UTF-8.
+    /// String values already encoded with the [`PrimitiveValue::Str`] and
+    /// [`PrimitiveValue::Strs`] variants are provided in UTF-8.
     ///
     /// Returns an error if the value is not primitive.
     pub fn to_bytes(&self) -> Result<Cow<'_, [u8]>, ConvertValueError> {
@@ -359,8 +361,6 @@ where
     /// a vector of strings as described in [`PrimitiveValue::to_multi_str`].
     ///
     /// Returns an error if the value is not primitive.
-    ///
-    /// [`PrimitiveValue::to_multi_str`]: ../enum.PrimitiveValue.html#to_multi_str
     pub fn to_multi_str(&self) -> Result<Cow<'_, [String]>, CastValueError> {
         self.value().to_multi_str()
     }
@@ -372,8 +372,6 @@ where
     /// as described in [`PrimitiveValue::to_int`].
     ///
     /// Returns an error if the value is not primitive.
-    ///
-    /// [`PrimitiveValue::to_int`]: ../enum.PrimitiveValue.html#to_int
     pub fn to_int<T>(&self) -> Result<T, ConvertValueError>
     where
         T: Clone,
@@ -387,9 +385,7 @@ where
     /// into a sequence of integers.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of integers as described in [PrimitiveValue::to_multi_int].
-    ///
-    /// [PrimitiveValue::to_multi_int]: ../enum.PrimitiveValue.html#to_multi_int
+    /// a vector of integers as described in [`PrimitiveValue::to_multi_int`].
     pub fn to_multi_int<T>(&self) -> Result<Vec<T>, ConvertValueError>
     where
         T: Clone,
@@ -406,8 +402,6 @@ where
     /// a number as described in [`PrimitiveValue::to_float32`].
     ///
     /// Returns an error if the value is not primitive.
-    ///
-    /// [`PrimitiveValue::to_float32`]: ../enum.PrimitiveValue.html#to_float32
     pub fn to_float32(&self) -> Result<f32, ConvertValueError> {
         self.value().to_float32()
     }
@@ -416,11 +410,10 @@ where
     /// into a sequence of single-precision floating point numbers.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of numbers as described in [`PrimitiveValue::to_multi_float32`].
+    /// a vector of numbers as described in
+    /// [`PrimitiveValue::to_multi_float32`].
     ///
     /// Returns an error if the value is not primitive.
-    ///
-    /// [`PrimitiveValue::to_multi_float32`]: ../enum.PrimitiveValue.html#to_multi_float32
     pub fn to_multi_float32(&self) -> Result<Vec<f32>, ConvertValueError> {
         self.value().to_multi_float32()
     }
@@ -432,8 +425,6 @@ where
     /// a number as described in [`PrimitiveValue::to_float64`].
     ///
     /// Returns an error if the value is not primitive.
-    ///
-    /// [`PrimitiveValue::to_float64`]: ../enum.PrimitiveValue.html#to_float64
     pub fn to_float64(&self) -> Result<f64, ConvertValueError> {
         self.value().to_float64()
     }
@@ -442,11 +433,10 @@ where
     /// into a sequence of double-precision floating point numbers.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of numbers as described in [`PrimitiveValue::to_multi_float64`].
+    /// a vector of numbers as described in
+    /// [`PrimitiveValue::to_multi_float64`].
     ///
     /// Returns an error if the value is not primitive.
-    ///
-    /// [`PrimitiveValue::to_multi_float64`]: ../enum.PrimitiveValue.html#to_multi_float64
     pub fn to_multi_float64(&self) -> Result<Vec<f64>, ConvertValueError> {
         self.value().to_multi_float64()
     }
@@ -454,7 +444,7 @@ where
     /// Retrieve and convert the primitive value into a date.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a `DicomDate` as described in [`PrimitiveValue::to_date`].
+    /// a [`DicomDate`] as described in [`PrimitiveValue::to_date`].
     ///
     /// Returns an error if the value is not primitive.
     ///
@@ -465,7 +455,8 @@ where
     /// Retrieve and convert the primitive value into a sequence of dates.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of `DicomDate` as described in [`PrimitiveValue::to_multi_date`].
+    /// a vector of [`DicomDate`] as described in
+    /// [`PrimitiveValue::to_multi_date`].
     ///
     /// Returns an error if the value is not primitive.
     ///
@@ -476,7 +467,7 @@ where
     /// Retrieve and convert the primitive value into a time.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a `DicomTime` as described in [`PrimitiveValue::to_time`].
+    /// a [`DicomTime`] as described in [`PrimitiveValue::to_time`].
     ///
     /// Returns an error if the value is not primitive.
     ///
@@ -487,7 +478,8 @@ where
     /// Retrieve and convert the primitive value into a sequence of times.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of `DicomTime` as described in [`PrimitiveValue::to_multi_time`].
+    /// a vector of [`DicomTime`] as described in
+    /// [`PrimitiveValue::to_multi_time`].
     ///
     /// Returns an error if the value is not primitive.
     ///
@@ -498,7 +490,7 @@ where
     /// Retrieve and convert the primitive value into a date-time.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a `DicomDateTime` as described in [`PrimitiveValue::to_datetime`].
+    /// a [`DicomDateTime`] as described in [`PrimitiveValue::to_datetime`].
     ///
     /// Returns an error if the value is not primitive.
     ///
@@ -509,7 +501,8 @@ where
     /// Retrieve and convert the primitive value into a sequence of date-times.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of `DicomDateTime` as described in [`PrimitiveValue::to_multi_datetime`].
+    /// a vector of [`DicomDateTime`] as described in
+    /// [`PrimitiveValue::to_multi_datetime`].
     ///
     /// Returns an error if the value is not primitive.
     ///
@@ -529,7 +522,7 @@ where
     /// The header's recorded length is automatically reset to undefined,
     /// in order to prevent inconsistencies.
     ///
-    /// Returns `None` if the underlying value is not a data set sequence.
+    /// Returns [`None`] if the underlying value is not a data set sequence.
     pub fn items_mut(&mut self) -> Option<&mut C<I>> {
         self.header.len = Length::UNDEFINED;
         self.value.items_mut()
@@ -537,7 +530,7 @@ where
 
     /// Retrieve the fragments stored in a pixel data sequence value.
     ///
-    /// Returns `None` if the value is not a pixel data sequence.
+    /// Returns [`None`] if the value is not a pixel data sequence.
     pub fn fragments(&self) -> Option<&[P]> {
         self.value().fragments()
     }
@@ -548,7 +541,7 @@ where
     /// The header's recorded length is automatically reset to undefined,
     /// in order to prevent inconsistencies.
     ///
-    /// Returns `None` if the value is not a pixel data sequence.
+    /// Returns [`None`] if the value is not a pixel data sequence.
     pub fn fragments_mut(&mut self) -> Option<&mut C<P>> {
         self.header.len = Length::UNDEFINED;
         self.value.fragments_mut()
@@ -556,7 +549,7 @@ where
 
     /// Obtain a reference to the encapsulated pixel data's basic offset table.
     ///
-    /// Returns `None` if the underlying value is not a pixel data sequence.
+    /// Returns [`None`] if the underlying value is not a pixel data sequence.
     pub fn offset_table(&self) -> Option<&[u32]> {
         self.value().offset_table()
     }
@@ -592,9 +585,9 @@ where
 }
 
 /// Macro for implementing getters to single and multi-values,
-/// by delegating to `Value`.
+/// by delegating to [`Value`].
 ///
-/// Should be placed inside `DataElement`'s impl block.
+/// Should be placed inside [`DataElement`]'s impl block.
 macro_rules! impl_primitive_getters {
     ($name_single: ident, $name_multi: ident, $variant: ident, $ret: ty) => {
         /// Get a single value of the requested type.
@@ -624,22 +617,23 @@ impl<I, P> DataElement<I, P> {
     /// An error is returned if the variant is not compatible.
     ///
     /// To enable conversions of other variants to a textual representation,
-    /// see [`to_str()`] instead.
+    /// see [`to_str`] instead.
     ///
-    /// [`to_str()`]: #method.to_str
+    /// [`to_str`]: Self::to_str
     pub fn string(&self) -> Result<&str, CastValueError> {
         self.value().string()
     }
 
     /// Get the inner sequence of string values
-    /// if the variant is either `Str` or `Strs`.
+    /// if the variant is either [`PrimitiveValue::Str`] or
+    /// [`PrimitiveValue::Strs`].
     ///
     /// An error is returned if the variant is not compatible.
     ///
     /// To enable conversions of other variants to a textual representation,
-    /// see [`to_str()`] instead.
+    /// see [`to_str`] instead.
     ///
-    /// [`to_str()`]: #method.to_str
+    /// [`to_str`]: Self::to_str
     pub fn strings(&self) -> Result<&[String], CastValueError> {
         self.value().strings()
     }
@@ -868,7 +862,7 @@ impl VR {
             .and_then(|s| VR::from_str(s).ok())
     }
 
-    /// Retrieve a string representation of this VR.
+    /// Retrieve a string representation of this `VR`.
     pub fn to_string(self) -> &'static str {
         use VR::*;
         match self {
@@ -909,7 +903,7 @@ impl VR {
         }
     }
 
-    /// Retrieve a copy of this VR's byte representation.
+    /// Retrieve a copy of this [`VR`]'s byte representation.
     /// The function returns two alphabetic characters in upper case.
     pub fn to_bytes(self) -> [u8; 2] {
         let bytes = self.to_string().as_bytes();
@@ -917,9 +911,9 @@ impl VR {
     }
 }
 
-/// Obtain the value representation corresponding to the given string.
-/// The string should hold exactly two UTF-8 encoded alphabetic characters
-/// in upper case, otherwise no match is made.
+// Obtain the value representation corresponding to the given string.
+// The string should hold exactly two UTF-8 encoded alphabetic characters
+// in upper case, otherwise no match is made.
 impl FromStr for VR {
     type Err = &'static str;
 
@@ -983,7 +977,7 @@ pub type ElementNumber = u16;
 /// a `Tag` may also be built by converting a `(u16, u16)` or a `[u16; 2]`.
 ///
 /// In its text form,
-/// DICOM tags are printed by [`Display`][display] in the form `(GGGG,EEEE)`,
+/// DICOM tags are printed by [`std::fmt::Display`] in the form `(GGGG,EEEE)`,
 /// where the group and element parts are in uppercase hexadecimal.
 /// Moreover, its [`FromStr`] implementation
 /// support converting strings in the following text formats into DICOM tags:
@@ -991,8 +985,6 @@ pub type ElementNumber = u16;
 /// - `(GGGG,EEEE)`
 /// - `GGGG,EEEE`
 /// - `GGGGEEEE`
-///
-/// [display]: std::fmt::Display
 ///
 /// # Example
 ///
@@ -1173,7 +1165,7 @@ impl Length {
     pub const UNDEFINED: Self = Length(UNDEFINED_LEN);
 
     /// Create a new length value from its internal representation.
-    /// This is equivalent to `Length(len)`.
+    /// This is equivalent to `[`[`Length`]`](len)`.
     #[inline]
     pub fn new(len: u32) -> Self {
         Length(len)
@@ -1327,7 +1319,7 @@ impl Length {
     }
 
     /// Check whether the length is equally specified as another length.
-    /// Unlike the implemented `PartialEq`, two undefined lengths are
+    /// Unlike the implemented [`PartialEq`], two undefined lengths are
     /// considered equivalent by this method.
     #[inline]
     pub fn inner_eq(self, other: Length) -> bool {
@@ -1380,7 +1372,7 @@ mod tests {
         assert_eq!(0x0020u16, t.element());
     }
 
-    /// Ensure good order between tags
+    // Ensure good order between tags
     #[test]
     fn tag_ord() {
         assert_eq!(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -97,7 +97,7 @@ pub use smallvec;
 /// ```
 ///
 /// The output is a [`PrimitiveValue`],
-/// which can be converted to a `DicomValue` as long as its type parameters
+/// which can be converted to a [`DicomValue`] as long as its type parameters
 /// are specified or inferable.
 ///
 /// ```
@@ -113,8 +113,6 @@ pub use smallvec;
 ///         PrimitiveValue::U16([5, 6, 7][..].into())),
 /// );
 /// ```
-///
-/// [`PrimitiveValue`]: ./enum.PrimitiveValue.html
 #[macro_export]
 macro_rules! dicom_value {
     // Empty value

--- a/core/src/ops.rs
+++ b/core/src/ops.rs
@@ -14,9 +14,11 @@
 //! # Example
 //!
 //! Given a DICOM object
-//! (opened using [`dicom_object`](https://docs.rs/dicom-object)),
+//! (opened using [`dicom_object`]),
 //! construct an [`AttributeOp`]
-//! and apply it using [`apply`](ApplyOp::apply).
+//! and apply it using [`ApplyOp::apply`].
+//!
+//! [`dicom_object`]: https://docs.rs/dicom_object
 //!
 //! ```no_run
 //! # use dicom_core::Tag;
@@ -101,13 +103,16 @@ impl AttributeOp {
 
 /// A single step of an attribute selection.
 ///
-/// A selector step may either select an element directly at the root (`Tag`)
-/// or a specific item in a sequence to navigate into (`Nested`).
+/// A selector step may either select an element directly at the root ([`Tag`])
+/// or a specific item in a sequence to navigate into ([`Nested`]).
 ///
 /// A full attribute selector can be specified
 /// by using a sequence of these steps
-/// (but should always end with the `Tag` variant,
+/// (but should always end with the [`Tag`] variant,
 /// otherwise the operation would be unspecified).
+///
+/// [`Tag`]: Self::Tag
+/// [`Nested`]: Self::Nested
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
 pub enum AttributeSelectorStep {
     /// Select the element with the tag reachable at the root of this data set
@@ -134,8 +139,11 @@ impl From<(Tag, u32)> for AttributeSelectorStep {
 
 impl std::fmt::Display for AttributeSelectorStep {
     /// Displays the attribute selector step:
-    /// `(GGGG,EEEE)` if `Tag`,
-    /// `(GGGG,EEEE)[i]` if `Nested`
+    /// `(GGGG,EEEE)` if [`Tag`],
+    /// `(GGGG,EEEE)[i]` if [`Nested`]
+    ///
+    /// [`Tag`]: Self::Tag
+    /// [`Nested`]: Self::Nested
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             AttributeSelectorStep::Tag(tag) => std::fmt::Display::fmt(tag, f),
@@ -157,29 +165,30 @@ impl std::fmt::Display for AttributeSelectorStep {
 /// the dynamic constructor function [`new`],
 /// or through parsing.
 ///
+/// [`new`]: Self::new
+///
 /// # Syntax
 ///
 /// A syntax is defined for the unambiguous conversion
-/// between a string and an `AttributeSelector` value,
+/// between a string and an [`AttributeSelector`] value,
 /// in both directions.
 /// Attribute selectors are defined by the syntax
 /// `( «key»([«item»])? . )* «key» `
 /// where:
 ///
 /// - _`«key»`_ is either a DICOM tag in a supported textual form,
-///   or a tag keyword as accepted by the [data dictionary][dict] in use;
+///   or a tag keyword as accepted by the [`crate::dictionary::DataDictionary`]
+///   in use;
 /// - _`«item»`_ is an unsigned integer representing the item index,
 ///   which is always surrounded by square brackets in the input;
 /// - _`[`_, _`]`_, and _`.`_ are literally their own characters
 ///   as part of the input.
 ///
-/// [dict]: crate::dictionary::DataDictionary
-///
 /// The first part in parentheses may appear zero or more times.
 /// The `[«item»]` part can be omitted,
 /// in which case it is assumed that the first item is selected.
 /// Whitespace is not admitted in any position.
-/// Displaying a selector through the [`Display`](std::fmt::Display) trait
+/// Displaying a selector through the [`std::fmt::Display`] trait
 /// produces a string that is compliant with this syntax.
 ///
 /// ### Examples of attribute selectors in text:
@@ -199,7 +208,7 @@ impl std::fmt::Display for AttributeSelectorStep {
 ///
 /// In most cases, you might only wish to select an attribute
 /// that is sitting at the root of the data set.
-/// This can be done by converting a [DICOM tag](crate::Tag) via [`From<Tag>`]:
+/// This can be done by converting a [`tag`](Tag) via [`From<Tag>`]:
 ///
 /// ```
 /// # use dicom_core::Tag;
@@ -234,8 +243,6 @@ impl std::fmt::Display for AttributeSelectorStep {
 /// Note that the function fails
 /// if the last step refers to a sequence item.
 ///
-/// [`new`]: AttributeSelector::new
-///
 /// ```
 /// # use dicom_core::Tag;
 /// # use dicom_core::ops::{AttributeSelector, AttributeSelectorStep};
@@ -253,8 +260,10 @@ impl std::fmt::Display for AttributeSelectorStep {
 /// # Result::<_, &'static str>::Ok(())
 /// ```
 ///
-/// A data dictionary's [`parse_selector`][parse] method
-/// can be used if you want to describe these selectors in text.
+/// A data dictionary's [`DataDictionary::parse_selector`]
+/// method can be used if you want to describe these selectors in text.
+///
+/// [`DataDictionary::parse_selector`]: crate::dictionary::DataDictionary::parse_selector
 ///
 /// ```no_run
 /// # // compile only: we don't have the std dict here
@@ -281,8 +290,6 @@ impl std::fmt::Display for AttributeSelectorStep {
 /// );
 /// # Result::<_, Box<dyn std::error::Error>>::Ok(())
 /// ```
-///
-/// [parse]: crate::dictionary::DataDictionary::parse_selector
 ///
 /// Selectors can be decomposed back into its constituent steps
 /// by turning it into an iterator:
@@ -313,14 +320,12 @@ impl AttributeSelector {
     /// Construct an attribute selector
     /// from an arbitrary sequence of selector steps.
     ///
-    /// Intermediate steps of variant [`Tag`][1]
+    /// Intermediate steps of variant [`AttributeSelectorStep::Tag`]
     /// (which do not specify an item index)
     /// are automatically reinterpreted as item selectors for item index 0.
     ///
-    /// Returns `None` if the sequence is empty
+    /// Returns [`None`] if the sequence is empty
     /// or the last step is not a tag selector step.
-    ///
-    /// [1]: AttributeSelectorStep::Tag
     pub fn new(steps: impl IntoIterator<Item = AttributeSelectorStep>) -> Option<Self> {
         let mut steps: SmallVec<_> = steps.into_iter().collect();
         debug_assert!(steps.len() < 256);
@@ -341,11 +346,11 @@ impl AttributeSelector {
     /// and its remainder.
     ///
     /// If the first part of the tuple is the last step of the selector,
-    /// the first item will be of the variant [`Tag`](AttributeSelectorStep::Tag)
+    /// the first item will be of the variant [`AttributeSelectorStep::Tag`]
     /// and the second item of the tuple will be `None`.
     /// Otherwise,
     /// the first item is guaranteed to be of the variant
-    /// [`Nested`](AttributeSelectorStep::Nested).
+    /// [`AttributeSelectorStep::Nested`].
     pub fn split_first(&self) -> (AttributeSelectorStep, Option<AttributeSelector>) {
         match self.0.split_first() {
             Some((first, rest)) => {
@@ -365,11 +370,10 @@ impl AttributeSelector {
     /// Return a non-empty iterator over the steps of attribute selection.
     ///
     /// The iterator is guaranteed to produce a series
-    /// starting with zero or more steps of the variant [`Nested`][1],
-    /// and terminated by one item guaranteed to be a [tag][2].
-    ///
-    /// [1]: AttributeSelectorStep::Nested
-    /// [2]: AttributeSelectorStep::Tag
+    /// starting with zero or more steps of the variant
+    /// [`AttributeSelectorStep::Nested`],
+    /// and terminated by one item guaranteed to be a
+    /// [`AttributeSelectorStep::Tag`].
     pub fn iter(&self) -> impl Iterator<Item = &AttributeSelectorStep> {
         self.into_iter()
     }
@@ -414,11 +418,10 @@ impl IntoIterator for AttributeSelector {
     /// Returns a non-empty iterator over the steps of attribute selection.
     ///
     /// The iterator is guaranteed to produce a series
-    /// starting with zero or more steps of the variant [`Nested`][1],
-    /// and terminated by one item guaranteed to be a [tag][2].
-    ///
-    /// [1]: AttributeSelectorStep::Nested
-    /// [2]: AttributeSelectorStep::Tag
+    /// starting with zero or more steps of the variant
+    /// [`AttributeSelectorStep::Nested`],
+    /// and terminated by one item guaranteed to be a
+    /// [`AttributeSelectorStep::Tag`].
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
@@ -431,11 +434,10 @@ impl<'a> IntoIterator for &'a AttributeSelector {
     /// Returns a non-empty iterator over the steps of attribute selection.
     ///
     /// The iterator is guaranteed to produce a series
-    /// starting with zero or more steps of the variant [`Nested`][1],
-    /// and terminated by one item guaranteed to be a [tag][2].
-    ///
-    /// [1]: AttributeSelectorStep::Nested
-    /// [2]: AttributeSelectorStep::Tag
+    /// starting with zero or more steps of the variant
+    /// [`AttributeSelectorStep::Nested`],
+    /// and terminated by one item guaranteed to be a
+    /// [`AttributeSelectorStep::Tag`].
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
     }

--- a/core/src/value/deserialize.rs
+++ b/core/src/value/deserialize.rs
@@ -56,7 +56,7 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Decode a single DICOM Date (DA) into a `chrono::NaiveDate` value.
+/// Decode a single DICOM Date (DA) into a [`chrono::NaiveDate`] value.
 /// As per standard, a full 8 byte representation (YYYYMMDD) is required,
 /// otherwise, the operation fails.
 pub fn parse_date(buf: &[u8]) -> Result<NaiveDate> {
@@ -83,10 +83,9 @@ pub fn parse_date(buf: &[u8]) -> Result<NaiveDate> {
     }
 }
 
-/** Decode a single DICOM Date (DA) into a `DicomDate` value.
- * Unlike `parse_date`, this method accepts incomplete dates such as YYYY and YYYYMM
- * The precision of the value is stored.
- */
+/// Decode a single DICOM Date (DA) into a [`DicomDate`] value.
+/// Unlike [`parse_date`], this method accepts incomplete dates such as YYYY and YYYYMM
+/// The precision of the value is stored.
 pub fn parse_date_partial(buf: &[u8]) -> Result<(DicomDate, &[u8])> {
     if buf.len() < 4 {
         UnexpectedEndOfElementSnafu.fail()
@@ -127,10 +126,9 @@ pub fn parse_date_partial(buf: &[u8]) -> Result<(DicomDate, &[u8])> {
     }
 }
 
-/** Decode a single DICOM Time (TM) into a `DicomTime` value.
- * Unlike `parse_time`, this method allows for missing Time components.
- * The precision of the second fraction is stored and can be returned as a range later.
- */
+/// Decode a single DICOM Time (TM) into a [`DicomTime`] value.
+/// Unlike [`parse_time`], this method allows for missing Time components.
+/// The precision of the second fraction is stored and can be returned as a range later.
 pub fn parse_time_partial(buf: &[u8]) -> Result<(DicomTime, &[u8])> {
     if buf.len() < 2 {
         UnexpectedEndOfElementSnafu.fail()
@@ -188,13 +186,12 @@ pub fn parse_time_partial(buf: &[u8]) -> Result<(DicomTime, &[u8])> {
     }
 }
 
-/** Decode a single DICOM Time (TM) into a `chrono::NaiveTime` value.
-* If a time component is missing, the operation fails.
-* Presence of the second fraction component `.FFFFFF` is mandatory with at
-  least one digit accuracy `.F` while missing digits default to zero.
-* For Time with missing components, or if exact second fraction accuracy needs to be preserved,
-  use `parse_time_partial`.
-*/
+/// Decode a single DICOM Time (TM) into a [`chrono::NaiveTime`] value.
+/// If a time component is missing, the operation fails.
+/// Presence of the second fraction component `.FFFFFF` is mandatory with at
+/// least one digit accuracy `.F` while missing digits default to zero.
+/// For Time with missing components, or if exact second fraction accuracy needs to be preserved,
+/// use [`parse_time_partial`].
 pub fn parse_time(buf: &[u8]) -> Result<(NaiveTime, &[u8])> {
     // at least HHMMSS.F required
     match buf.len() {
@@ -332,8 +329,8 @@ where
 /// Decode the text from the byte slice into a [`DicomDateTime`] value,
 /// which allows for missing Date / Time components.
 ///
-/// This is the underlying implementation of [`FromStr`](std::str::FromStr)
-/// for `DicomDateTime`.
+/// This is the underlying implementation of [`std::str::FromStr`]
+/// for [`DicomDateTime`].
 ///
 /// # Example
 ///

--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -84,7 +84,7 @@ where
 /// `I` is the complex type for nest data set items, which should usually
 /// implement [`HasLength`].
 /// `P` is the encapsulated pixel data provider,
-/// which should usually implement `AsRef<[u8]>`.
+/// which should usually implement [`AsRef<[u8]>`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value<I = EmptyObject, P = InMemFragment> {
     /// Primitive value.
@@ -105,7 +105,7 @@ impl<P> Value<EmptyObject, P> {
     /// As a consequence, it cannot be directly combined with
     /// DICOM objects that may contain sequence values.
     /// To let the type parameter `I` be inferred from its context,
-    /// create a [`PixelFragmentSequence`] and use `Value::from` instead.
+    /// create a [`PixelFragmentSequence`] and use [`Value::from`] instead.
     ///
     /// **Note:** This function does not validate the offset table
     /// against the fragments.
@@ -122,11 +122,11 @@ impl<I> Value<I> {
     /// from a list of items and length.
     ///
     /// This function will define the pixel data fragment type parameter `P`
-    /// to the `Value` type's default ([`InMemFragment`]),
+    /// to the [`Value`] type's default ([`InMemFragment`]),
     /// so that it can be used more easily.
     /// If necessary,
     /// it is possible to let this type parameter be inferred from its context
-    /// by creating a [`DataSetSequence`] and using `Value::from` instead.
+    /// by creating a [`DataSetSequence`] and using [`Value::from`] instead.
     #[inline]
     pub fn new_sequence<T>(items: T, length: Length) -> Self
     where
@@ -139,7 +139,7 @@ impl<I> Value<I> {
 impl Value {
     /// Construct a DICOM value from a primitive value.
     ///
-    /// This is equivalent to `Value::from` in behavior,
+    /// This is equivalent to [`Value::from`] in behavior,
     /// except that suitable type parameters are specified
     /// instead of inferred.
     ///
@@ -153,7 +153,7 @@ impl Value {
     /// DICOM objects that may contain
     /// nested data sets or encapsulated pixel data.
     /// To let the type parameters `I` and `P` be inferred from their context,
-    /// create a value of one of the types and use `Value::from` instead.
+    /// create a value of one of the types and use [`Value::from`] instead.
     ///
     /// - [`PrimitiveValue`]
     /// - [`PixelFragmentSequence`]
@@ -217,7 +217,7 @@ impl<I, P> Value<I, P> {
 
     /// Gets a reference to the items of a sequence.
     ///
-    /// Returns `None` if the value is not a data set sequence.
+    /// Returns [`None`] if the value is not a data set sequence.
     pub fn items(&self) -> Option<&[I]> {
         match self {
             Value::Sequence(v) => Some(v.items()),
@@ -227,7 +227,7 @@ impl<I, P> Value<I, P> {
 
     /// Gets a mutable reference to the items of a sequence.
     ///
-    /// Returns `None` if the value is not a data set sequence.
+    /// Returns [`None`] if the value is not a data set sequence.
     pub fn items_mut(&mut self) -> Option<&mut C<I>> {
         match self {
             Value::Sequence(v) => Some(v.items_mut()),
@@ -237,7 +237,7 @@ impl<I, P> Value<I, P> {
 
     /// Gets a reference to the fragments of a pixel data sequence.
     ///
-    /// Returns `None` if the value is not a pixel data sequence.
+    /// Returns [`None`] if the value is not a pixel data sequence.
     pub fn fragments(&self) -> Option<&[P]> {
         match self {
             Value::PixelSequence(v) => Some(v.fragments()),
@@ -247,7 +247,7 @@ impl<I, P> Value<I, P> {
 
     /// Gets a mutable reference to the fragments of a pixel data sequence.
     ///
-    /// Returns `None` if the value is not a pixel data sequence.
+    /// Returns [`None`] if the value is not a pixel data sequence.
     pub fn fragments_mut(&mut self) -> Option<&mut C<P>> {
         match self {
             Value::PixelSequence(v) => Some(v.fragments_mut()),
@@ -266,7 +266,7 @@ impl<I, P> Value<I, P> {
     /// Retrieves the data set items,
     /// discarding the recorded length information.
     ///
-    /// Returns `None` if the value is not a data set sequence.
+    /// Returns [`None`] if the value is not a data set sequence.
     pub fn into_items(self) -> Option<C<I>> {
         match self {
             Value::Sequence(v) => Some(v.into_items()),
@@ -285,7 +285,7 @@ impl<I, P> Value<I, P> {
 
     /// Gets a reference to the encapsulated pixel data's offset table.
     ///
-    /// Returns `None` if the value is not a pixel data sequence.
+    /// Returns [`None`] if the value is not a pixel data sequence.
     pub fn offset_table(&self) -> Option<&[u32]> {
         match self {
             Value::PixelSequence(v) => Some(v.offset_table()),
@@ -295,7 +295,7 @@ impl<I, P> Value<I, P> {
 
     /// Gets a mutable reference to the encapsulated pixel data's offset table.
     ///
-    /// Returns `None` if the value is not a pixel data sequence.
+    /// Returns [`None`] if the value is not a pixel data sequence.
     pub fn offset_table_mut(&mut self) -> Option<&mut C<u32>> {
         match self {
             Value::PixelSequence(v) => Some(v.offset_table_mut()),
@@ -454,8 +454,6 @@ where
     /// a vector of strings as described in [`PrimitiveValue::to_multi_str`].
     ///
     /// Returns an error if the value is not primitive.
-    ///
-    /// [`PrimitiveValue::to_multi_str`]: ../enum.PrimitiveValue.html#to_multi_str
     pub fn to_multi_str(&self) -> Result<Cow<'_, [String]>, CastValueError> {
         match self {
             Value::Primitive(prim) => Ok(prim.to_multi_str()),
@@ -468,8 +466,8 @@ where
 
     /// Convert the full primitive value into raw bytes.
     ///
-    /// String values already encoded with the `Str` and `Strs` variants
-    /// are provided in UTF-8.
+    /// String values already encoded with the [`PrimitiveValue::Str`] and
+    /// [`PrimitiveValue::Strs`] variants are provided in UTF-8.
     ///
     /// Returns an error if the value is not primitive.
     pub fn to_bytes(&self) -> Result<Cow<'_, [u8]>, ConvertValueError> {
@@ -487,8 +485,6 @@ where
     ///
     /// If the value is a primitive, it will be converted into
     /// an integer as described in [`PrimitiveValue::to_int`].
-    ///
-    /// [`PrimitiveValue::to_int`]: ../enum.PrimitiveValue.html#to_int
     pub fn to_int<T>(&self) -> Result<T, ConvertValueError>
     where
         T: Clone,
@@ -508,9 +504,7 @@ where
     /// Retrieve and convert the primitive value into a sequence of integers.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of integers as described in [PrimitiveValue::to_multi_int].
-    ///
-    /// [PrimitiveValue::to_multi_int]: ../enum.PrimitiveValue.html#to_multi_int
+    /// a vector of integers as described in [`PrimitiveValue::to_multi_int`].
     pub fn to_multi_int<T>(&self) -> Result<Vec<T>, ConvertValueError>
     where
         T: Clone,
@@ -532,8 +526,6 @@ where
     ///
     /// If the value is a primitive, it will be converted into
     /// a number as described in [`PrimitiveValue::to_float32`].
-    ///
-    /// [`PrimitiveValue::to_float32`]: ../enum.PrimitiveValue.html#to_float32
     pub fn to_float32(&self) -> Result<f32, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_float32(),
@@ -549,9 +541,8 @@ where
     /// into a sequence of single-precision floating point numbers.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of numbers as described in [`PrimitiveValue::to_multi_float32`].
-    ///
-    /// [`PrimitiveValue::to_multi_float32`]: ../enum.PrimitiveValue.html#to_multi_float32
+    /// a vector of numbers as described in
+    /// [`PrimitiveValue::to_multi_float32`].
     pub fn to_multi_float32(&self) -> Result<Vec<f32>, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_multi_float32(),
@@ -568,8 +559,6 @@ where
     ///
     /// If the value is a primitive, it will be converted into
     /// a number as described in [`PrimitiveValue::to_float64`].
-    ///
-    /// [`PrimitiveValue::to_float64`]: ../enum.PrimitiveValue.html#to_float64
     pub fn to_float64(&self) -> Result<f64, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_float64(),
@@ -585,9 +574,8 @@ where
     /// into a sequence of double-precision floating point numbers.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of numbers as described in [`PrimitiveValue::to_multi_float64`].
-    ///
-    /// [`PrimitiveValue::to_multi_float64`]: ../enum.PrimitiveValue.html#to_multi_float64
+    /// a vector of numbers as described in
+    /// [`PrimitiveValue::to_multi_float64`].
     pub fn to_multi_float64(&self) -> Result<Vec<f64>, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_multi_float64(),
@@ -599,11 +587,10 @@ where
         }
     }
 
-    /// Retrieve and convert the primitive value into a `DicomDate`.
+    /// Retrieve and convert the primitive value into a [`DicomDate`].
     ///
     /// If the value is a primitive, it will be converted into
-    /// a `DicomDate` as described in [`PrimitiveValue::to_date`].
-    ///
+    /// a [`DicomDate`] as described in [`PrimitiveValue::to_date`].
     pub fn to_date(&self) -> Result<DicomDate, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_date(),
@@ -615,11 +602,12 @@ where
         }
     }
 
-    /// Retrieve and convert the primitive value into a sequence of `DicomDate`s.
+    /// Retrieve and convert the primitive value into a sequence of
+    /// [`DicomDate`]s.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of `DicomDate` as described in [`PrimitiveValue::to_multi_date`].
-    ///
+    /// a vector of [`DicomDate`] as described in
+    /// [`PrimitiveValue::to_multi_date`].
     pub fn to_multi_date(&self) -> Result<Vec<DicomDate>, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_multi_date(),
@@ -631,11 +619,10 @@ where
         }
     }
 
-    /// Retrieve and convert the primitive value into a `DicomTime`.
+    /// Retrieve and convert the primitive value into a [`DicomTime`].
     ///
     /// If the value is a primitive, it will be converted into
-    /// a `DicomTime` as described in [`PrimitiveValue::to_time`].
-    ///
+    /// a [`DicomTime`] as described in [`PrimitiveValue::to_time`].
     pub fn to_time(&self) -> Result<DicomTime, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_time(),
@@ -647,11 +634,12 @@ where
         }
     }
 
-    /// Retrieve and convert the primitive value into a sequence of `DicomTime`s.
+    /// Retrieve and convert the primitive value into a sequence of
+    /// [`DicomTime`]s.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of `DicomTime` as described in [`PrimitiveValue::to_multi_time`].
-    ///
+    /// a vector of [`DicomTime`] as described in
+    /// [`PrimitiveValue::to_multi_time`].
     pub fn to_multi_time(&self) -> Result<Vec<DicomTime>, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_multi_time(),
@@ -663,11 +651,11 @@ where
         }
     }
 
-    /// Retrieve and convert the primitive value into a `DicomDateTime`.
+    /// Retrieve and convert the primitive value into a [`DicomDateTime`].
     ///
     /// If the value is a primitive, it will be converted into
-    /// a `DateTime` as described in [`PrimitiveValue::to_datetime`].
-    ///
+    /// a [`PrimitiveValue::DateTime`] as described in
+    /// [`PrimitiveValue::to_datetime`].
     pub fn to_datetime(&self) -> Result<DicomDateTime, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_datetime(),
@@ -679,11 +667,12 @@ where
         }
     }
 
-    /// Retrieve and convert the primitive value into a sequence of `DicomDateTime`s.
+    /// Retrieve and convert the primitive value into a sequence of
+    /// [`DicomDateTime`]s.
     ///
     /// If the value is a primitive, it will be converted into
-    /// a vector of `DicomDateTime` as described in [`PrimitiveValue::to_multi_datetime`].
-    ///
+    /// a vector of [`DicomDateTime`] as described in
+    /// [`PrimitiveValue::to_multi_datetime`].
     pub fn to_multi_datetime(&self) -> Result<Vec<DicomDateTime>, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_multi_datetime(),
@@ -695,11 +684,10 @@ where
         }
     }
 
-    /// Retrieve and convert the primitive value into a `DateRange`.
+    /// Retrieve and convert the primitive value into a [`DateRange`].
     ///
     /// If the value is a primitive, it will be converted into
-    /// a `DateRange` as described in [`PrimitiveValue::to_date_range`].
-    ///
+    /// a [`DateRange`] as described in [`PrimitiveValue::to_date_range`].
     pub fn to_date_range(&self) -> Result<DateRange, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_date_range(),
@@ -711,11 +699,10 @@ where
         }
     }
 
-    /// Retrieve and convert the primitive value into a `TimeRange`.
+    /// Retrieve and convert the primitive value into a [`TimeRange`].
     ///
     /// If the value is a primitive, it will be converted into
-    /// a `TimeRange` as described in [`PrimitiveValue::to_time_range`].
-    ///
+    /// a [`TimeRange`] as described in [`PrimitiveValue::to_time_range`].
     pub fn to_time_range(&self) -> Result<TimeRange, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_time_range(),
@@ -727,11 +714,11 @@ where
         }
     }
 
-    /// Retrieve and convert the primitive value into a `DateTimeRange`.
+    /// Retrieve and convert the primitive value into a [`DateTimeRange`].
     ///
     /// If the value is a primitive, it will be converted into
-    /// a `DateTimeRange` as described in [`PrimitiveValue::to_datetime_range`].
-    ///
+    /// a [`DateTimeRange`] as described in
+    /// [`PrimitiveValue::to_datetime_range`].
     pub fn to_datetime_range(&self) -> Result<DateTimeRange, ConvertValueError> {
         match self {
             Value::Primitive(v) => v.to_datetime_range(),
@@ -768,9 +755,9 @@ where
 }
 
 /// Macro for implementing getters to single and multi-values,
-/// by delegating to `PrimitiveValue`.
+/// by delegating to [`PrimitiveValue`].
 ///
-/// Should be placed inside `Value`'s impl block.
+/// Should be placed inside [`Value`]'s impl block.
 macro_rules! impl_primitive_getters {
     ($name_single: ident, $name_multi: ident, $variant: ident, $ret: ty) => {
         /// Get a single value of the requested type.
@@ -812,9 +799,9 @@ impl<I, P> Value<I, P> {
     /// An error is returned if the variant is not compatible.
     ///
     /// To enable conversions of other variants to a textual representation,
-    /// see [`to_str()`] instead.
+    /// see [`DataElement::to_str`] instead.
     ///
-    /// [`to_str()`]: #method.to_str
+    /// [`DataElement::to_str`]: crate::header::DataElement::to_str
     pub fn string(&self) -> Result<&str, CastValueError> {
         match self {
             Value::Primitive(v) => v.string(),
@@ -826,14 +813,15 @@ impl<I, P> Value<I, P> {
     }
 
     /// Get the inner sequence of string values
-    /// if the variant is either `Str` or `Strs`.
+    /// if the variant is either [`PrimitiveValue::Str`] or
+    /// [`PrimitiveValue::Strs`].
     ///
     /// An error is returned if the variant is not compatible.
     ///
     /// To enable conversions of other variants to a textual representation,
-    /// see [`to_str()`] instead.
+    /// see [`DataElement::to_str`] instead.
     ///
-    /// [`to_str()`]: #method.to_str
+    /// [`DataElement::to_str`]: crate::header::DataElement::to_str
     pub fn strings(&self) -> Result<&[String], CastValueError> {
         match self {
             Value::Primitive(v) => v.strings(),
@@ -872,7 +860,7 @@ pub struct DataSetSequence<I> {
     items: C<I>,
     /// The sequence length in bytes.
     ///
-    /// The value may be [`UNDEFINED`](Length::UNDEFINED)
+    /// The value may be [`Length::UNDEFINED`]
     /// if the length is implicitly defined,
     /// otherwise it should match the full byte length of all items.
     length: Length,
@@ -885,7 +873,7 @@ impl<I> DataSetSequence<I> {
     /// **Note:** This function does not validate the `length`
     /// against the items.
     /// When not sure,
-    /// `length` can be set to [`UNDEFINED`](Length::UNDEFINED)
+    /// `length` can be set to [`Length::UNDEFINED`]
     /// to leave it as implicitly defined.
     #[inline]
     pub fn new(items: impl Into<C<I>>, length: Length) -> Self {
@@ -984,7 +972,7 @@ where
     A: smallvec::Array<Item = I>,
     C<I>: From<SmallVec<A>>,
 {
-    /// Converts a smallvec of items
+    /// Converts a [`smallvec`] of items
     /// into a data set sequence with an undefined length.
     #[inline]
     fn from(items: SmallVec<A>) -> Self {

--- a/core/src/value/partial.rs
+++ b/core/src/value/partial.rs
@@ -89,10 +89,10 @@ pub enum DateComponent {
 /// Represents a Dicom date (DA) value with a partial precision,
 /// where some date components may be missing.
 ///
-/// Unlike [chrono::NaiveDate], it does not allow for negative years.
+/// Unlike [`chrono::NaiveDate`], it does not allow for negative years.
 ///
-/// `DicomDate` implements [AsRange] trait, enabling to retrieve specific
-/// [date](NaiveDate) values.
+/// [`DicomDate`] implements [`AsRange`] trait, enabling to retrieve specific
+/// [`NaiveDate`] values.
 ///
 /// # Example
 /// ```
@@ -123,11 +123,11 @@ pub struct DicomDate(DicomDateImpl);
 /// Represents a Dicom time (TM) value with a partial precision,
 /// where some time components may be missing.
 ///
-/// Unlike [chrono::NaiveTime], this implementation has only 6 digit precision
+/// Unlike [`chrono::NaiveTime`], this implementation has only 6 digit precision
 /// for fraction of a second.
 ///
-/// `DicomTime` implements [AsRange] trait, enabling to retrieve specific
-/// [time](NaiveTime) values.
+/// [`DicomTime`] implements [`AsRange`] trait, enabling to retrieve specific
+/// [`NaiveTime`] values.
 ///
 /// # Example
 /// ```
@@ -167,7 +167,7 @@ pub struct DicomDate(DicomDateImpl);
 #[derive(Clone, Copy, PartialEq)]
 pub struct DicomTime(DicomTimeImpl);
 
-/// `DicomDate` is internally represented as this enum.
+/// [`DicomDate`] is internally represented as this enum.
 /// It has 3 possible variants for YYYY, YYYYMM, YYYYMMDD values.
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum DicomDateImpl {
@@ -176,9 +176,9 @@ enum DicomDateImpl {
     Day(u16, u8, u8),
 }
 
-/// `DicomTime` is internally represented as this enum.
+/// [`DicomTime`] is internally represented as this enum.
 /// It has 4 possible variants.
-/// The `Fraction` variant stores the fraction second value as `u32`
+/// The [`Self::Fraction`] variant stores the fraction second value as [`u32`]
 /// followed by fraction precision as `u8` ranging from 1 to 6.
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum DicomTimeImpl {
@@ -191,10 +191,10 @@ enum DicomTimeImpl {
 /// Represents a Dicom date-time (DT) value with a partial precision,
 /// where some date or time components may be missing.
 ///
-/// `DicomDateTime` is always internally represented by a [DicomDate].
-/// The [DicomTime] and a timezone [FixedOffset] values are optional.
+/// [`DicomDateTime`] is always internally represented by a [`DicomDate`].
+/// The [`DicomTime`] and a timezone [`FixedOffset`] values are optional.
 ///
-/// It implements [AsRange] trait,
+/// It implements [`AsRange`] trait,
 /// which serves to retrieve a [`PreciseDateTime`]
 /// from values with missing components.
 /// # Example
@@ -250,9 +250,8 @@ pub struct DicomDateTime {
     time_zone: Option<FixedOffset>,
 }
 
-/**
- * Throws a detailed `InvalidComponent` error if date / time components are out of range.
- */
+/// Throws a detailed [`Error::InvalidComponent`] error if
+/// date / time components are out of range.
 pub fn check_component<T>(component: DateComponent, value: &T) -> Result<()>
 where
     T: Into<u32> + Copy,
@@ -284,27 +283,21 @@ where
 }
 
 impl DicomDate {
-    /**
-     * Constructs a new `DicomDate` with year precision
-     * (`YYYY`)
-     */
+    /// Constructs a new [`DicomDate`] with year precision (`YYYY`)
     pub fn from_y(year: u16) -> Result<DicomDate> {
         check_component(DateComponent::Year, &year)?;
         Ok(DicomDate(DicomDateImpl::Year(year)))
     }
-    /**
-     * Constructs a new `DicomDate` with year and month precision
-     * (`YYYYMM`)
-     */
+
+    /// Constructs a new [`DicomDate`] with year and month precision (`YYYYMM`)
     pub fn from_ym(year: u16, month: u8) -> Result<DicomDate> {
         check_component(DateComponent::Year, &year)?;
         check_component(DateComponent::Month, &month)?;
         Ok(DicomDate(DicomDateImpl::Month(year, month)))
     }
-    /**
-     * Constructs a new `DicomDate` with a year, month and day precision
-     * (`YYYYMMDD`)
-     */
+
+    /// Constructs a new [`DicomDate`] with a year, month and day precision
+    /// (`YYYYMMDD`)
     pub fn from_ymd(year: u16, month: u8, day: u8) -> Result<DicomDate> {
         check_component(DateComponent::Year, &year)?;
         check_component(DateComponent::Month, &month)?;
@@ -320,6 +313,7 @@ impl DicomDate {
             DicomDate(DicomDateImpl::Day(y, _, _)) => y,
         }
     }
+
     /// Retrieves the month from a date as a reference
     pub fn month(&self) -> Option<&u8> {
         match self {
@@ -328,6 +322,7 @@ impl DicomDate {
             DicomDate(DicomDateImpl::Day(_, m, _)) => Some(m),
         }
     }
+
     /// Retrieves the day from a date as a reference
     pub fn day(&self) -> Option<&u8> {
         match self {
@@ -337,7 +332,7 @@ impl DicomDate {
         }
     }
 
-    /** Retrieves the last fully precise `DateComponent` of the value */
+    /// Retrieves the last fully precise [`DateComponent`] of the value
     pub(crate) fn precision(&self) -> DateComponent {
         match self {
             DicomDate(DicomDateImpl::Year(..)) => DateComponent::Year,
@@ -396,39 +391,30 @@ impl fmt::Debug for DicomDate {
 }
 
 impl DicomTime {
-    /**
-     * Constructs a new `DicomTime` with hour precision
-     * (`HH`).
-     */
+    /// Constructs a new [`DicomTime`] with hour precision (`HH`).
     pub fn from_h(hour: u8) -> Result<DicomTime> {
         check_component(DateComponent::Hour, &hour)?;
         Ok(DicomTime(DicomTimeImpl::Hour(hour)))
     }
 
-    /**
-     * Constructs a new `DicomTime` with hour and minute precision
-     * (`HHMM`).
-     */
+    /// Constructs a new [`DicomTime`] with hour and minute precision (`HHMM`).
     pub fn from_hm(hour: u8, minute: u8) -> Result<DicomTime> {
         check_component(DateComponent::Hour, &hour)?;
         check_component(DateComponent::Minute, &minute)?;
         Ok(DicomTime(DicomTimeImpl::Minute(hour, minute)))
     }
 
-    /**
-     * Constructs a new `DicomTime` with hour, minute and second precision
-     * (`HHMMSS`).
-     */
+    /// Constructs a new [`DicomTime`] with hour, minute and second precision
+    /// (`HHMMSS`).
     pub fn from_hms(hour: u8, minute: u8, second: u8) -> Result<DicomTime> {
         check_component(DateComponent::Hour, &hour)?;
         check_component(DateComponent::Minute, &minute)?;
         check_component(DateComponent::Second, &second)?;
         Ok(DicomTime(DicomTimeImpl::Second(hour, minute, second)))
     }
-    /**
-     * Constructs a new `DicomTime` from an hour, minute, second and millisecond value,
-     * which leads to the precision `HHMMSS.FFF`. Millisecond cannot exceed `999`.
-     */
+
+    /// Constructs a new [`DicomTime`] from an hour, minute, second and millisecond value,
+    /// which leads to the precision `HHMMSS.FFF`. Millisecond cannot exceed `999`.
     pub fn from_hms_milli(hour: u8, minute: u8, second: u8, millisecond: u32) -> Result<DicomTime> {
         check_component(DateComponent::Millisecond, &millisecond)?;
         Ok(DicomTime(DicomTimeImpl::Fraction(
@@ -440,7 +426,7 @@ impl DicomTime {
         )))
     }
 
-    /// Constructs a new `DicomTime` from an hour, minute, second and microsecond value,
+    /// Constructs a new [`DicomTime`] from an hour, minute, second and microsecond value,
     /// which leads to the full precision `HHMMSS.FFFFFF`.
     ///
     /// Microsecond cannot exceed `999_999`.
@@ -456,7 +442,7 @@ impl DicomTime {
         )))
     }
 
-    /** Retrieves the hour from a time as a reference */
+    /// Retrieves the hour from a time as a reference
     pub fn hour(&self) -> &u8 {
         match self {
             DicomTime(DicomTimeImpl::Hour(h)) => h,
@@ -465,7 +451,8 @@ impl DicomTime {
             DicomTime(DicomTimeImpl::Fraction(h, _, _, _, _)) => h,
         }
     }
-    /** Retrieves the minute from a time as a reference */
+
+    /// Retrieves the minute from a time as a reference
     pub fn minute(&self) -> Option<&u8> {
         match self {
             DicomTime(DicomTimeImpl::Hour(_)) => None,
@@ -474,7 +461,8 @@ impl DicomTime {
             DicomTime(DicomTimeImpl::Fraction(_, m, _, _, _)) => Some(m),
         }
     }
-    /** Retrieves the minute from a time as a reference */
+
+    /// Retrieves the minute from a time as a reference
     pub fn second(&self) -> Option<&u8> {
         match self {
             DicomTime(DicomTimeImpl::Hour(_)) => None,
@@ -486,7 +474,7 @@ impl DicomTime {
 
     /// Retrieves the fraction of a second in milliseconds.
     ///
-    /// Only returns `Some(_)` if the time is precise to the millisecond or more.
+    /// Only returns [`Some`] if the time is precise to the millisecond or more.
     /// Any precision beyond the millisecond is discarded.
     pub fn millisecond(&self) -> Option<u32> {
         self.fraction_and_precision().and_then(|(f, fp)| match fp {
@@ -501,7 +489,7 @@ impl DicomTime {
 
     /// Retrieves the total known fraction of a second in microseconds.
     ///
-    /// Only returns `None` if the time value defines no fraction of a second.
+    /// Only returns [`None`] if the time value defines no fraction of a second.
     ///
     /// # Example
     ///
@@ -532,7 +520,7 @@ impl DicomTime {
     /// This may result in precision loss if
     /// the time value was more precise than 3 decimal places.
     ///
-    /// Only returns `None` if the time value defines no fraction of a second.
+    /// Only returns [`None`] if the time value defines no fraction of a second.
     ///
     /// # Example
     ///
@@ -609,10 +597,9 @@ impl DicomTime {
         }
     }
 
-    /**
-     * Constructs a new `DicomTime` from an hour, minute, second, second fraction
-     * and fraction precision value (1-6). Function used for parsing only.
-     */
+    /// Constructs a new [`DicomTime`] from an hour, minute, second,
+    /// second fraction and fraction precision value (1-6).
+    /// Function used for parsing only.
     pub(crate) fn from_hmsf(
         hour: u8,
         minute: u8,
@@ -648,7 +635,7 @@ impl DicomTime {
         )))
     }
 
-    /** Retrieves the last fully precise `DateComponent` of the value */
+    /// Retrieves the last fully precise [`DateComponent`] of the value
     pub(crate) fn precision(&self) -> DateComponent {
         match self {
             DicomTime(DicomTimeImpl::Hour(..)) => DateComponent::Hour,
@@ -734,9 +721,7 @@ impl fmt::Debug for DicomTime {
 }
 
 impl DicomDateTime {
-    /**
-     * Constructs a new `DicomDateTime` from a `DicomDate` and a timezone `FixedOffset`.
-     */
+    /// Constructs a new [`DicomDateTime`] from a [`DicomDate`] and a timezone [`FixedOffset`].
     pub fn from_date_with_time_zone(date: DicomDate, time_zone: FixedOffset) -> DicomDateTime {
         DicomDateTime {
             date,
@@ -745,9 +730,7 @@ impl DicomDateTime {
         }
     }
 
-    /**
-     * Constructs a new `DicomDateTime` from a `DicomDate` .
-     */
+    /// Constructs a new [`DicomDateTime`] from a [`DicomDate`].
     pub fn from_date(date: DicomDate) -> DicomDateTime {
         DicomDateTime {
             date,
@@ -756,10 +739,8 @@ impl DicomDateTime {
         }
     }
 
-    /**
-     * Constructs a new `DicomDateTime` from a `DicomDate` and a `DicomTime`,
-     * providing that `DicomDate` is precise.
-     */
+    /// Constructs a new [`DicomDateTime`] from a [`DicomDate`] and a
+    /// [`DicomTime`], providing that [`DicomDate`] is precise.
     pub fn from_date_and_time(date: DicomDate, time: DicomTime) -> Result<DicomDateTime> {
         if date.is_precise() {
             Ok(DicomDateTime {
@@ -775,10 +756,8 @@ impl DicomDateTime {
         }
     }
 
-    /**
-     * Constructs a new `DicomDateTime` from a `DicomDate`, `DicomTime` and a timezone `FixedOffset`,
-     * providing that `DicomDate` is precise.
-     */
+    /// Constructs a new [`DicomDateTime`] from a [`DicomDate`], [`DicomTime`]
+    /// and a timezone [`FixedOffset`], providing that [`DicomDate`] is precise.
     pub fn from_date_and_time_with_time_zone(
         date: DicomDate,
         time: DicomTime,
@@ -798,45 +777,39 @@ impl DicomDateTime {
         }
     }
 
-    /**
-     * Returns a DicomDateTime object corresponding to the
-     * current date and time in the system's local time zone
-     */
+    /// Returns a [`DicomDateTime`] object corresponding to the  current date
+    /// and time in the system's local time zone
     pub fn now_local() -> Result<DicomDateTime> {
         DicomDateTime::try_from(&Local::now().naive_local())
     }
 
-    /**
-     * Returns a DicomDateTime object corresponding to the
-     * current date and time in the UTC time zone
-     */
+    /// Returns a [`DicomDateTime`] object corresponding to the current date and
+    /// time in the UTC time zone
     pub fn now_utc() -> Result<DicomDateTime> {
         DicomDateTime::try_from(&Utc::now().naive_utc())
     }
 
-    /**
-     * Returns the components stored in a DicomDateTime, consuming it.
-     */
+    /// Returns the components stored in a [`DicomDateTime`], consuming it.
     pub fn into_parts(self) -> (DicomDate, Option<DicomTime>, Option<FixedOffset>) {
         (self.date, self.time, self.time_zone)
     }
 
-    /** Retrieves a reference to the internal date value */
+    /// Retrieves a reference to the internal date value
     pub fn date(&self) -> &DicomDate {
         &self.date
     }
 
-    /** Retrieves a reference to the internal time value, if present */
+    /// Retrieves a reference to the internal time value, if present
     pub fn time(&self) -> Option<&DicomTime> {
         self.time.as_ref()
     }
 
-    /** Retrieves a reference to the internal time-zone value, if present */
+    /// Retrieves a reference to the internal time-zone value, if present
     pub fn time_zone(&self) -> Option<&FixedOffset> {
         self.time_zone.as_ref()
     }
 
-    /** Returns true, if the `DicomDateTime` contains a time-zone */
+    /// Returns true, if the [`DicomDateTime`] contains a time-zone
     pub fn has_time_zone(&self) -> bool {
         self.time_zone.is_some()
     }
@@ -966,9 +939,7 @@ impl std::str::FromStr for DicomDateTime {
 }
 
 impl DicomDate {
-    /**
-     * Retrieves a dicom encoded string representation of the value.
-     */
+    /// Retrieves a dicom encoded string representation of the value.
     pub fn to_encoded(&self) -> String {
         match self {
             DicomDate(DicomDateImpl::Year(y)) => format!("{y:04}"),
@@ -979,9 +950,7 @@ impl DicomDate {
 }
 
 impl DicomTime {
-    /**
-     * Retrieves a dicom encoded string representation of the value.
-     */
+    /// Retrieves a dicom encoded string representation of the value.
     pub fn to_encoded(&self) -> String {
         match self {
             DicomTime(DicomTimeImpl::Hour(h)) => format!("{h:02}"),
@@ -996,9 +965,7 @@ impl DicomTime {
 }
 
 impl DicomDateTime {
-    /**
-     * Retrieves a dicom encoded string representation of the value.
-     */
+    /// Retrieves a dicom encoded string representation of the value.
     pub fn to_encoded(&self) -> String {
         match self.time {
             Some(time) => match self.time_zone {
@@ -1026,8 +993,7 @@ impl DicomDateTime {
 /// and can either be time-zone aware or time-zone naive.
 ///
 /// It is usually the outcome of converting a precise
-/// [DICOM date-time value](DicomDateTime)
-/// to a [chrono] date-time value.
+/// [`DicomDateTime`] to a [`chrono`] date-time value.
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum PreciseDateTime {
     /// Naive date-time, with no time zone
@@ -1037,7 +1003,7 @@ pub enum PreciseDateTime {
 }
 
 impl PreciseDateTime {
-    /// Retrieves a reference to a [`chrono::DateTime<FixedOffset>`][chrono::DateTime]
+    /// Retrieves a reference to a [`chrono::DateTime<FixedOffset>`]
     /// if the result is time-zone aware.
     pub fn as_datetime(&self) -> Option<&DateTime<FixedOffset>> {
         match self {
@@ -1055,7 +1021,7 @@ impl PreciseDateTime {
         }
     }
 
-    /// Moves out a [`chrono::DateTime<FixedOffset>`](chrono::DateTime)
+    /// Moves out a [`chrono::DateTime<FixedOffset>`]
     /// if the result is time-zone aware.
     pub fn into_datetime(self) -> Option<DateTime<FixedOffset>> {
         match self {
@@ -1078,10 +1044,11 @@ impl PreciseDateTime {
     ///
     /// # Panics
     ///
-    /// The time-zone aware variant uses `DateTime`,
-    /// which internally stores the date and time in UTC with a `NaiveDateTime`.
+    /// The time-zone aware variant uses [`DateTime`],
+    /// which internally stores the date and time in UTC with a
+    /// [`NaiveDateTime`].
     /// This method will panic if the offset from UTC would push the local date
-    /// outside of the representable range of a `NaiveDate`.
+    /// outside of the representable range of a [`NaiveDate`].
     pub fn to_naive_date(&self) -> NaiveDate {
         match self {
             PreciseDateTime::Naive(value) => value.date(),
@@ -1104,12 +1071,15 @@ impl PreciseDateTime {
     }
 }
 
-/// The partial ordering for `PreciseDateTime`
+/// The partial ordering for [`PreciseDateTime`]
 /// is defined by the partial ordering of matching variants
-/// (`Naive` with `Naive`, `TimeZone` with `TimeZone`).
+/// ([`Naive`][1] with [`Naive`][1], [`TimeZone`][2] with [`TimeZone`][2]).
 ///
 /// Any other comparison cannot be defined,
-/// and therefore will always return `None`.
+/// and therefore will always return [`None`].
+///
+///  [1]: Self::Naive
+///  [2]: Self::TimeZone
 impl PartialOrd for PreciseDateTime {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match (self, other) {

--- a/core/src/value/person_name.rs
+++ b/core/src/value/person_name.rs
@@ -13,9 +13,9 @@ use std::mem;
 ///
 /// # Example
 ///
-/// A value of type `PersonName` can be obtained
-/// either by parsing a DICOM formatted string via [`from_text`](PersonName::from_text)
-/// or by using the [builder](PersonNameBuilder) API.
+/// A value of type [`PersonName`] can be obtained
+/// either by parsing a DICOM formatted string via [`PersonName::from_text`]
+/// or by using the [`PersonNameBuilder`] API.
 ///
 /// ```
 /// # use dicom_core::value::person_name::PersonName;
@@ -74,23 +74,23 @@ impl Display for PersonName<'_> {
 }
 
 impl<'a> PersonName<'a> {
-    /// Retrieve PersonName prefix
+    /// Retrieve [`PersonName`] prefix
     pub fn prefix(&self) -> Option<&str> {
         self.prefix.as_deref()
     }
-    /// Retrieve PersonName suffix
+    /// Retrieve [`PersonName`] suffix
     pub fn suffix(&self) -> Option<&str> {
         self.suffix.as_deref()
     }
-    /// Retrieve family name from PersonName
+    /// Retrieve family name from [`PersonName`]
     pub fn family(&self) -> Option<&str> {
         self.family.as_deref()
     }
-    /// Retrieve given name from PersonName
+    /// Retrieve given name from [`PersonName`]
     pub fn given(&self) -> Option<&str> {
         self.given.as_deref()
     }
-    /// Retrieve middle name from PersonName
+    /// Retrieve middle name from [`PersonName`]
     pub fn middle(&self) -> Option<&str> {
         self.middle.as_deref()
     }

--- a/core/src/value/primitive.rs
+++ b/core/src/value/primitive.rs
@@ -1,6 +1,6 @@
 //! Declaration and implementation of a DICOM primitive value.
 //!
-//! See [`PrimitiveValue`](./enum.PrimitiveValue.html).
+//! See [`PrimitiveValue`].
 
 use super::{AsRange, DicomValueType};
 use crate::header::{HasLength, Length, Tag};
@@ -119,10 +119,12 @@ pub enum ModifyValueError {
 /// an error of this type is returned.
 ///
 /// If such a conversion is acceptable, please use conversion methods instead:
-/// `to_date` instead of `date`, `to_str` instead of `string`, and so on.
+/// [`PrimitiveValue::to_date`] instead of `date`,
+/// [`PrimitiveValue::to_str`] instead of `string`, and so on.
 /// The error type would then be [`ConvertValueError`].
 ///
-/// [`ConvertValueError`]: ./struct.ConvertValueError.html
+/// [`PrimitiveValue::to_date`]: crate::value::primitive::PrimitiveValue::to_date
+/// [`PrimitiveValue::to_str`]: crate::value::primitive::PrimitiveValue::to_str
 #[derive(Debug, Clone, PartialEq)]
 pub struct CastValueError {
     /// The value format requested
@@ -193,13 +195,15 @@ pub type C<T> = SmallVec<[T; 2]>;
 /// depending on its content and value representation.
 ///
 /// Multiple elements are contained in a [`smallvec`] vector,
-/// conveniently aliased to the type [`C`].
+/// conveniently aliased to the type [`crate::value::C`].
 ///
 /// See the macro [`dicom_value!`] for a more intuitive means
 /// of constructing these values.
-/// Alternatively, `From` conversions into `PrimitiveValue` exist
+/// Alternatively, `From` conversions into [`PrimitiveValue`] exist
 /// for single element types,
-/// including numeric types, `String`, and `&str`.
+/// including numeric types, [`String`], and [`&str`].
+///
+/// [`dicom_value!`]: crate::dicom_value!
 ///
 /// # Example
 ///
@@ -213,10 +217,6 @@ pub type C<T> = SmallVec<[T; 2]>;
 /// let value = PrimitiveValue::from(512_u16);
 /// assert_eq!(value, PrimitiveValue::U16(smallvec![512]));
 /// ```
-///
-/// [`smallvec`]: ../../smallvec/index.html
-/// [`C`]: ./type.C.html
-/// [`dicom_value!`]: ../macro.dicom_value.html
 #[derive(Debug, Clone)]
 pub enum PrimitiveValue {
     /// No data. Usually employed for zero-length values.
@@ -523,9 +523,10 @@ impl PrimitiveValue {
 
     /// Convert the primitive value into a string representation.
     ///
-    /// String values already encoded with the `Str` and `Strs` variants
+    /// String values already encoded with the [`Str`] and
+    /// [`Strs`] variants
     /// are provided as is.
-    /// In the case of `Strs`, the strings are first joined together
+    /// In the case of [`Strs`], the strings are first joined together
     /// with a backslash (`'\\'`).
     /// All other type variants are first converted to a string,
     /// then joined together with a backslash.
@@ -535,14 +536,18 @@ impl PrimitiveValue {
     /// **Note:**
     /// As the process of reading a DICOM value
     /// may not always preserve its original nature,
-    /// it is not guaranteed that `to_str()` returns a string with
+    /// it is not guaranteed that [`to_str`] returns a string with
     /// the exact same byte sequence as the one originally found
     /// at the source of the value,
     /// even for the string variants.
     /// Therefore, this method is not reliable
     /// for compliant DICOM serialization.
     ///
-    /// # Examples
+    /// [`Str`]: Self::Str
+    /// [`Strs`]: Self::Strs
+    /// [`to_str`]: Self::to_str
+    ///
+    /// # Example
     ///
     /// ```
     /// # use dicom_core::dicom_value;
@@ -596,27 +601,33 @@ impl PrimitiveValue {
 
     /// Convert the primitive value into a raw string representation.
     ///
-    /// String values already encoded with the `Str` and `Strs` variants
+    /// String values already encoded with the [`Str`] and
+    /// [`Strs`] variants
     /// are provided as is.
-    /// In the case of `Strs`, the strings are first joined together
+    /// In the case of [`Strs`], the strings are first joined together
     /// with a backslash (`'\\'`).
     /// All other type variants are first converted to a string,
     /// then joined together with a backslash.
     ///
     /// This method keeps all trailing whitespace,
-    /// unlike [`to_str()`](PrimitiveValue::to_str).
+    /// unlike [`to_str`].
     ///
     /// **Note:**
     /// As the process of reading a DICOM value
     /// may not always preserve its original nature,
-    /// it is not guaranteed that `to_raw_str()` returns a string with
+    /// it is not guaranteed that [`to_raw_str`] returns a string with
     /// the exact same byte sequence as the one originally found
     /// at the source of the value,
     /// even for the string variants.
     /// Therefore, this method is not reliable
     /// for compliant DICOM serialization.
     ///
-    /// # Examples
+    /// [`Str`]: Self::Str
+    /// [`Strs`]: Self::Strs
+    /// [`to_str`]: Self::to_str
+    /// [`to_raw_str`]: Self::to_raw_str
+    ///
+    /// # Example
     ///
     /// ```
     /// # use dicom_core::dicom_value;
@@ -658,26 +669,31 @@ impl PrimitiveValue {
 
     /// Convert the primitive value into a multi-string representation.
     ///
-    /// String values already encoded with the `Str` and `Strs` variants
-    /// are provided as is.
+    /// String values already encoded with the [`Str`] and
+    /// [`Strs`] variants are provided as is.
     /// All other type variants are first converted to a string,
     /// then collected into a vector.
     ///
     /// Trailing whitespace is stripped from each string.
     /// If keeping it is desired,
-    /// use [`to_raw_str()`](PrimitiveValue::to_raw_str).
+    /// use [`to_raw_str`].
     ///
     /// **Note:**
     /// As the process of reading a DICOM value
     /// may not always preserve its original nature,
-    /// it is not guaranteed that `to_multi_str()` returns strings with
+    /// it is not guaranteed that [`to_multi_str`] returns strings with
     /// the exact same byte sequence as the one originally found
     /// at the source of the value,
     /// even for the string variants.
     /// Therefore, this method is not reliable
     /// for compliant DICOM serialization.
     ///
-    /// # Examples
+    /// [`Str`]: Self::Str
+    /// [`Strs`]: Self::Strs
+    /// [`to_raw_str`]: Self::to_raw_str
+    /// [`to_multi_str`]: Self::to_multi_str
+    ///
+    /// # Example
     ///
     /// ```
     /// # use dicom_core::dicom_value;
@@ -765,25 +781,28 @@ impl PrimitiveValue {
     /// without copying,
     /// under the platform's native byte order.
     ///
-    /// String values already encoded with the `Str` and `Strs` variants
-    /// are provided as their respective bytes in UTF-8.
-    /// In the case of `Strs`, the strings are first joined together
+    /// String values already encoded with the [`Str`] and [`Strs`]
+    /// variants are provided as their respective bytes in UTF-8.
+    /// In the case of [`Strs`], the strings are first joined together
     /// with a backslash (`'\\'`).
     /// Other type variants are first converted to a string,
     /// joined together with a backslash,
     /// then turned into a byte vector.
     /// For values which are inherently textual according the standard,
-    /// this is equivalent to calling `as_bytes()` after [`to_str()`].
+    /// this is equivalent to calling [`String::as_bytes`] after [`to_str`].
     ///
     /// **Note:**
     /// As the process of reading a DICOM value
     /// may not always preserve its original nature,
-    /// it is not guaranteed that `to_bytes()` returns the same byte sequence
+    /// it is not guaranteed that [`to_bytes`] returns the same byte sequence
     /// as the one originally found at the source of the value.
     /// Therefore, this method is not reliable
     /// for compliant DICOM serialization.
     ///
-    /// [`to_str()`]: #method.to_str
+    /// [`Str`]: Self::Str
+    /// [`Strs`]: Self::Strs
+    /// [`to_str`]: Self::to_str
+    /// [`to_bytes`]: Self::to_bytes
     ///
     /// # Examples
     ///
@@ -878,8 +897,8 @@ impl PrimitiveValue {
     /// retrieve a float via [`to_float32`] or [`to_float64`] instead,
     /// then cast it to an integer.
     ///
-    /// [`to_float32`]: #method.to_float32
-    /// [`to_float64`]: #method.to_float64
+    /// [`to_float32`]: Self::to_float32
+    /// [`to_float64`]: Self::to_float64
     ///
     /// # Example
     ///
@@ -1033,19 +1052,20 @@ impl PrimitiveValue {
     /// each string is parsed to obtain an integer,
     /// potentially failing if the string does not represent a valid integer.
     /// The string is stripped of leading/trailing whitespace before parsing.
-    /// If the value is a sequence of U8 bytes,
+    /// If the value is a sequence of [`U8`] bytes,
     /// the bytes are individually interpreted as independent numbers.
     /// Otherwise, the operation fails.
     ///
     /// Note that this method does not enable
     /// the conversion of floating point numbers to integers via truncation.
     /// If this is intentional,
-    /// retrieve a float via [`to_float32`] or [`to_float64`] instead,
-    /// then cast it to an integer.
+    /// retrieve a float via [`to_float32`] or
+    /// [`to_float64`] instead, then cast it to
+    /// an integer.
     ///
-    /// [`NumCast`]: ../num_traits/cast/trait.NumCast.html
-    /// [`to_float32`]: #method.to_float32
-    /// [`to_float64`]: #method.to_float64
+    /// [`U8`]: Self::U8
+    /// [`to_float32`]: Self::to_float32
+    /// [`to_float64`]: Self::to_float64
     ///
     /// # Example
     ///
@@ -1222,16 +1242,18 @@ impl PrimitiveValue {
     /// Retrieve one single-precision floating point from this value.
     ///
     /// If the value is already represented as a number,
-    /// it is returned after a conversion to `f32`.
+    /// it is returned after a conversion to [`f32`].
     /// An error is returned if the number cannot be represented
     /// by the given number type.
     /// If the value is a string or sequence of strings,
     /// the first string is parsed to obtain a number,
     /// potentially failing if the string does not represent a valid number.
     /// The string is stripped of leading/trailing whitespace before parsing.
-    /// If the value is a sequence of U8 bytes,
+    /// If the value is a sequence of [`U8`] bytes,
     /// the bytes are individually interpreted as independent numbers.
     /// Otherwise, the operation fails.
+    ///
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -1389,16 +1411,18 @@ impl PrimitiveValue {
     /// from this value.
     ///
     /// If the value is already represented as numbers,
-    /// they are returned after a conversion to `f32`.
+    /// they are returned after a conversion to [`f32`].
     /// An error is returned if any of the numbers cannot be represented
-    /// by an `f32`.
+    /// by an [`f32`].
     /// If the value is a string or sequence of strings,
     /// the strings are parsed to obtain a number,
     /// potentially failing if the string does not represent a valid number.
     /// The string is stripped of leading/trailing whitespace before parsing.
-    /// If the value is a sequence of U8 bytes,
+    /// If the value is a sequence of [`U8`] bytes,
     /// the bytes are individually interpreted as independent numbers.
     /// Otherwise, the operation fails.
+    ///
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -1587,16 +1611,18 @@ impl PrimitiveValue {
     /// Retrieve one double-precision floating point from this value.
     ///
     /// If the value is already represented as a number,
-    /// it is returned after a conversion to `f64`.
+    /// it is returned after a conversion to [`f64`].
     /// An error is returned if the number cannot be represented
     /// by the given number type.
     /// If the value is a string or sequence of strings,
     /// the first string is parsed to obtain a number,
     /// potentially failing if the string does not represent a valid number.
     /// The string is stripped of leading/trailing whitespace before parsing.
-    /// If the value is a sequence of U8 bytes,
+    /// If the value is a sequence of [`U8`] bytes,
     /// the bytes are individually interpreted as independent numbers.
     /// Otherwise, the operation fails.
+    ///
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -1754,16 +1780,18 @@ impl PrimitiveValue {
     /// from this value.
     ///
     /// If the value is already represented as numbers,
-    /// they are returned after a conversion to `f64`.
+    /// they are returned after a conversion to [`f64`].
     /// An error is returned if any of the numbers cannot be represented
-    /// by an `f64`.
+    /// by an [`f64`].
     /// If the value is a string or sequence of strings,
     /// the strings are parsed to obtain a number,
     /// potentially failing if the string does not represent a valid number.
     /// The string is stripped of leading/trailing whitespace before parsing.
-    /// If the value is a sequence of U8 bytes,
+    /// If the value is a sequence of [`U8`] bytes,
     /// the bytes are individually interpreted as independent numbers.
     /// Otherwise, the operation fails.
+    ///
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -1948,14 +1976,14 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve a single `chrono::NaiveDate` from this value.
+    /// Retrieve a single [`chrono::NaiveDate`] from this value.
     ///
     /// Please note, that this is a shortcut to obtain a usable date from a primitive value.
     /// As per standard, the stored value might not be precise. It is highly recommended to
-    /// use [`.to_date()`](PrimitiveValue::to_date) as the only way to obtain dates.
+    /// use [`to_date`] as the only way to obtain dates.
     ///
-    /// If the value is already represented as a precise `DicomDate`, it is converted
-    ///  to a `NaiveDate` value. It fails for imprecise values.
+    /// If the value is already represented as a precise [`DicomDate`], it is converted
+    ///  to a [`NaiveDate`] value. It fails for imprecise values.
     /// If the value is a string or sequence of strings,
     /// the first string is decoded to obtain a date, potentially failing if the
     /// string does not represent a valid date.
@@ -1964,9 +1992,11 @@ impl PrimitiveValue {
     ///
     /// Users are advised that this method is DICOM compliant and a full
     /// date representation of YYYYMMDD is required. Otherwise, the operation fails.
-    ///  
-    /// Partial precision dates are handled by `DicomDate`, which can be retrieved
-    /// by [`.to_date()`](PrimitiveValue::to_date).
+    ///
+    /// Partial precision dates are handled by [`DicomDate`], which can be retrieved
+    /// by [`to_date`].
+    ///
+    /// [`to_date`]: Self::to_date
     ///
     /// # Example
     ///
@@ -2040,26 +2070,29 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve the full sequence of `chrono::NaiveDate`s from this value.
+    /// Retrieve the full sequence of [`chrono::NaiveDate`]s from this value.
     ///
     /// Please note, that this is a shortcut to obtain usable dates from a primitive value.
     /// As per standard, the stored values might not be precise. It is highly recommended to
-    /// use [`.to_multi_date()`](PrimitiveValue::to_multi_date) as the only way to obtain dates.
+    /// use [`to_multi_date`] as the only way to obtain dates.
     ///
-    /// If the value is already represented as a sequence of precise `DicomDate` values,
+    /// If the value is already represented as a sequence of precise [`DicomDate`] values,
     /// it is converted. It fails for imprecise values.
     /// If the value is a string or sequence of strings,
     /// the strings are decoded to obtain a date, potentially failing if
     /// any of the strings does not represent a valid date.
-    /// If the value is a sequence of U8 bytes, the bytes are
+    /// If the value is a sequence of [`U8`] bytes, the bytes are
     /// first interpreted as an ASCII character string,
     /// then as a backslash-separated list of dates.
-    ///  
+    ///
     /// Users are advised that this method is DICOM compliant and a full
     /// date representation of YYYYMMDD is required. Otherwise, the operation fails.
-    ///  
-    /// Partial precision dates are handled by `DicomDate`, which can be retrieved
-    /// by [`.to_multi_date()`](PrimitiveValue::to_multi_date).
+    ///
+    /// Partial precision dates are handled by [`DicomDate`], which can be retrieved
+    /// by [`to_multi_date`].
+    ///
+    /// [`U8`]: Self::U8
+    /// [`to_multi_date`]: Self::to_multi_date
     ///
     /// # Example
     ///
@@ -2143,21 +2176,25 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve a single `DicomDate` from this value.
+    /// Retrieve a single [`DicomDate`] from this value.
     ///
-    /// If the value is already represented as a `DicomDate`, it is returned.
+    /// If the value is already represented as a [`DicomDate`], it is returned.
     /// If the value is a string or sequence of strings,
-    /// the first string is decoded to obtain a DicomDate, potentially failing if the
-    /// string does not represent a valid DicomDate.
-    /// If the value is a sequence of U8 bytes, the bytes are
+    /// the first string is decoded to obtain a [`DicomDate`], potentially failing if the
+    /// string does not represent a valid [`DicomDate`].
+    /// If the value is a sequence of [`U8`] bytes, the bytes are
     /// first interpreted as an ASCII character string.
     ///
-    /// Unlike Rust's `chrono::NaiveDate`, `DicomDate` allows for missing date components.
-    /// DicomDate implements `AsRange` trait, so specific `chrono::NaiveDate` values can be retrieved.
-    /// - [`.exact()`](crate::value::range::AsRange::exact)
-    /// - [`.earliest()`](crate::value::range::AsRange::earliest)
-    /// - [`.latest()`](crate::value::range::AsRange::latest)
-    /// - [`.range()`](crate::value::range::AsRange::range)
+    /// Unlike Rust's [`chrono::NaiveDate`], [`DicomDate`] allows for missing date components.
+    /// [`DicomDate`] implements [`AsRange`] trait, so specific
+    /// [`chrono::NaiveDate`] values can be retrieved.
+    ///
+    /// - [`AsRange::exact`]
+    /// - [`AsRange::earliest`]
+    /// - [`AsRange::latest`]
+    /// - [`AsRange::range`]
+    ///
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -2238,7 +2275,7 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve the full sequence of `DicomDate`s from this value.
+    /// Retrieve the full sequence of [`DicomDate`]s from this value.
     ///
     /// # Example
     /// ```
@@ -2307,25 +2344,28 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve a single `chrono::NaiveTime` from this value.
+    /// Retrieve a single [`chrono::NaiveTime`] from this value.
     ///
     /// Please note, that this is a shortcut to obtain a usable time from a primitive value.
     /// As per standard, the stored value might not be precise. It is highly recommended to
-    /// use [`.to_time()`](PrimitiveValue::to_time) as the only way to obtain times.
+    /// use [`Self::to_time`] as the only way to obtain times.
     ///
-    /// If the value is represented as a precise `DicomTime`,
-    /// it is converted to a `NaiveTime`.
+    /// If the value is represented as a precise [`DicomTime`],
+    /// it is converted to a [`NaiveTime`].
     /// It fails for imprecise values,
     /// as in, those which do not specify up to at least the seconds.
     /// If the value is a string or sequence of strings,
     /// the first string is decoded to obtain a time, potentially failing if the
     /// string does not represent a valid time.
-    /// If the value is a sequence of U8 bytes, the bytes are
+    /// If the value is a sequence of [`U8`] bytes, the bytes are
     /// first interpreted as an ASCII character string.
     /// Otherwise, the operation fails.
     ///
-    /// Partial precision times are handled by `DicomTime`,
-    /// which can be retrieved by [`.to_time()`](PrimitiveValue::to_time).
+    /// Partial precision times are handled by [`DicomTime`],
+    /// which can be retrieved by [`to_time`].
+    ///
+    /// [`U8`]: Self::U8
+    /// [`to_time`]: Self::to_time
     ///
     /// # Example
     ///
@@ -2398,27 +2438,30 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve the full sequence of `chrono::NaiveTime`s from this value.
+    /// Retrieve the full sequence of [`chrono::NaiveTime`]s from this value.
     ///
     /// Please note, that this is a shortcut to obtain a usable time from a primitive value.
     /// As per standard, the stored values might not be precise. It is highly recommended to
-    /// use [`.to_multi_time()`](PrimitiveValue::to_multi_time) as the only way to obtain times.
+    /// use [`to_multi_time`] as the only way to obtain times.
     ///
-    /// If the value is already represented as a sequence of precise `DicomTime` values,
-    /// it is converted to a sequence of `NaiveTime` values. It fails for imprecise values.
+    /// If the value is already represented as a sequence of precise [`DicomTime`] values,
+    /// it is converted to a sequence of [`NaiveTime`] values. It fails for imprecise values.
     /// If the value is a string or sequence of strings,
     /// the strings are decoded to obtain a date, potentially failing if
     /// any of the strings does not represent a valid date.
-    /// If the value is a sequence of U8 bytes, the bytes are
+    /// If the value is a sequence of [`U8`] bytes, the bytes are
     /// first interpreted as an ASCII character string,
     /// then as a backslash-separated list of times.
     /// Otherwise, the operation fails.
     ///
     /// Users are advised that this method requires at least 1 out of 6 digits of the second
-    /// fraction .F to be present. Otherwise, the operation fails.
+    /// fraction `.F` to be present. Otherwise, the operation fails.
     ///
-    /// Partial precision times are handled by `DicomTime`,
-    /// which can be retrieved by [`.to_multi_time()`](PrimitiveValue::to_multi_time).
+    /// Partial precision times are handled by [`DicomTime`],
+    /// which can be retrieved by [`to_multi_time`].
+    ///
+    /// [`to_multi_time`]: Self::to_multi_time
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -2502,21 +2545,24 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve a single `DicomTime` from this value.
+    /// Retrieve a single [`DicomTime`] from this value.
     ///
-    /// If the value is already represented as a time, it is converted into DicomTime.
+    /// If the value is already represented as a time, it is converted into [`DicomTime`].
     /// If the value is a string or sequence of strings,
-    /// the first string is decoded to obtain a DicomTime, potentially failing if the
-    /// string does not represent a valid DicomTime.
-    /// If the value is a sequence of U8 bytes, the bytes are
+    /// the first string is decoded to obtain a [`DicomTime`], potentially failing if the
+    /// string does not represent a valid [`DicomTime`].
+    /// If the value is a sequence of [`U8`] bytes, the bytes are
     /// first interpreted as an ASCII character string.
     ///
-    /// Unlike Rust's `chrono::NaiveTime`, `DicomTime` allows for missing time components.
-    /// DicomTime implements `AsRange` trait, so specific `chrono::NaiveTime` values can be retrieved.
-    /// - [`.exact()`](crate::value::range::AsRange::exact)
-    /// - [`.earliest()`](crate::value::range::AsRange::earliest)
-    /// - [`.latest()`](crate::value::range::AsRange::latest)
-    /// - [`.range()`](crate::value::range::AsRange::range)
+    /// Unlike Rust's [`chrono::NaiveTime`], [`DicomTime`] allows for missing time components.
+    /// [`DicomTime`] implements [`AsRange`] trait, so specific [`chrono::NaiveTime`] values can be retrieved.
+    ///
+    /// - [`AsRange::exact`]
+    /// - [`AsRange::earliest`]
+    /// - [`AsRange::latest`]
+    /// - [`AsRange::range`]
+    ///
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -2558,7 +2604,7 @@ impl PrimitiveValue {
     ///
     ///  let fraction6 = PrimitiveValue::Str("101259.123456".into());
     ///  let fraction5 = PrimitiveValue::Str("101259.12345".into());
-    ///  
+    ///
     ///  // is not precise, last digit of second fraction is unspecified
     ///  assert!(
     ///     fraction5.to_time()?.exact().is_err()
@@ -2566,7 +2612,7 @@ impl PrimitiveValue {
     ///  assert!(
     ///     fraction6.to_time()?.exact().is_ok()
     ///  );
-    ///  
+    ///
     ///  assert_eq!(
     ///     fraction6.to_time()?.exact()?,
     ///     fraction6.to_time()?.to_naive_time()?
@@ -2618,21 +2664,24 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve the full sequence of `DicomTime`s from this value.
+    /// Retrieve the full sequence of [`DicomTime`]s from this value.
     ///
-    /// If the value is already represented as a time, it is converted into DicomTime.
+    /// If the value is already represented as a time, it is converted into [`DicomTime`].
     /// If the value is a string or sequence of strings,
-    /// the first string is decoded to obtain a DicomTime, potentially failing if the
-    /// string does not represent a valid DicomTime.
-    /// If the value is a sequence of U8 bytes, the bytes are
+    /// the first string is decoded to obtain a [`DicomTime`], potentially failing if the
+    /// string does not represent a valid [`DicomTime`].
+    /// If the value is a sequence of [`U8`] bytes, the bytes are
     /// first interpreted as an ASCII character string.
     ///
-    /// Unlike Rust's `chrono::NaiveTime`, `DicomTime` allows for missing time components.
-    /// DicomTime implements `AsRange` trait, so specific `chrono::NaiveTime` values can be retrieved.
-    /// - [`.exact()`](crate::value::range::AsRange::exact)
-    /// - [`.earliest()`](crate::value::range::AsRange::earliest)
-    /// - [`.latest()`](crate::value::range::AsRange::latest)
-    /// - [`.range()`](crate::value::range::AsRange::range)
+    /// Unlike Rust's [`chrono::NaiveTime`], [`DicomTime`] allows for missing time components.
+    /// [`DicomTime`] implements [`AsRange`] trait, so specific [`chrono::NaiveTime`] values can be retrieved.
+    ///
+    /// - [`AsRange::exact`]
+    /// - [`AsRange::earliest`]
+    /// - [`AsRange::latest`]
+    /// - [`AsRange::range`]
+    ///
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -2703,21 +2752,25 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve a single `DicomDateTime` from this value.
+    /// Retrieve a single [`DicomDateTime`] from this value.
     ///
-    /// If the value is already represented as a date-time, it is converted into DicomDateTime.
+    /// If the value is already represented as a date-time, it is converted into [`DicomDateTime`].
     /// If the value is a string or sequence of strings,
-    /// the first string is decoded to obtain a DicomDateTime, potentially failing if the
-    /// string does not represent a valid DicomDateTime.
-    /// If the value is a sequence of U8 bytes, the bytes are
+    /// the first string is decoded to obtain a [`DicomDateTime`], potentially failing if the
+    /// string does not represent a valid [`DicomDateTime`].
+    /// If the value is a sequence of [`U8`] bytes, the bytes are
     /// first interpreted as an ASCII character string.
     ///
-    /// Unlike Rust's `chrono::DateTime`, `DicomDateTime` allows for missing date or time components.
-    /// DicomDateTime implements `AsRange` trait, so specific `chrono::DateTime` values can be retrieved.
-    /// - [`.exact()`](crate::value::range::AsRange::exact)
-    /// - [`.earliest()`](crate::value::range::AsRange::earliest)
-    /// - [`.latest()`](crate::value::range::AsRange::latest)
-    /// - [`.range()`](crate::value::range::AsRange::range)
+    /// Unlike Rust's [`chrono::DateTime`], [`DicomDateTime`] allows for missing date or time components.
+    /// [`DicomDateTime`] implements [`AsRange`] trait, so specific [`chrono::DateTime`] values can be retrieved.
+    ///
+    /// - [`AsRange::exact`]
+    /// - [`AsRange::earliest`]
+    /// - [`AsRange::latest`]
+    /// - [`AsRange::range`]
+    ///
+    /// [`U8`]: Self::U8
+    ///
     /// # Example
     ///
     /// ```
@@ -2761,7 +2814,7 @@ impl PrimitiveValue {
     ///     .ymd_opt(2012, 12, 21).unwrap()
     ///     .and_hms_micro_opt(9, 30, 1, 123_456).unwrap()
     ///     )
-    ///        
+    ///
     /// );
     ///
     /// // ranges are inclusive, for a precise value, two identical values are returned
@@ -2775,7 +2828,7 @@ impl PrimitiveValue {
     ///             .ymd_opt(2012, 12, 21).unwrap()
     ///             .and_hms_micro_opt(9, 30, 1, 123_456).unwrap()
     ///     )?
-    ///     
+    ///
     /// );
     /// # Ok(())
     /// # }
@@ -2820,7 +2873,7 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve the full sequence of `DicomDateTime`s from this value.
+    /// Retrieve the full sequence of [`DicomDateTime`]s from this value.
     ///
     pub fn to_multi_datetime(&self) -> Result<Vec<DicomDateTime>, ConvertValueError> {
         match self {
@@ -2866,14 +2919,16 @@ impl PrimitiveValue {
             }),
         }
     }
-    /// Retrieve a single `DateRange` from this value.
+    /// Retrieve a single [`DateRange`] from this value.
     ///
-    /// If the value is already represented as a `DicomDate`, it is converted into `DateRange`.
+    /// If the value is already represented as a [`DicomDate`], it is converted into [`DateRange`].
     /// If the value is a string or sequence of strings,
-    /// the first string is decoded to obtain a `DateRange`, potentially failing if the
-    /// string does not represent a valid `DateRange`.
-    /// If the value is a sequence of U8 bytes, the bytes are
+    /// the first string is decoded to obtain a [`DateRange`], potentially failing if the
+    /// string does not represent a valid [`DateRange`].
+    /// If the value is a sequence of [`U8`] bytes, the bytes are
     /// first interpreted as an ASCII character string.
+    ///
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -2950,14 +3005,16 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve a single `TimeRange` from this value.
+    /// Retrieve a single [`TimeRange`] from this value.
     ///
-    /// If the value is already represented as a `DicomTime`, it is converted into a `TimeRange`.
+    /// If the value is already represented as a [`DicomTime`], it is converted into a [`TimeRange`].
     /// If the value is a string or sequence of strings,
-    /// the first string is decoded to obtain a `TimeRange`, potentially failing if the
-    /// string does not represent a valid `DateRange`.
-    /// If the value is a sequence of U8 bytes, the bytes are
+    /// the first string is decoded to obtain a [`TimeRange`], potentially failing if the
+    /// string does not represent a valid [`DateRange`].
+    /// If the value is a sequence of [`U8`] bytes, the bytes are
     /// first interpreted as an ASCII character string.
+    ///
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -3037,14 +3094,17 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve a single `DateTimeRange` from this value.
+    /// Retrieve a single [`DateTimeRange`] from this value.
     ///
-    /// If the value is already represented as a `DicomDateTime`, it is converted into `DateTimeRange`.
+    /// If the value is already represented as a [`DicomDateTime`], it is
+    /// converted into [`DateTimeRange`].
     /// If the value is a string or sequence of strings,
-    /// the first string is decoded to obtain a `DateTimeRange`, potentially failing if the
-    /// string does not represent a valid `DateTimeRange`.
-    /// If the value is a sequence of U8 bytes, the bytes are
+    /// the first string is decoded to obtain a [`DateTimeRange`], potentially
+    /// failing if the  string does not represent a valid [`DateTimeRange`].
+    /// If the value is a sequence of [`U8`] bytes, the bytes are
     /// first interpreted as an ASCII character string.
+    ///
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -3067,7 +3127,7 @@ impl PrimitiveValue {
     ///     Some(PreciseDateTime::TimeZone(
     ///         FixedOffset::east_opt(5*3600).unwrap().ymd_opt(1992, 1, 1).unwrap()
     ///         .and_hms_micro_opt(15, 30, 20, 123_000).unwrap()
-    ///         )  
+    ///         )
     ///     )
     /// );
     ///
@@ -3077,7 +3137,7 @@ impl PrimitiveValue {
     ///     Some(PreciseDateTime::TimeZone(
     ///         FixedOffset::east_opt(3*3600).unwrap().ymd_opt(1993, 12, 31).unwrap()
     ///         .and_hms_micro_opt(23, 59, 59, 999_999).unwrap()
-    ///         )  
+    ///         )
     ///     )
     /// );
     ///
@@ -3155,11 +3215,15 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve a single `DateTimeRange` from this value.
+    /// Retrieve a single [`DateTimeRange`] from this value.
     ///
     /// Use a custom ambiguous date-time range parser.
     ///
-    /// For full description see [PrimitiveValue::to_datetime_range] and [AmbiguousDtRangeParser].
+    /// For full description see [`to_datetime_range`] and
+    /// [`AmbiguousDtRangeParser`].
+    ///
+    /// [`to_datetime_range`]: Self::to_datetime_range
+    ///
     /// # Example
     ///
     /// ```
@@ -3263,12 +3327,10 @@ impl PrimitiveValue {
         }
     }
 
-    /// Retrieve a single [`PersonName`][1] from this value.
+    /// Retrieve a single [`PersonName`] from this value.
     ///
     /// If the value is a string or sequence of strings,
-    /// the first string is split to obtain a `PersonName`.
-    ///
-    /// [1]: super::person_name::PersonName
+    /// the first string is split to obtain a [`PersonName`].
     ///
     /// # Example
     ///
@@ -3317,7 +3379,7 @@ impl PrimitiveValue {
 
 /// Macro for implementing getters to single and multi-values of each variant.
 ///
-/// Should be placed inside `PrimitiveValue`'s impl block.
+/// Should be placed inside [`PrimitiveValue`]'s impl block.
 macro_rules! impl_primitive_getters {
     ($name_single: ident, $name_multi: ident, $variant: ident, $ret: ty) => {
         /// Get a single value of the requested type.
@@ -3365,9 +3427,9 @@ impl PrimitiveValue {
     /// An error is returned if the variant is not compatible.
     ///
     /// To enable conversions of other variants to a textual representation,
-    /// see [`to_str()`] instead.
+    /// see [`to_str`] instead.
     ///
-    /// [`to_str()`]: #method.to_str
+    /// [`to_str`]: Self::to_str
     pub fn string(&self) -> Result<&str, CastValueError> {
         use self::PrimitiveValue::*;
         match self {
@@ -3385,14 +3447,17 @@ impl PrimitiveValue {
     }
 
     /// Get the inner sequence of string values
-    /// if the variant is either `Str` or `Strs`.
+    /// if the variant is either [`Str`] or
+    /// [`Strs`].
     ///
     /// An error is returned if the variant is not compatible.
     ///
     /// To enable conversions of other variants to a textual representation,
-    /// see [`to_str()`] instead.
+    /// see [`to_str`] instead.
     ///
-    /// [`to_str()`]: #method.to_str
+    /// [`Str`]: Self::Str
+    /// [`Strs`]: Self::Strs
+    /// [`to_str`]: Self::to_str
     pub fn strings(&self) -> Result<&[String], CastValueError> {
         use self::PrimitiveValue::*;
         match self {
@@ -3500,7 +3565,9 @@ impl PrimitiveValue {
     ///
     /// An error is returned
     /// if the current value is not compatible with the insertion of integers,
-    /// such as `Tag` or `Date`.
+    /// such as [`Tag`] or [`Date`].
+    ///
+    /// [`Date`]: Self::Date
     ///
     /// # Example
     ///
@@ -3605,7 +3672,9 @@ impl PrimitiveValue {
     ///
     /// An error is returned
     /// if the current value is not compatible with the insertion of integers,
-    /// such as `Tag` or `Date`.
+    /// such as [`Tag`] or [`Date`].
+    ///
+    /// [`Date`]: Self::Date
     ///
     /// # Example
     ///
@@ -3710,7 +3779,9 @@ impl PrimitiveValue {
     ///
     /// An error is returned
     /// if the current value is not compatible with the insertion of integers,
-    /// such as `Tag` or `Date`.
+    /// such as [`Tag`] or [`Date`].
+    ///
+    /// [`Date`]: Self::Date
     ///
     /// # Example
     ///
@@ -3815,7 +3886,9 @@ impl PrimitiveValue {
     ///
     /// An error is returned
     /// if the current value is not compatible with the insertion of integers,
-    /// such as `Tag` or `Date`.
+    /// such as [`Tag`] or [`Date`].
+    ///
+    /// [`Date`]: Self::Date
     ///
     /// # Example
     ///
@@ -3920,7 +3993,9 @@ impl PrimitiveValue {
     ///
     /// An error is returned
     /// if the current value is not compatible with the insertion of integers,
-    /// such as `Tag` or `Date`.
+    /// such as [`Tag`] or [`Date`].
+    ///
+    /// [`Date`]: Self::Date
     ///
     /// # Example
     ///
@@ -4025,7 +4100,9 @@ impl PrimitiveValue {
     ///
     /// An error is returned
     /// if the current value is not compatible with the insertion of integers,
-    /// such as `Tag` or `Date`.
+    /// such as [`Tag`] or [`Date`].
+    ///
+    /// [`Date`]: Self::Date
     ///
     /// # Example
     ///
@@ -4117,11 +4194,13 @@ impl PrimitiveValue {
     /// to fit the given limit.
     ///
     /// Elements are counted by the number of individual value items
-    /// (note that bytes in a [`PrimitiveValue::U8`]
+    /// (note that bytes in a [`U8`]
     /// are treated as individual items).
     ///
     /// Nothing is done if the value's cardinality
     /// is already lower than or equal to the limit.
+    ///
+    /// [`U8`]: Self::U8
     ///
     /// # Example
     ///
@@ -4157,7 +4236,9 @@ impl PrimitiveValue {
     }
 }
 
-/// The output of this method is equivalent to calling the method `to_str`
+/// The output of this method is equivalent to calling the method [`to_str`]
+///
+/// [`to_str`]: Self::to_str
 impl Display for PrimitiveValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         /// Auxiliary function for turning a sequence of values
@@ -4253,8 +4334,11 @@ impl PartialEq<&str> for PrimitiveValue {
 }
 
 /// An enum representing an abstraction of a DICOM element's data value type.
-/// This should be the equivalent of `PrimitiveValue` without the content,
-/// plus the `DataSetSequence` and `PixelSequence` entries.
+/// This should be the equivalent of [`PrimitiveValue`] without the content,
+/// plus the [`DataSetSequence`] and [`PixelSequence`] entries.
+///
+/// [`DataSetSequence`]: Self::DataSetSequence
+/// [`PixelSequence`]: Self::PixelSequence
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ValueType {
     /// No data. Used for any value of length 0.

--- a/core/src/value/range.rs
+++ b/core/src/value/range.rs
@@ -1,6 +1,8 @@
 //! Handling of date, time, date-time ranges. Needed for range matching.
-//! Parsing into ranges happens via partial precision  structures (DicomDate, DicomTime,
-//! DicomDatime) so ranges can handle null components in date, time, date-time values.
+//! Parsing into ranges happens via partial precision  structures
+//! ([`DicomDate`], [`DicomTime`], [`DicomDateTime`])
+//! so ranges can handle null components in date, time, date-time values.
+
 use chrono::{DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone};
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 
@@ -83,14 +85,14 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 ///
 /// This trait is implemented by date / time structures with partial precision.
 ///
-/// [AsRange::is_precise()] method will check if the given value has full precision. If so, it can be
-/// converted with [AsRange::exact()] to a precise value. If not, [AsRange::range()] will yield a
+/// [`AsRange::is_precise`] method will check if the given value has full precision. If so, it can be
+/// converted with [`AsRange::exact`] to a precise value. If not, [`AsRange::range`] will yield a
 /// date / time / date-time range.
 ///
-/// Please note that precision does not equal validity. A precise 'YYYYMMDD' [DicomDate] can still
-/// fail to produce a valid [chrono::NaiveDate]
+/// Please note that precision does not equal validity. A precise 'YYYYMMDD' [`DicomDate`] can still
+/// fail to produce a valid [`chrono::NaiveDate`]
 ///
-/// # Examples
+/// # Example
 ///
 /// ```
 /// # use dicom_core::value::{C, PrimitiveValue};
@@ -174,11 +176,16 @@ pub trait AsRange {
 
     /// Returns the earliest possible value from a partial precision structure.
     /// Missing components default to 1 (days, months) or 0 (hours, minutes, ...)
-    /// If structure contains invalid combination of `DateComponent`s, it fails.
+    /// If the structure contains an invalid combination of [`DateComponent`]s, it fails.
+    ///
+    /// [`DateComponent`]: crate::value::partial::DateComponent
     fn earliest(&self) -> Result<Self::PreciseValue>;
 
     /// Returns the latest possible value from a partial precision structure.
-    /// If structure contains invalid combination of `DateComponent`s, it fails.
+    /// If the structure contains an invalid combination of [`DateComponent`]s, it fails.
+    ///
+    ///
+    /// [`DateComponent`]: crate::value::partial::DateComponent
     fn latest(&self) -> Result<Self::PreciseValue>;
 
     /// Returns a tuple of the earliest and latest possible value from a partial precision structure.
@@ -393,7 +400,7 @@ impl AsRange for DicomDateTime {
 }
 
 impl DicomDate {
-    /// Retrieves a `chrono::NaiveDate`
+    /// Retrieves a [`chrono::NaiveDate`]
     /// if the value is precise up to the day of the month.
     pub fn to_naive_date(self) -> Result<NaiveDate> {
         self.exact()
@@ -401,7 +408,7 @@ impl DicomDate {
 }
 
 impl DicomTime {
-    /// Retrieves a `chrono::NaiveTime`
+    /// Retrieves a [`chrono::NaiveTime`]
     /// if the value is precise up to the second.
     ///
     /// Missing second fraction defaults to zero.
@@ -415,7 +422,7 @@ impl DicomTime {
 }
 
 impl DicomDateTime {
-    /// Retrieves a [PreciseDateTime] from a date-time value.
+    /// Retrieves a [`PreciseDateTime`] from a date-time value.
     /// If the date-time value is not precise or the conversion leads to ambiguous results,
     /// it fails.
     pub fn to_precise_datetime(&self) -> Result<PreciseDateTime> {
@@ -424,7 +431,8 @@ impl DicomDateTime {
 }
 
 /// Represents a date range as two [`Option<chrono::NaiveDate>`] values.
-/// [None] means no upper or no lower bound for range is present.
+/// [`None`] means no upper or no lower bound for range is present.
+///
 /// # Example
 /// ```
 /// use chrono::NaiveDate;
@@ -441,7 +449,8 @@ pub struct DateRange {
     end: Option<NaiveDate>,
 }
 /// Represents a time range as two [`Option<chrono::NaiveTime>`] values.
-/// [None] means no upper or no lower bound for range is present.
+/// [`None`] means no upper or no lower bound for range is present.
+///
 /// # Example
 /// ```
 /// use chrono::NaiveTime;
@@ -457,9 +466,12 @@ pub struct TimeRange {
     start: Option<NaiveTime>,
     end: Option<NaiveTime>,
 }
-/// Represents a date-time range, that can either be time-zone naive or time-zone aware. It is stored as two [`Option<chrono::DateTime<FixedOffset>>`] or
+
+/// Represents a date-time range, that can either be time-zone naive or
+/// time-zone aware.
+/// It is stored as two [`Option<chrono::DateTime<FixedOffset>>`] or
 /// two [`Option<chrono::NaiveDateTime>`] values.
-/// [None] means no upper or no lower bound for range is present.
+/// [`None`] means no upper or no lower bound for range is present.
 ///
 /// # Example
 /// ```
@@ -501,7 +513,7 @@ pub enum DateTimeRange {
 }
 
 impl DateRange {
-    /// Constructs a new `DateRange` from two `chrono::NaiveDate` values
+    /// Constructs a new [`DateRange`] from two [`chrono::NaiveDate`] values
     /// monotonically ordered in time.
     pub fn from_start_to_end(start: NaiveDate, end: NaiveDate) -> Result<DateRange> {
         if start > end {
@@ -518,7 +530,7 @@ impl DateRange {
         }
     }
 
-    /// Constructs a new `DateRange` beginning with a `chrono::NaiveDate` value
+    /// Constructs a new [`DateRange`] beginning with a [`chrono::NaiveDate`] value
     /// and no upper limit.
     pub fn from_start(start: NaiveDate) -> DateRange {
         DateRange {
@@ -527,7 +539,8 @@ impl DateRange {
         }
     }
 
-    /// Constructs a new `DateRange` with no lower limit, ending with a `chrono::NaiveDate` value.
+    /// Constructs a new [`DateRange`] with no lower limit, ending with a
+    /// [`chrono::NaiveDate`] value.
     pub fn from_end(end: NaiveDate) -> DateRange {
         DateRange {
             start: None,
@@ -547,7 +560,7 @@ impl DateRange {
 }
 
 impl TimeRange {
-    /// Constructs a new `TimeRange` from two `chrono::NaiveTime` values
+    /// Constructs a new [`TimeRange`] from two [`chrono::NaiveTime`] values
     /// monotonically ordered in time.
     pub fn from_start_to_end(start: NaiveTime, end: NaiveTime) -> Result<TimeRange> {
         if start > end {
@@ -564,8 +577,8 @@ impl TimeRange {
         }
     }
 
-    /// Constructs a new `TimeRange` beginning with a `chrono::NaiveTime` value
-    /// and no upper limit.
+    /// Constructs a new [`TimeRange`] beginning with a [`chrono::NaiveTime`]
+    /// value and no upper limit.
     pub fn from_start(start: NaiveTime) -> TimeRange {
         TimeRange {
             start: Some(start),
@@ -573,7 +586,8 @@ impl TimeRange {
         }
     }
 
-    /// Constructs a new `TimeRange` with no lower limit, ending with a `chrono::NaiveTime` value.
+    /// Constructs a new [`TimeRange`] with no lower limit, ending with a
+    /// [`chrono::NaiveTime`] value.
     pub fn from_end(end: NaiveTime) -> TimeRange {
         TimeRange {
             start: None,
@@ -593,8 +607,8 @@ impl TimeRange {
 }
 
 impl DateTimeRange {
-    /// Constructs a new time-zone aware `DateTimeRange` from two `chrono::DateTime<FixedOffset>` values
-    /// monotonically ordered in time.
+    /// Constructs a new time-zone aware [`DateTimeRange`] from two
+    /// [`chrono::DateTime<FixedOffset>`] values monotonically ordered in time.
     pub fn from_start_to_end_with_time_zone(
         start: DateTime<FixedOffset>,
         end: DateTime<FixedOffset>,
@@ -613,8 +627,8 @@ impl DateTimeRange {
         }
     }
 
-    /// Constructs a new time-zone naive `DateTimeRange` from two `chrono::NaiveDateTime` values
-    /// monotonically ordered in time.
+    /// Constructs a new time-zone naive [`DateTimeRange`] from two
+    /// [`chrono::NaiveDateTime`] values monotonically ordered in time.
     pub fn from_start_to_end(start: NaiveDateTime, end: NaiveDateTime) -> Result<DateTimeRange> {
         if start > end {
             RangeInversionSnafu {
@@ -630,8 +644,8 @@ impl DateTimeRange {
         }
     }
 
-    /// Constructs a new time-zone aware `DateTimeRange` beginning with a `chrono::DateTime<FixedOffset>` value
-    /// and no upper limit.
+    /// Constructs a new time-zone aware [`DateTimeRange`] beginning with a
+    /// [`chrono::DateTime<FixedOffset>`] value and no upper limit.
     pub fn from_start_with_time_zone(start: DateTime<FixedOffset>) -> DateTimeRange {
         DateTimeRange::TimeZone {
             start: Some(start),
@@ -639,8 +653,8 @@ impl DateTimeRange {
         }
     }
 
-    /// Constructs a new time-zone naive `DateTimeRange` beginning with a `chrono::NaiveDateTime` value
-    /// and no upper limit.
+    /// Constructs a new time-zone naive [`DateTimeRange`] beginning with a
+    /// [`chrono::NaiveDateTime`] value and no upper limit.
     pub fn from_start(start: NaiveDateTime) -> DateTimeRange {
         DateTimeRange::Naive {
             start: Some(start),
@@ -648,7 +662,8 @@ impl DateTimeRange {
         }
     }
 
-    /// Constructs a new time-zone aware `DateTimeRange` with no lower limit, ending with a `chrono::DateTime<FixedOffset>` value.
+    /// Constructs a new time-zone aware [`DateTimeRange`] with no lower limit,
+    /// ending with a [`chrono::DateTime<FixedOffset>`] value.
     pub fn from_end_with_time_zone(end: DateTime<FixedOffset>) -> DateTimeRange {
         DateTimeRange::TimeZone {
             start: None,
@@ -656,7 +671,8 @@ impl DateTimeRange {
         }
     }
 
-    /// Constructs a new time-zone naive `DateTimeRange` with no lower limit, ending with a `chrono::NaiveDateTime` value.
+    /// Constructs a new time-zone naive [`DateTimeRange`] with no lower limit,
+    /// ending with a [`chrono::NaiveDateTime`] value.
     pub fn from_end(end: NaiveDateTime) -> DateTimeRange {
         DateTimeRange::Naive {
             start: None,
@@ -681,9 +697,10 @@ impl DateTimeRange {
     }
 
     /// For combined datetime range matching,
-    /// this method constructs a `DateTimeRange` from a `DateRange` and a `TimeRange`.
-    /// As 'DateRange' and 'TimeRange' are always time-zone unaware, the resulting DateTimeRange
-    /// will always be time-zone unaware.
+    /// this method constructs a [`DateTimeRange`] from a [`DateRange`] and a
+    /// [`TimeRange`].
+    /// As [`DateRange`] and [`TimeRange`] are always time-zone unaware, the
+    /// resulting [`DateTimeRange`] will always be time-zone unaware.
     pub fn from_date_and_time_range(dr: DateRange, tr: TimeRange) -> Result<DateTimeRange> {
         let start_date = dr.start();
         let end_date = dr.end();
@@ -724,10 +741,9 @@ impl DateTimeRange {
     }
 }
 
-/**
- *  Looks for a range separator '-'.
- *  Returns a `DateRange`.
- */
+/// Looks for a range separator '-'.
+///
+/// Returns a [`DateRange`].
 pub fn parse_date_range(buf: &[u8]) -> Result<DateRange> {
     // minimum length of one valid DicomDate (YYYY) and one '-' separator
     if buf.len() < 5 {
@@ -761,7 +777,8 @@ pub fn parse_date_range(buf: &[u8]) -> Result<DateRange> {
 }
 
 /// Looks for a range separator '-'.
-///  Returns a `TimeRange`.
+///
+///  Returns a [`TimeRange`].
 pub fn parse_time_range(buf: &[u8]) -> Result<TimeRange> {
     // minimum length of one valid DicomTime (HH) and one '-' separator
     if buf.len() < 3 {
@@ -804,6 +821,7 @@ pub fn parse_time_range(buf: &[u8]) -> Result<TimeRange> {
 ///
 /// This trait is implemented by parsers handling the aforementioned situation.
 /// For concrete implementations, see:
+///
 /// - [`ToLocalTimeZone`] (the default implementation)
 /// - [`ToKnownTimeZone`]
 /// - [`FailOnAmbiguousRange`]
@@ -823,20 +841,22 @@ pub trait AmbiguousDtRangeParser {
 
 /// For the missing time-zone,
 /// use time-zone information of the local system clock.
-/// Retrieves a [DateTimeRange::TimeZone].
+/// Retrieves a [`DateTimeRange::TimeZone`].
 ///
 /// This is the default behavior of the parser,
 /// which helps attain compliance with the standard
-/// as per [DICOM PS3.5 6.2](https://dicom.nema.org/medical/dicom/2023e/output/chtml/part05/sect_6.2.html):
+/// as per [`DICOM PS3.5 6.2`]:
 ///
 /// > A Date Time Value without the optional suffix
 /// > is interpreted to be in the local time zone of the application creating the Data Element,
 /// > unless explicitly specified by the Timezone Offset From UTC (0008,0201).
+///
+/// [`DICOM PS3.5 6.2`]: https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html
 #[derive(Debug)]
 pub struct ToLocalTimeZone;
 
 /// Use time-zone information from the time-zone aware value.
-/// Retrieves a [DateTimeRange::TimeZone].
+/// Retrieves a [`DateTimeRange::TimeZone`].
 #[derive(Debug)]
 pub struct ToKnownTimeZone;
 
@@ -845,7 +865,7 @@ pub struct ToKnownTimeZone;
 pub struct FailOnAmbiguousRange;
 
 /// Discard known (parsed) time-zone information.
-/// Retrieves a [DateTimeRange::Naive].
+/// Retrieves a [`DateTimeRange::Naive`].
 #[derive(Debug)]
 pub struct IgnoreTimeZone;
 
@@ -1024,20 +1044,21 @@ impl AmbiguousDtRangeParser for IgnoreTimeZone {
 }
 
 /// Looks for a range separator '-'.
-/// Returns a `DateTimeRange`.
+///
+/// Returns a [`DateTimeRange`].
 ///
 /// If the parser encounters two date-time values, where one is time-zone aware and the other is not,
 /// it will use the local time-zone offset and use it instead of the missing time-zone.
 ///
 /// This is the default behavior of the parser,
 /// which helps attain compliance with the standard
-/// as per [DICOM PS3.5 6.2](https://dicom.nema.org/medical/dicom/2023e/output/chtml/part05/sect_6.2.html):
+/// as per [`DICOM PS3.5 6.2`]:
 ///
 /// > A Date Time Value without the optional suffix
 /// > is interpreted to be in the local time zone of the application creating the Data Element,
 /// > unless explicitly specified by the Timezone Offset From UTC (0008,0201).
 ///
-/// To customize this behavior, please use [parse_datetime_range_custom()].
+/// To customize this behavior, please use [`parse_datetime_range_custom`].
 ///
 /// Users are advised, that for very specific inputs, inconsistent behavior can occur.
 /// This behavior can only be produced when all of the following is true:
@@ -1046,13 +1067,15 @@ impl AmbiguousDtRangeParser for IgnoreTimeZone {
 /// - only one west UTC offset is presented. e.g. (1000-1100-0100)
 ///
 /// In such cases, two '-' characters are present and the parser will favor the first one as a range separator,
-/// if it produces a valid `DateTimeRange`. Otherwise, it tries the second one.
+/// if it produces a valid [`DateTimeRange`]. Otherwise, it tries the second one.
+///
+/// [`DICOM PS3.5 6.2`]: https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html
 pub fn parse_datetime_range(buf: &[u8]) -> Result<DateTimeRange> {
     parse_datetime_range_impl::<ToLocalTimeZone>(buf)
 }
 
-/// Same as [parse_datetime_range()] but allows for custom handling of ambiguous Date-time ranges.
-/// See [AmbiguousDtRangeParser].
+/// Same as [`parse_datetime_range`] but allows for custom handling of ambiguous Date-time ranges.
+/// See [`AmbiguousDtRangeParser`].
 pub fn parse_datetime_range_custom<T: AmbiguousDtRangeParser>(buf: &[u8]) -> Result<DateTimeRange> {
     parse_datetime_range_impl::<T>(buf)
 }


### PR DESCRIPTION
This PR addresses part of #73 by introducing intra-doc links to the public API of the `core` crate. 

Additional changes:
- Converted obsolete comment blocks  (/* */) to idiomatic documentation comments (///).
- Refactored various comments to improve clarity and readability.