### PR TITLE
Add safeguards from excessive allocations

### DIFF
--- a/encoding/src/adapters.rs
+++ b/encoding/src/adapters.rs
@@ -63,6 +63,22 @@ pub enum DecodeError {
     /// from the DICOM object representing the image.
     #[snafu(display("Missing required attribute `{}`", name))]
     MissingAttribute { name: &'static str },
+
+    /// A piece of data could not be allocated.
+    ///
+    /// This may be either a sign of memory saturation
+    /// while trying to decode very large images,
+    /// or a sign of the input data being invalid or otherwise problematic.
+    #[snafu(display("Could not allocate {name}"))]
+    Allocate {
+        /// A name for the memory object being allocated,
+        /// such as a frame of pixel data.
+        ///
+        /// Names at this level are not standardized.
+        name: &'static str,
+        /// The size of the attempted allocation in bytes
+        size: Option<usize>,
+    },
 }
 
 /// The possible error conditions when encoding (writing) pixel data.

--- a/object/src/meta.rs
+++ b/object/src/meta.rs
@@ -31,6 +31,13 @@ use crate::{
 
 const DICM_MAGIC_CODE: [u8; 4] = *b"DICM";
 
+/// A hard limit for the size
+/// of binary data elements in the file meta information group.
+///
+/// Although this can reject DICOM-compliant files,
+/// the file meta information group is not expected to be exaggeratedly large.
+const META_FILE_INFO_ELEM_SIZE_LIMIT: u32 = 1 << 26;
+
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
 pub enum Error {
@@ -644,9 +651,16 @@ impl FileMetaTable {
                 Tag(0x0002, 0x0012) => {
                     builder.implementation_class_uid(read_str_body(&mut file, &text, elem_len)?)
                 }
-                Tag(0x0002, 0x0013) => {
+                tag @ Tag(0x0002, 0x0013) => {
                     // Implementation Version Name
                     let mut v = Vec::new();
+                    ensure!(
+                        elem_len <= 16,
+                        UnexpectedDataValueLengthSnafu {
+                            length: elem_len,
+                            tag,
+                        }
+                    );
                     v.try_reserve_exact(elem_len as usize)
                         .context(AllocationSizeSnafu)?;
                     v.resize(elem_len as usize, 0);
@@ -657,9 +671,16 @@ impl FileMetaTable {
                             .context(DecodeTextSnafu { name: text.name() })?,
                     )
                 }
-                Tag(0x0002, 0x0016) => {
+                tag @ Tag(0x0002, 0x0016) => {
                     // Source Application Entity Title
                     let mut v = Vec::new();
+                    ensure!(
+                        elem_len <= 16,
+                        UnexpectedDataValueLengthSnafu {
+                            length: elem_len,
+                            tag,
+                        }
+                    );
                     v.try_reserve_exact(elem_len as usize)
                         .context(AllocationSizeSnafu)?;
                     v.resize(elem_len as usize, 0);
@@ -670,9 +691,16 @@ impl FileMetaTable {
                             .context(DecodeTextSnafu { name: text.name() })?,
                     )
                 }
-                Tag(0x0002, 0x0017) => {
+                tag @ Tag(0x0002, 0x0017) => {
                     // Sending Application Entity Title
                     let mut v = Vec::new();
+                    ensure!(
+                        elem_len <= 16,
+                        UnexpectedDataValueLengthSnafu {
+                            length: elem_len,
+                            tag,
+                        }
+                    );
                     v.try_reserve_exact(elem_len as usize)
                         .context(AllocationSizeSnafu)?;
                     v.resize(elem_len as usize, 0);
@@ -683,9 +711,16 @@ impl FileMetaTable {
                             .context(DecodeTextSnafu { name: text.name() })?,
                     )
                 }
-                Tag(0x0002, 0x0018) => {
+                tag @ Tag(0x0002, 0x0018) => {
                     // Receiving Application Entity Title
                     let mut v = Vec::new();
+                    ensure!(
+                        elem_len <= 16,
+                        UnexpectedDataValueLengthSnafu {
+                            length: elem_len,
+                            tag,
+                        }
+                    );
                     v.try_reserve_exact(elem_len as usize)
                         .context(AllocationSizeSnafu)?;
                     v.resize(elem_len as usize, 0);
@@ -696,9 +731,16 @@ impl FileMetaTable {
                             .context(DecodeTextSnafu { name: text.name() })?,
                     )
                 }
-                Tag(0x0002, 0x0100) => {
+                tag @ Tag(0x0002, 0x0100) => {
                     // Private Information Creator UID
                     let mut v = Vec::new();
+                    ensure!(
+                        elem_len <= 64,
+                        UnexpectedDataValueLengthSnafu {
+                            length: elem_len,
+                            tag,
+                        }
+                    );
                     v.try_reserve_exact(elem_len as usize)
                         .context(AllocationSizeSnafu)?;
                     v.resize(elem_len as usize, 0);
@@ -709,9 +751,16 @@ impl FileMetaTable {
                             .context(DecodeTextSnafu { name: text.name() })?,
                     )
                 }
-                Tag(0x0002, 0x0102) => {
+                tag @ Tag(0x0002, 0x0102) => {
                     // Private Information
                     let mut v = Vec::new();
+                    ensure!(
+                        elem_len <= META_FILE_INFO_ELEM_SIZE_LIMIT,
+                        UnexpectedDataValueLengthSnafu {
+                            length: elem_len,
+                            tag,
+                        }
+                    );
                     v.try_reserve_exact(elem_len as usize)
                         .context(AllocationSizeSnafu)?;
                     v.resize(elem_len as usize, 0);

--- a/parser/src/dataset/read.rs
+++ b/parser/src/dataset/read.rs
@@ -82,6 +82,18 @@ pub enum Error {
     InvalidElementLength { tag: Tag, len: u32, bytes_read: u64 },
     /// Invalid sequence item length {len:04X} at {bytes_read:#x}
     InvalidItemLength { len: u32, bytes_read: u64 },
+    /// Could not reserve memory for the offset table ({len} bytes)
+    AllocateOffsetTable {
+        /// the length of the attempted allocation
+        len: u32,
+        source: std::collections::TryReserveError,
+    },
+    /// Could not reserve memory for the offset table ({len} bytes)
+    AllocateItem {
+        /// the length of the attempted allocation
+        len: u32,
+        source: std::collections::TryReserveError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -446,7 +458,12 @@ where
 
                 if self.offset_table_next {
                     // offset table
-                    let mut offset_table = Vec::with_capacity(len);
+                    let mut offset_table = Vec::new();
+                    let res = offset_table.try_reserve_exact(len)
+                        .context(AllocateOffsetTableSnafu { len: len as u32 });
+                    if let Err(e) = res {
+                        return Some(Err(e));
+                    }
 
                     self.offset_table_next = false;
 
@@ -461,7 +478,13 @@ where
                     )
                 } else {
                     // item value
-                    let mut value = Vec::with_capacity(len);
+                    let mut value = Vec::new();
+                    let res = value.try_reserve_exact(len)
+                        .context(AllocateItemSnafu { len: len as u32 });
+                    if let Err(e) = res {
+                        return Some(Err(e));
+                    }
+
 
                     // need to pop item delimiter on the next iteration
                     self.delimiter_check_pending = true;

--- a/parser/src/stateful/decode.rs
+++ b/parser/src/stateful/decode.rs
@@ -17,7 +17,7 @@ use dicom_encoding::text::{
     validate_dt, validate_tm,
 };
 use dicom_encoding::transfer_syntax::{DynDecoder, TransferSyntax};
-use smallvec::smallvec;
+use smallvec::SmallVec;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use std::io::Read;
 use std::{fmt::Debug, io::Seek, io::SeekFrom};
@@ -70,6 +70,12 @@ pub enum Error {
         position: u64,
         #[snafu(backtrace)]
         source: dicom_encoding::text::DecodeTextError,
+    },
+
+    #[snafu(display("Could not reserve memory for data value ({len} bytes)"))]
+    AllocateValueData {
+        /// the byte length of the attempted allocation
+        len: u32,
     },
 
     #[snafu(display("Could not read value from source at position {}", position))]
@@ -457,7 +463,12 @@ where
         let len = self.require_known_length(header)?;
 
         // sequence of 8-bit integers (or arbitrary byte data)
-        let mut buf = smallvec![0u8; len];
+        let mut buf = SmallVec::new();
+        buf.try_reserve_exact(len)
+            // discard allocation error, does not impl std::error::Error
+            .ok()
+            .context(AllocateValueDataSnafu { len: len as u32 })?;
+        buf.resize(len, 0);
         self.from.read_exact(&mut buf).context(ReadValueDataSnafu {
             position: self.position,
         })?;
@@ -532,7 +543,11 @@ where
         let len = self.require_known_length(header)?;
 
         let n = len >> 1;
-        let mut vec = smallvec![0; n];
+        let mut vec = SmallVec::new();
+        vec.try_reserve_exact(n)
+            .ok()
+            .context(AllocateValueDataSnafu { len: len as u32 })?;
+        vec.resize(n, 0);
         self.basic
             .decode_ss_into(&mut self.from, &mut vec[..])
             .context(ReadValueDataSnafu {
@@ -547,7 +562,11 @@ where
         let len = self.require_known_length(header)?;
         // sequence of 32-bit floats
         let n = len >> 2;
-        let mut vec = smallvec![0.; n];
+        let mut vec = SmallVec::new();
+        vec.try_reserve_exact(n)
+            .ok()
+            .context(AllocateValueDataSnafu { len: len as u32 })?;
+        vec.resize(n, 0.);
         self.basic
             .decode_fl_into(&mut self.from, &mut vec[..])
             .context(ReadValueDataSnafu {
@@ -740,7 +759,11 @@ where
         let len = self.require_known_length(header)?;
         // sequence of 64-bit floats
         let n = len >> 3;
-        let mut vec = smallvec![0.; n];
+        let mut vec = SmallVec::new();
+        vec.try_reserve_exact(n)
+            .ok()
+            .context(AllocateValueDataSnafu { len: len as u32 })?;
+        vec.resize(n, 0.);
         self.basic
             .decode_fd_into(&mut self.from, &mut vec[..])
             .context(ReadValueDataSnafu {
@@ -755,7 +778,11 @@ where
         // sequence of 32-bit unsigned integers
 
         let n = len >> 2;
-        let mut vec = smallvec![0u32; n];
+        let mut vec = SmallVec::new();
+        vec.try_reserve_exact(n)
+            .ok()
+            .context(AllocateValueDataSnafu { len: len as u32 })?;
+        vec.resize(n, 0);
         self.basic
             .decode_ul_into(&mut self.from, &mut vec[..])
             .context(ReadValueDataSnafu {
@@ -767,6 +794,11 @@ where
 
     fn read_u32(&mut self, n: usize, vec: &mut Vec<u32>) -> Result<()> {
         let base = vec.len();
+
+        vec.try_reserve_exact(n)
+            .ok()
+            .context(AllocateValueDataSnafu { len: n as u32 * 4 })?;
+
         vec.resize(base + n, 0);
 
         self.basic
@@ -783,7 +815,11 @@ where
         // sequence of 16-bit unsigned integers
 
         let n = len >> 1;
-        let mut vec = smallvec![0; n];
+        let mut vec = SmallVec::new();
+        vec.try_reserve_exact(n)
+            .ok()
+            .context(AllocateValueDataSnafu { len: len as u32 })?;
+        vec.resize(n, 0);
         self.basic
             .decode_us_into(&mut self.from, &mut vec[..])
             .context(ReadValueDataSnafu {
@@ -805,7 +841,11 @@ where
         // sequence of 64-bit unsigned integers
 
         let n = len >> 3;
-        let mut vec = smallvec![0; n];
+        let mut vec = SmallVec::new();
+        vec.try_reserve_exact(n)
+            .ok()
+            .context(AllocateValueDataSnafu { len: len as u32 })?;
+        vec.resize(n, 0);
         self.basic
             .decode_uv_into(&mut self.from, &mut vec[..])
             .context(ReadValueDataSnafu {
@@ -820,7 +860,11 @@ where
         // sequence of 32-bit signed integers
 
         let n = len >> 2;
-        let mut vec = smallvec![0; n];
+        let mut vec = SmallVec::new();
+        vec.try_reserve_exact(n)
+            .ok()
+            .context(AllocateValueDataSnafu { len: len as u32 })?;
+        vec.resize(n, 0);
         self.basic
             .decode_sl_into(&mut self.from, &mut vec[..])
             .context(ReadValueDataSnafu {
@@ -835,7 +879,11 @@ where
         // sequence of 64-bit signed integers
 
         let n = len >> 3;
-        let mut vec = smallvec![0; n];
+        let mut vec = SmallVec::new();
+        vec.try_reserve_exact(n)
+            .ok()
+            .context(AllocateValueDataSnafu { len: len as u32 })?;
+        vec.resize(n, 0);
         self.basic
             .decode_sv_into(&mut self.from, &mut vec[..])
             .context(ReadValueDataSnafu {

--- a/transfer-syntax-registry/src/adapters/jpeg.rs
+++ b/transfer-syntax-registry/src/adapters/jpeg.rs
@@ -374,7 +374,10 @@ fn guarded_resize(
 ) -> DecodeResult<()> {
     crate::alloc::guarded_resize(out, additional_capacity, encapsulated_size, COMPRESSION_RATIO_THRESHOLD)
         .ok()
-        .whatever_context("Could not allocate frame")
+        .context(decode_error::AllocateSnafu {
+            name: "frame",
+            size: additional_capacity,
+        })
 }
 
 /// reduce data precision to 8 bits if necessary.

--- a/transfer-syntax-registry/src/adapters/jpeg.rs
+++ b/transfer-syntax-registry/src/adapters/jpeg.rs
@@ -46,10 +46,14 @@ impl PixelDataReader for JpegAdapter {
         // `stride` it the total number of bytes for each sample plane
         let stride: usize = bytes_per_sample as usize * cols as usize * rows as usize;
         let base_offset = dst.len();
-        dst.resize(
-            base_offset + (samples_per_pixel as usize * stride) * nr_frames,
-            0,
-        );
+        // !!! using an approximation of encapsulated size
+        // so we do not need to go through every frame
+        let encapsulated_size = src.fragment(0).unwrap_or_default().len() * nr_frames;
+        guarded_resize(
+            dst,
+            samples_per_pixel as usize * stride * nr_frames,
+            encapsulated_size * nr_frames,
+        )?;
 
         let raw = src
             .raw_pixel_data()
@@ -164,8 +168,6 @@ impl PixelDataReader for JpegAdapter {
 
         // `stride` it the total number of bytes for each sample plane
         let stride: usize = bytes_per_sample as usize * cols as usize * rows as usize;
-        let base_offset = dst.len();
-        dst.resize(base_offset + (samples_per_pixel as usize * stride), 0);
 
         let raw = src
             .raw_pixel_data()
@@ -214,6 +216,9 @@ impl PixelDataReader for JpegAdapter {
 
             Cow::Owned(fragments)
         };
+
+        let base_offset = dst.len();
+        guarded_resize(dst, samples_per_pixel as usize * stride, frame_data.len())?;
 
         let mut cursor = Cursor::new(&*frame_data);
         let dst_offset = base_offset;
@@ -359,7 +364,20 @@ fn next_even(l: u64) -> u64 {
     (l + 1) & !1
 }
 
-/// reduce data precision to 8 bits if necessary
+const COMPRESSION_RATIO_THRESHOLD: u32 = 64;
+
+/// Perform a resize of a vector (with zeros), safeguarded from extreme cases.
+fn guarded_resize(
+    out: &mut Vec<u8>,
+    additional_capacity: usize,
+    encapsulated_size: usize,
+) -> DecodeResult<()> {
+    crate::alloc::guarded_resize(out, additional_capacity, encapsulated_size, COMPRESSION_RATIO_THRESHOLD)
+        .ok()
+        .whatever_context("Could not allocate frame")
+}
+
+/// reduce data precision to 8 bits if necessary.
 /// data loss is possible
 fn narrow_8bit(frame_data: &[u8], bits_stored: u16) -> EncodeResult<Cow<'_, [u8]>> {
     debug_assert!(bits_stored >= 8);

--- a/transfer-syntax-registry/src/adapters/jpeg2k.rs
+++ b/transfer-syntax-registry/src/adapters/jpeg2k.rs
@@ -104,7 +104,15 @@ fn guarded_resize(
     additional_capacity: usize,
     fragment_size: usize,
 ) -> DecodeResult<()> {
-    crate::alloc::guarded_resize(out, additional_capacity, fragment_size, COMPRESSION_RATIO_THRESHOLD)
-        .ok()
-        .whatever_context("Could not allocate frame")
+    crate::alloc::guarded_resize(
+        out,
+        additional_capacity,
+        fragment_size,
+        COMPRESSION_RATIO_THRESHOLD,
+    )
+    .ok()
+    .context(decode_error::AllocateSnafu {
+        name: "frame",
+        size: additional_capacity,
+    })
 }

--- a/transfer-syntax-registry/src/adapters/jpeg2k.rs
+++ b/transfer-syntax-registry/src/adapters/jpeg2k.rs
@@ -56,13 +56,15 @@ impl PixelDataReader for Jpeg2000Adapter {
 
         // `stride` it the total number of bytes for each sample plane
         let stride: usize = bytes_per_sample as usize * cols as usize * rows as usize;
-        dst.reserve_exact(samples_per_pixel as usize * stride);
         let base_offset = dst.len();
-        dst.resize(base_offset + (samples_per_pixel as usize * stride), 0);
 
         let frame_data = src
             .frame_pixel_data(frame)
             .context(decode_error::FrameRangeOutOfBoundsSnafu)?;
+
+        // extend output vector
+        guarded_resize(dst, samples_per_pixel as usize * stride, frame_data.len())?;
+
         let image = Image::from_bytes(&frame_data).whatever_context("jpeg2k decoder failure")?;
 
         // Note: we cannot use `get_pixels`
@@ -92,4 +94,17 @@ impl PixelDataReader for Jpeg2000Adapter {
 
         Ok(())
     }
+}
+
+const COMPRESSION_RATIO_THRESHOLD: u32 = 64;
+
+/// Perform a resize of a vector (with zeros), safeguarded from extreme cases.
+fn guarded_resize(
+    out: &mut Vec<u8>,
+    additional_capacity: usize,
+    fragment_size: usize,
+) -> DecodeResult<()> {
+    crate::alloc::guarded_resize(out, additional_capacity, fragment_size, COMPRESSION_RATIO_THRESHOLD)
+        .ok()
+        .whatever_context("Could not allocate frame")
 }

--- a/transfer-syntax-registry/src/adapters/jpegxl.rs
+++ b/transfer-syntax-registry/src/adapters/jpegxl.rs
@@ -65,7 +65,6 @@ impl PixelDataReader for JpegXlAdapter {
 
         // `stride` it the total number of bytes for each sample plane
         let stride: usize = bytes_per_sample as usize * cols as usize * rows as usize;
-        dst.reserve_exact(samples_per_pixel as usize * stride);
 
         let raw = src
             .raw_pixel_data()
@@ -82,6 +81,9 @@ impl PixelDataReader for JpegXlAdapter {
                 .with_whatever_context(|| {
                     format!("Missing fragment #{frame} for the frame requested")
                 })?;
+
+        // extend output vector
+        guarded_reserve(dst, samples_per_pixel as usize * stride, frame_data.len())?;
 
         let image = JxlImage::builder()
             .read(&**frame_data)
@@ -103,11 +105,8 @@ impl PixelDataReader for JpegXlAdapter {
                 let samples_per_frame =
                     stream.channels() as usize * stream.width() as usize * stream.height() as usize;
 
-                dst.try_reserve(samples_per_frame)
-                    .whatever_context("Failed to reserve heap space for JPEG XL frame")?;
-
                 let offset = dst.len();
-                dst.resize(offset + samples_per_frame, 0);
+                guarded_resize(dst, samples_per_frame, frame_data.len())?;
 
                 let count = stream.write_to_buffer(&mut dst[offset..]);
                 dst.truncate(offset + count);
@@ -308,4 +307,26 @@ impl PixelDataWriter for JpegXlLosslessEncoder {
         options.quality = Some(100);
         JpegXlAdapter.encode(src, options, dst, offset_table)
     }
+}
+
+const COMPRESSION_RATIO_THRESHOLD: u32 = 64;
+
+fn guarded_reserve(
+    out: &mut Vec<u8>,
+    additional_capacity: usize,
+    encapsulated_size: usize,
+) -> DecodeResult<()> {
+    crate::alloc::guarded_reserve(out, additional_capacity, encapsulated_size, COMPRESSION_RATIO_THRESHOLD)
+        .ok()
+        .whatever_context("Failed to reserve heap space for JPEG XL frame")
+}
+
+fn guarded_resize(
+    out: &mut Vec<u8>,
+    additional_capacity: usize,
+    encapsulated_size: usize,
+) -> DecodeResult<()> {
+    crate::alloc::guarded_resize(out, additional_capacity, encapsulated_size, COMPRESSION_RATIO_THRESHOLD)
+        .ok()
+        .whatever_context("Failed to reserve heap space for JPEG XL frame")
 }

--- a/transfer-syntax-registry/src/adapters/jpegxl.rs
+++ b/transfer-syntax-registry/src/adapters/jpegxl.rs
@@ -316,9 +316,17 @@ fn guarded_reserve(
     additional_capacity: usize,
     encapsulated_size: usize,
 ) -> DecodeResult<()> {
-    crate::alloc::guarded_reserve(out, additional_capacity, encapsulated_size, COMPRESSION_RATIO_THRESHOLD)
-        .ok()
-        .whatever_context("Failed to reserve heap space for JPEG XL frame")
+    crate::alloc::guarded_reserve(
+        out,
+        additional_capacity,
+        encapsulated_size,
+        COMPRESSION_RATIO_THRESHOLD,
+    )
+    .ok()
+    .context(decode_error::AllocateSnafu {
+        name: "JPEG XL frame",
+        size: additional_capacity,
+    })
 }
 
 fn guarded_resize(
@@ -326,7 +334,15 @@ fn guarded_resize(
     additional_capacity: usize,
     encapsulated_size: usize,
 ) -> DecodeResult<()> {
-    crate::alloc::guarded_resize(out, additional_capacity, encapsulated_size, COMPRESSION_RATIO_THRESHOLD)
-        .ok()
-        .whatever_context("Failed to reserve heap space for JPEG XL frame")
+    crate::alloc::guarded_resize(
+        out,
+        additional_capacity,
+        encapsulated_size,
+        COMPRESSION_RATIO_THRESHOLD,
+    )
+    .ok()
+    .context(decode_error::AllocateSnafu {
+        name: "JPEG XL frame",
+        size: additional_capacity,
+    })
 }

--- a/transfer-syntax-registry/src/adapters/rle_lossless.rs
+++ b/transfer-syntax-registry/src/adapters/rle_lossless.rs
@@ -306,7 +306,10 @@ const COMPRESSION_RATIO_THRESHOLD: u32 = 32;
 fn guarded_alloc(capacity: usize, fragment_size: usize) -> DecodeResult<Vec<u8>> {
     crate::alloc::guarded_alloc(capacity, fragment_size, COMPRESSION_RATIO_THRESHOLD)
         .ok()
-        .whatever_context("Could not allocate RLE segment")
+        .context(decode_error::AllocateSnafu {
+            name: "RLE segment",
+            size: capacity,
+        })
 }
 
 /// Perform a resize of a vector (with zeros), safeguarded from extreme cases.
@@ -315,9 +318,17 @@ fn guarded_resize(
     additional_capacity: usize,
     fragment_size: usize,
 ) -> DecodeResult<()> {
-    crate::alloc::guarded_resize(out, additional_capacity, fragment_size, COMPRESSION_RATIO_THRESHOLD)
-        .ok()
-        .whatever_context("Could not allocate frame")
+    crate::alloc::guarded_resize(
+        out,
+        additional_capacity,
+        fragment_size,
+        COMPRESSION_RATIO_THRESHOLD,
+    )
+    .ok()
+    .context(decode_error::AllocateSnafu {
+        name: "frame",
+        size: additional_capacity,
+    })
 }
 
 #[cfg(test)]

--- a/transfer-syntax-registry/src/adapters/rle_lossless.rs
+++ b/transfer-syntax-registry/src/adapters/rle_lossless.rs
@@ -52,9 +52,12 @@ impl PixelDataReader for RleLosslessAdapter {
         // `stride` is the total number of bytes for each sample plane
         let stride = bytes_per_sample * cols as usize * rows as usize;
         let frame_size = stride * samples_per_pixel;
+
         // extend `dst` to make room for decoded pixel data
         let base_offset = dst.len();
-        dst.resize(base_offset + frame_size * nr_frames, 0);
+        // estimate the sizes of the encapsulated fragments
+        let encapsulated_size = src.fragment(0).unwrap_or_default().len() * nr_frames;
+        guarded_resize(dst, frame_size * nr_frames, encapsulated_size)?;
 
         // RLE encoded data is ordered like this (for 16-bit, 3 sample):
         //  Segment: 0     | 1     | 2     | 3     | 4     | 5
@@ -80,11 +83,16 @@ impl PixelDataReader for RleLosslessAdapter {
                     // ii is 1, 0, 3, 2, 5, 4 for the example above
                     // This is where the segment order correction occurs
                     let ii = sample_number * bytes_per_sample + byte_offset;
-                    let segment = &fragment[offsets[ii] as usize..offsets[ii + 1] as usize];
+                    ensure_whatever!(ii + 1 < offsets.len(), "Invalid RLE segment offsets");
+                    let segment_range = offsets[ii] as usize..offsets[ii + 1] as usize;
+                    let segment = fragment
+                        .get(segment_range)
+                        .whatever_context("Invalid RLE segment range")?;
                     let buff = io::Cursor::new(segment);
                     let (_, decoder) = PackBitsReader::new(buff, segment.len())
                         .whatever_context("Failed to read RLE segments")?;
-                    let mut decoded_segment = Vec::with_capacity(rows as usize * cols as usize);
+                    let mut decoded_segment =
+                        guarded_alloc(rows as usize * cols as usize, fragment.len())?;
                     decoder
                         .take(rows as u64 * cols as u64)
                         .read_to_end(&mut decoded_segment)
@@ -163,9 +171,7 @@ impl PixelDataReader for RleLosslessAdapter {
         // `stride` is the total number of bytes for each sample plane
         let stride = bytes_per_sample * cols as usize * rows as usize;
         let frame_size = stride * samples_per_pixel;
-        // extend `dst` to make room for decoded pixel data
         let base_offset = dst.len();
-        dst.resize(base_offset + frame_size, 0);
 
         // RLE encoded data is ordered like this (for 16-bit, 3 sample):
         //  Segment: 0     | 1     | 2     | 3     | 4     | 5
@@ -185,17 +191,25 @@ impl PixelDataReader for RleLosslessAdapter {
         let mut offsets = read_rle_header(fragment);
         offsets.push(fragment.len() as u32);
 
+        // extend `dst` to make room for decoded pixel data
+        guarded_resize(dst, frame_size, fragment.len())?;
+
         for sample_number in 0..samples_per_pixel {
             for byte_offset in (0..bytes_per_sample).rev() {
                 // ii is 1, 0, 3, 2, 5, 4 for the example above
                 // This is where the segment order correction occurs
                 let ii = sample_number * bytes_per_sample + byte_offset;
-                let segment = &fragment[offsets[ii] as usize..offsets[ii + 1] as usize];
+                ensure_whatever!(ii + 1 < offsets.len(), "Invalid RLE segment offsets");
+                let segment_range = offsets[ii] as usize..offsets[ii + 1] as usize;
+                let segment = fragment
+                    .get(segment_range)
+                    .whatever_context("Invalid RLE segment range")?;
                 let buff = io::Cursor::new(segment);
                 let (_, decoder) = PackBitsReader::new(buff, segment.len())
                     .map_err(|e| Box::new(e) as Box<_>)
                     .whatever_context("Failed to read RLE segments")?;
-                let mut decoded_segment = Vec::with_capacity(rows as usize * cols as usize);
+                let mut decoded_segment =
+                    guarded_alloc(rows as usize * cols as usize, fragment.len())?;
                 decoder
                     .take(rows as u64 * cols as u64)
                     .read_to_end(&mut decoded_segment)
@@ -284,6 +298,26 @@ impl Read for PackBitsReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.buffer.read(buf)
     }
+}
+
+const COMPRESSION_RATIO_THRESHOLD: u32 = 32;
+
+/// Perform an allocation, safeguarded from extreme cases.
+fn guarded_alloc(capacity: usize, fragment_size: usize) -> DecodeResult<Vec<u8>> {
+    crate::alloc::guarded_alloc(capacity, fragment_size, COMPRESSION_RATIO_THRESHOLD)
+        .ok()
+        .whatever_context("Could not allocate RLE segment")
+}
+
+/// Perform a resize of a vector (with zeros), safeguarded from extreme cases.
+fn guarded_resize(
+    out: &mut Vec<u8>,
+    additional_capacity: usize,
+    fragment_size: usize,
+) -> DecodeResult<()> {
+    crate::alloc::guarded_resize(out, additional_capacity, fragment_size, COMPRESSION_RATIO_THRESHOLD)
+        .ok()
+        .whatever_context("Could not allocate frame")
 }
 
 #[cfg(test)]

--- a/transfer-syntax-registry/src/alloc.rs
+++ b/transfer-syntax-registry/src/alloc.rs
@@ -1,4 +1,11 @@
 //! Private module to assist in making safe memory allocations
+#![cfg(any(
+    feature = "rle",
+    feature = "jpeg",
+    feature = "jpegxl",
+    feature = "openjp2",
+    feature = "openjpeg-sys"
+))]
 
 const DANGEROUS_CAPACITY: usize = 16_777_216;
 
@@ -32,7 +39,6 @@ pub fn guarded_alloc(
 }
 
 /// Reserve extra capacity for a vector (with zeros), safeguarded from extreme cases.
-#[allow(dead_code)]
 pub fn guarded_reserve(
     out: &mut Vec<u8>,
     additional_capacity: usize,

--- a/transfer-syntax-registry/src/alloc.rs
+++ b/transfer-syntax-registry/src/alloc.rs
@@ -14,6 +14,7 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Perform an allocation, safeguarded from extreme cases.
+#[allow(dead_code)]
 pub fn guarded_alloc(
     capacity: usize,
     encapsulated_size: usize,
@@ -31,6 +32,7 @@ pub fn guarded_alloc(
 }
 
 /// Reserve extra capacity for a vector (with zeros), safeguarded from extreme cases.
+#[allow(dead_code)]
 pub fn guarded_reserve(
     out: &mut Vec<u8>,
     additional_capacity: usize,
@@ -50,6 +52,7 @@ pub fn guarded_reserve(
 }
 
 /// Perform a resize of a vector (with zeros), safeguarded from extreme cases.
+#[allow(dead_code)]
 pub fn guarded_resize(
     out: &mut Vec<u8>,
     additional_capacity: usize,

--- a/transfer-syntax-registry/src/alloc.rs
+++ b/transfer-syntax-registry/src/alloc.rs
@@ -1,0 +1,62 @@
+//! Private module to assist in making safe memory allocations
+
+const DANGEROUS_CAPACITY: usize = 16_777_216;
+
+/// Simplified allocation error
+#[derive(Debug)]
+pub enum Error {
+    /// Could not allocate via `try_reserve`
+    TryReserve,
+    /// Allocation would have been dangerous
+    Dangerous,
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Perform an allocation, safeguarded from extreme cases.
+pub fn guarded_alloc(
+    capacity: usize,
+    encapsulated_size: usize,
+    ratio_threshold: u32,
+) -> Result<Vec<u8>> {
+    // do not expect an allocation N times larger than the given encapsulated data size
+    if capacity >= DANGEROUS_CAPACITY && encapsulated_size < capacity / ratio_threshold as usize {
+        return Err(Error::Dangerous);
+    }
+
+    let mut out = Vec::new();
+    out.try_reserve_exact(capacity)
+        .map_err(|_| Error::TryReserve)?;
+    Ok(out)
+}
+
+/// Reserve extra capacity for a vector (with zeros), safeguarded from extreme cases.
+pub fn guarded_reserve(
+    out: &mut Vec<u8>,
+    additional_capacity: usize,
+    encapsulated_size: usize,
+    ratio_threshold: u32,
+) -> Result<()> {
+    // do not expect an allocation N times larger than the given encapsulated data size
+    if additional_capacity >= DANGEROUS_CAPACITY
+        && encapsulated_size < additional_capacity / ratio_threshold as usize
+    {
+        return Err(Error::Dangerous);
+    }
+
+    out.try_reserve_exact(additional_capacity)
+        .map_err(|_| Error::TryReserve)?;
+    Ok(())
+}
+
+/// Perform a resize of a vector (with zeros), safeguarded from extreme cases.
+pub fn guarded_resize(
+    out: &mut Vec<u8>,
+    additional_capacity: usize,
+    encapsulated_size: usize,
+    ratio_threshold: u32,
+) -> Result<()> {
+    guarded_reserve(out, additional_capacity, encapsulated_size, ratio_threshold)?;
+    out.resize(out.len() + additional_capacity, 0);
+    Ok(())
+}

--- a/transfer-syntax-registry/src/lib.rs
+++ b/transfer-syntax-registry/src/lib.rs
@@ -116,6 +116,8 @@ use std::fmt;
 pub use dicom_encoding::{TransferSyntax, TransferSyntaxIndex};
 pub mod entries;
 
+pub(crate) mod alloc;
+
 mod adapters;
 #[cfg(feature = "deflate")]
 mod deflate;

--- a/transfer-syntax-registry/tests/rle.rs
+++ b/transfer-syntax-registry/tests/rle.rs
@@ -163,3 +163,36 @@ fn read_rle_2() {
 
     check_u16_rgb_pixel(&dest, 100, 10, 95, [0xFFFF, 0xFFFF, 0xFFFF]);
 }
+
+#[test]
+fn read_rle_dangerous_image() {
+    let mut buf = vec![0; 66];
+    buf[0] = 1;
+
+    let obj = TestDataObject {
+        // RLE lossless
+        ts_uid: "1.2.840.10008.1.2.5".to_string(),
+        rows: 51220,
+        columns: 58804,
+        bits_allocated: 8,
+        bits_stored: 8,
+        samples_per_pixel: 1,
+        photometric_interpretation: "MONOCHROME2",
+        number_of_frames: 1,
+        flat_pixel_data: None,
+        pixel_data_sequence: Some(PixelFragmentSequence::new(vec![0], vec![buf])),
+    };
+
+    // instantiate RLE lossless adapter
+
+    let Codec::EncapsulatedPixelData(Some(adapter), _) = RLE_LOSSLESS.codec() else {
+        panic!("RLE lossless pixel data reader not found")
+    };
+
+    let mut dest = vec![];
+
+    // decode the whole image (1 frame)
+
+    let out = adapter.decode(&obj, &mut dest);
+    assert!(matches!(out, Err(_)));
+}


### PR DESCRIPTION
I attempted a systematic inspection of places where input data could influence large data allocation and ensured that it uses fallible allocation methods. I also implemented more checks for the data length, stopping the program when a value in the file meta information group claims to be too large to be compliant, and in some cases using heuristics to determine whether the uncompressed byte length is unreasonable against the compressed counterpart.

### Summary

- [ts-registry] Safeguard RLE segment reading and allocating
- [ts-registry] Adjust more codec adapters with guarded allocations: jpeg, jpeg2k, jpegxl
- [parser] Harden dataset reader from failed allocations
- [parser] Harden stateful decoder from failed allocations
- [object] Protect meta info reader from excessively large element lengths
- [encoding] Add `DecodeError::Allocate` error variant, use it for allocation-related errors
