### PR TITLE
Clippy lint fix (2026-07)

### DIFF
--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -1348,7 +1348,7 @@ impl fmt::Display for Length {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
             UNDEFINED_LEN => f.write_str("U/L"),
-            l => write!(f, "{}", &l),
+            l => write!(f, "{}", l),
         }
     }
 }

--- a/devtools/dictionary-builder/src/uids.rs
+++ b/devtools/dictionary-builder/src/uids.rs
@@ -340,7 +340,7 @@ where
             f,
             "#[rustfmt::skip]\npub const {}: &str = {:?};",
             e.keyword.to_shouty_snake_case(),
-            &e.uid,
+            e.uid,
         )?;
     }
 

--- a/dump/src/lib.rs
+++ b/dump/src/lib.rs
@@ -661,8 +661,8 @@ where
             let byte_len = offset_table.len() * 4;
             let summary = offset_table_summary(
                 offset_table,
-                Some(width)
-                    .filter(|_| !no_limit)
+                (!no_limit)
+                    .then_some(width)
                     .map(|w| w.saturating_sub(38 + depth * 2)),
             );
             writeln!(
@@ -679,8 +679,8 @@ where
                 let byte_len = fragment.len();
                 let summary = item_value_summary(
                     fragment,
-                    Some(width)
-                        .filter(|_| !no_limit)
+                    (!no_limit)
+                        .then_some(width)
                         .map(|w| w.saturating_sub(38 + depth * 2)),
                 );
                 writeln!(

--- a/findscu/src/query.rs
+++ b/findscu/src/query.rs
@@ -56,7 +56,7 @@ where
             AttributeAction::Set(v),
         ))
         .with_whatever_context(|_| {
-            format!("could not set query attribute {}", &term_query.selector)
+            format!("could not set query attribute {}", term_query.selector)
         })?;
     }
     Ok(obj)

--- a/movescu/src/query.rs
+++ b/movescu/src/query.rs
@@ -56,7 +56,7 @@ where
             AttributeAction::Set(v),
         ))
         .with_whatever_context(|_| {
-            format!("could not set query attribute {}", &term_query.selector)
+            format!("could not set query attribute {}", term_query.selector)
         })?;
     }
     Ok(obj)

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -29,7 +29,7 @@ use crate::{
     IMPLEMENTATION_VERSION_NAME,
 };
 
-const DICM_MAGIC_CODE: [u8; 4] = [b'D', b'I', b'C', b'M'];
+const DICM_MAGIC_CODE: [u8; 4] = *b"DICM";
 
 #[derive(Debug, Snafu)]
 #[non_exhaustive]

--- a/parser/src/dataset/lazy_read.rs
+++ b/parser/src/dataset/lazy_read.rs
@@ -268,17 +268,16 @@ where
                 match end_of_sequence.cmp(&bytes_read) {
                     Ordering::Equal => {
                         // end of delimiter, as indicated by the element's length
-                        let token;
-                        match sd.typ {
+                        let token = match sd.typ {
                             SeqTokenType::Sequence => {
                                 self.in_sequence = false;
-                                token = LazyDataToken::SequenceEnd;
+                                LazyDataToken::SequenceEnd
                             }
                             SeqTokenType::Item => {
                                 self.in_sequence = true;
-                                token = LazyDataToken::ItemEnd;
+                                LazyDataToken::ItemEnd
                             }
-                        }
+                        };
                         self.seq_delimiters.pop();
                         return Ok(Some(token));
                     }

--- a/parser/src/dataset/mod.rs
+++ b/parser/src/dataset/mod.rs
@@ -738,12 +738,8 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         // ensure a token sequence
         if self.tokens.is_none() {
-            match self.seq.next() {
-                Some(entries) => {
-                    self.tokens = Some(entries.into_tokens_with_options(self.into_token_options));
-                }
-                None => return None,
-            }
+            let entries = self.seq.next()?;
+            self.tokens = Some(entries.into_tokens_with_options(self.into_token_options));
         }
 
         // retrieve the next token

--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -687,17 +687,16 @@ where
                 match end_of_sequence.cmp(&bytes_read) {
                     Ordering::Equal => {
                         // end of delimiter, as indicated by the element's length
-                        let token;
-                        match sd.typ {
+                        let token = match sd.typ {
                             SeqTokenType::Sequence => {
                                 self.in_sequence = false;
-                                token = DataToken::SequenceEnd;
+                                DataToken::SequenceEnd
                             }
                             SeqTokenType::Item => {
                                 self.in_sequence = true;
-                                token = DataToken::ItemEnd;
+                                DataToken::ItemEnd
                             }
-                        }
+                        };
                         self.seq_delimiters.pop();
                         return Ok(Some(token));
                     }


### PR DESCRIPTION
With a new version of Rust came a few new lints by default.

### Summary

- [core] Clippy lint fix
- [parser] Clippy lint fix
- [object] Clippy lint fix
- [dump] Clippy lint fix
- [movescu] [findscu] Clippy lint fix
- [dictionary-builder] Clippy lint fix
