### PR TITLE
Make module functions private in binary crates

### DIFF
--- a/devtools/dictionary-builder/src/common.rs
+++ b/devtools/dictionary-builder/src/common.rs
@@ -1,6 +1,6 @@
 /// How to process retired entries
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub enum RetiredOptions {
+pub(crate) enum RetiredOptions {
     /// ignore retired attributes
     Ignore,
     /// include retired attributes
@@ -13,7 +13,7 @@ pub enum RetiredOptions {
 impl RetiredOptions {
     /// Create retired options from two flags.
     /// `ignore` takes precedence over `deprecate.
-    pub fn from_flags(ignore: bool, deprecate: bool) -> Self {
+    pub(crate) fn from_flags(ignore: bool, deprecate: bool) -> Self {
         if ignore {
             RetiredOptions::Ignore
         } else {

--- a/devtools/dictionary-builder/src/tags.rs
+++ b/devtools/dictionary-builder/src/tags.rs
@@ -21,7 +21,7 @@ const DEFAULT_LOCATION: &str =
 /// (tags)
 #[derive(Debug, Parser)]
 #[clap(name = "data-element", alias = "tags")]
-pub struct DataElementApp {
+pub(crate) struct DataElementApp {
     /// Path or URL to the data element dictionary
     #[clap(default_value(DEFAULT_LOCATION))]
     from: String,
@@ -36,7 +36,7 @@ pub struct DataElementApp {
     deprecate_retired: bool,
 }
 
-pub fn run(args: DataElementApp) -> Result<()> {
+pub(crate) fn run(args: DataElementApp) -> Result<()> {
     let DataElementApp {
         from,
         ignore_retired,

--- a/devtools/dictionary-builder/src/uids.rs
+++ b/devtools/dictionary-builder/src/uids.rs
@@ -26,7 +26,7 @@ const DEFAULT_LOCATION: &str =
 /// Fetch and build a dictionary of DICOM unique identifiers
 #[derive(Debug, Parser)]
 #[clap(name = "uids", alias = "uid")]
-pub struct UidApp {
+pub(crate) struct UidApp {
     /// Path or URL to the XML file containing the UID values tables
     #[clap(default_value(DEFAULT_LOCATION))]
     from: String,
@@ -48,7 +48,7 @@ pub struct UidApp {
     feature_gate: bool,
 }
 
-pub fn run(app: UidApp) -> Result<()> {
+pub(crate) fn run(app: UidApp) -> Result<()> {
     let UidApp {
         from,
         output,

--- a/findscu/src/query.rs
+++ b/findscu/src/query.rs
@@ -42,7 +42,10 @@ impl FromStr for TermQuery {
     }
 }
 
-pub fn parse_queries<T>(base: InMemDicomObject, qs: &[T]) -> Result<InMemDicomObject, Whatever>
+pub(crate) fn parse_queries<T>(
+    base: InMemDicomObject,
+    qs: &[T],
+) -> Result<InMemDicomObject, Whatever>
 where
     T: AsRef<str>,
 {

--- a/movescu/src/query.rs
+++ b/movescu/src/query.rs
@@ -42,7 +42,10 @@ impl FromStr for TermQuery {
     }
 }
 
-pub fn parse_queries<T>(base: InMemDicomObject, qs: &[T]) -> Result<InMemDicomObject, Whatever>
+pub(crate) fn parse_queries<T>(
+    base: InMemDicomObject,
+    qs: &[T],
+) -> Result<InMemDicomObject, Whatever>
 where
     T: AsRef<str>,
 {

--- a/movescu/src/store_async.rs
+++ b/movescu/src/store_async.rs
@@ -16,7 +16,7 @@ use crate::App;
 
 /// A list of supported abstract syntaxes for storage services
 #[allow(deprecated)]
-pub static ABSTRACT_SYNTAXES: &[&str] = &[
+pub(crate) static ABSTRACT_SYNTAXES: &[&str] = &[
     CT_IMAGE_STORAGE,
     ENHANCED_CT_IMAGE_STORAGE,
     STANDALONE_CURVE_STORAGE,
@@ -85,7 +85,7 @@ fn create_cstore_response(
     ])
 }
 
-pub async fn run_store_async(
+pub(crate) async fn run_store_async(
     scu_stream: tokio::net::TcpStream,
     progress: Option<ProgressBar>,
     args: &App,

--- a/scpproxy/src/main.rs
+++ b/scpproxy/src/main.rs
@@ -50,7 +50,7 @@ enum Error {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum ProviderType {
+enum ProviderType {
     /// Service class provider
     Scp,
     /// Service class user
@@ -58,7 +58,7 @@ pub enum ProviderType {
 }
 
 #[derive(Debug)]
-pub enum ThreadMessage {
+enum ThreadMessage {
     SendPdu {
         to: ProviderType,
         pdu: Pdu,
@@ -67,6 +67,7 @@ pub enum ThreadMessage {
         from: ProviderType,
         err: dicom_ul::association::Error,
     },
+    #[allow(dead_code)]
     WriteErr {
         from: ProviderType,
         err: dicom_ul::pdu::WriteError,

--- a/storescp/src/store_async.rs
+++ b/storescp/src/store_async.rs
@@ -14,7 +14,7 @@ use snafu::{OptionExt, Report, ResultExt, Whatever};
 use tracing::{debug, info, warn};
 
 use crate::{App, create_cecho_response, create_cstore_response, transfer::ABSTRACT_SYNTAXES};
-pub async fn run_store_async(
+pub(crate) async fn run_store_async(
     scu_stream: tokio::net::TcpStream,
     args: &App,
 ) -> Result<(), Whatever> {

--- a/storescp/src/store_sync.rs
+++ b/storescp/src/store_sync.rs
@@ -14,7 +14,7 @@ use snafu::{OptionExt, Report, ResultExt, Whatever};
 use tracing::{debug, info, warn};
 
 use crate::{App, create_cecho_response, create_cstore_response, transfer::ABSTRACT_SYNTAXES};
-pub fn run_store_sync(scu_stream: TcpStream, args: &App) -> Result<(), Whatever> {
+pub(crate) fn run_store_sync(scu_stream: TcpStream, args: &App) -> Result<(), Whatever> {
     let App {
         verbose,
         calling_ae_title,

--- a/storescp/src/transfer.rs
+++ b/storescp/src/transfer.rs
@@ -4,7 +4,7 @@ use dicom_dictionary_std::uids::*;
 
 /// A list of supported abstract syntaxes for storage services
 #[allow(deprecated)]
-pub static ABSTRACT_SYNTAXES: &[&str] = &[
+pub(crate) static ABSTRACT_SYNTAXES: &[&str] = &[
     CT_IMAGE_STORAGE,
     ENHANCED_CT_IMAGE_STORAGE,
     STANDALONE_CURVE_STORAGE,

--- a/storescu/src/main.rs
+++ b/storescu/src/main.rs
@@ -183,7 +183,7 @@ enum Error {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn get_scu_options<'a>(
+pub(crate) fn get_scu_options<'a>(
     calling_ae_title: String,
     called_ae_title: Option<String>,
     max_pdu_length: u32,

--- a/storescu/src/store_async.rs
+++ b/storescu/src/store_async.rs
@@ -20,7 +20,7 @@ use crate::{
     WriteDatasetSnafu, check_presentation_contexts, into_ts, store_req_command,
 };
 
-pub async fn send_file<T>(
+pub(crate) async fn send_file<T>(
     mut scu: AsyncClientAssociation<T>,
     file: DicomFile,
     message_id: u16,
@@ -204,7 +204,7 @@ where
     Ok(scu)
 }
 
-pub async fn inner<T>(
+pub(crate) async fn inner<T>(
     mut scu: AsyncClientAssociation<T>,
     d_files: Arc<Mutex<Vec<DicomFile>>>,
     pbx: Option<Arc<Mutex<ProgressBar>>>,

--- a/storescu/src/store_sync.rs
+++ b/storescu/src/store_sync.rs
@@ -19,7 +19,7 @@ use crate::{
     WriteDatasetSnafu, WriteIOSnafu, check_presentation_contexts, into_ts, store_req_command,
 };
 
-pub fn send_file<T>(
+pub(crate) fn send_file<T>(
     mut scu: ClientAssociation<T>,
     file: DicomFile,
     message_id: u16,
@@ -205,7 +205,7 @@ where
     Ok(scu)
 }
 
-pub fn inner<T>(
+pub(crate) fn inner<T>(
     mut scu: ClientAssociation<T>,
     d_files: Vec<DicomFile>,
     pbx: &Option<ProgressBar>,


### PR DESCRIPTION
Since this issue is still open (https://github.com/rust-lang/rust/issues/74970), it's better to change all `pub` modifiers in binary crates to `pub(crate)`. This change also helped uncover an unused enum variant.
