### PR TITLE
Support overlays

### DIFF
--- a/pixeldata/src/attribute.rs
+++ b/pixeldata/src/attribute.rs
@@ -33,6 +33,15 @@ pub enum AttributeName {
     LutDescriptor,
     LutData,
     LutExplanation,
+    OverlayRows,
+    OverlayColumns,
+    OverlayType,
+    OverlayOrigin,
+    OverlayBitsAllocated,
+    OverlayBitPosition,
+    OverlayData,
+    NumberOfFramesInOverlay,
+    ImageFrameOrigin,
 }
 
 impl std::fmt::Display for AttributeName {
@@ -767,6 +776,196 @@ pub fn voi_lut_sequence<D: DataDictionary + Clone>(
                 },
             )
         })
+}
+
+/// Get the Overlay Rows (60xx,0010) of the overlay plane in the given group
+pub fn overlay_rows<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Result<u16> {
+    retrieve_required_u16(obj, Tag(group, 0x0010), AttributeName::OverlayRows)
+}
+
+/// Get the Overlay Columns (60xx,0011) of the overlay plane in the given group
+pub fn overlay_columns<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Result<u16> {
+    retrieve_required_u16(obj, Tag(group, 0x0011), AttributeName::OverlayColumns)
+}
+
+/// Get the Overlay Type (60xx,0040) of the overlay plane in the given group
+pub fn overlay_type<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Result<String> {
+    let name = AttributeName::OverlayType;
+    Ok(obj
+        .element_opt(Tag(group, 0x0040))
+        .context(RetrieveSnafu { name })?
+        .context(MissingRequiredSnafu { name })?
+        .string()
+        .context(CastValueSnafu { name })?
+        .trim_matches(|c: char| c.is_whitespace() || c == '\0')
+        .to_string())
+}
+
+/// Get the Overlay Origin (60xx,0050) of the overlay plane in the given group,
+/// as the 1-based `[row, column]` of the image pixel
+/// under the top left overlay pixel
+/// (values may be zero or negative)
+pub fn overlay_origin<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Result<[i32; 2]> {
+    let name = AttributeName::OverlayOrigin;
+    let origin = obj
+        .element_opt(Tag(group, 0x0050))
+        .context(RetrieveSnafu { name })?
+        .context(MissingRequiredSnafu { name })?
+        .to_multi_int::<i32>()
+        .context(ConvertValueSnafu { name })?;
+    ensure!(
+        origin.len() >= 2,
+        InvalidValueSnafu {
+            name,
+            value: format!("value with multiplicity {}", origin.len()),
+        }
+    );
+    Ok([origin[0], origin[1]])
+}
+
+/// Get the Overlay Bits Allocated (60xx,0100) of the overlay plane
+/// in the given group
+pub fn overlay_bits_allocated<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Result<u16> {
+    retrieve_required_u16(obj, Tag(group, 0x0100), AttributeName::OverlayBitsAllocated)
+}
+
+/// Get the Overlay Bit Position (60xx,0102) of the overlay plane
+/// in the given group
+pub fn overlay_bit_position<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Result<u16> {
+    retrieve_required_u16(obj, Tag(group, 0x0102), AttributeName::OverlayBitPosition)
+}
+
+/// Get the Number of Frames in Overlay (60xx,0015) of the overlay plane
+/// in the given group,
+/// returning 1 if it is not present
+pub fn number_of_frames_in_overlay<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Result<u32> {
+    let name = AttributeName::NumberOfFramesInOverlay;
+    let elem = if let Some(elem) = obj
+        .element_opt(Tag(group, 0x0015))
+        .context(RetrieveSnafu { name })?
+    {
+        elem
+    } else {
+        return Ok(1);
+    };
+
+    if elem.is_empty() {
+        return Ok(1);
+    }
+
+    let integer = elem.to_int::<i32>().context(ConvertValueSnafu { name })?;
+
+    ensure!(
+        integer > 0,
+        InvalidValueSnafu {
+            name,
+            value: integer.to_string(),
+        }
+    );
+
+    Ok(integer as u32)
+}
+
+/// Get the Image Frame Origin (60xx,0051) of the overlay plane
+/// in the given group,
+/// as the 1-based number of the first image frame the overlay applies to,
+/// returning 1 if it is not present
+pub fn image_frame_origin<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Result<u32> {
+    let name = AttributeName::ImageFrameOrigin;
+    let elem = if let Some(elem) = obj
+        .element_opt(Tag(group, 0x0051))
+        .context(RetrieveSnafu { name })?
+    {
+        elem
+    } else {
+        return Ok(1);
+    };
+
+    if elem.is_empty() {
+        return Ok(1);
+    }
+
+    let integer = elem.to_int::<i32>().context(ConvertValueSnafu { name })?;
+
+    ensure!(
+        integer > 0,
+        InvalidValueSnafu {
+            name,
+            value: integer.to_string(),
+        }
+    );
+
+    Ok(integer as u32)
+}
+
+/// Get the Overlay Label (60xx,1500) of the overlay plane in the given group,
+/// if it is present
+pub fn overlay_label<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Option<String> {
+    obj.get(Tag(group, 0x1500))
+        .and_then(|e| e.string().ok())
+        .map(|s| {
+            s.trim_matches(|c: char| c.is_whitespace() || c == '\0')
+                .to_string()
+        })
+}
+
+/// Get the Overlay Description (60xx,0022) of the overlay plane
+/// in the given group,
+/// if it is present
+pub fn overlay_description<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Option<String> {
+    obj.get(Tag(group, 0x0022))
+        .and_then(|e| e.string().ok())
+        .map(|s| {
+            s.trim_matches(|c: char| c.is_whitespace() || c == '\0')
+                .to_string()
+        })
+}
+
+/// Get the Overlay Data (60xx,3000) of the overlay plane in the given group
+/// as a byte stream in little endian order,
+/// returning `None` if the element is not present
+pub fn overlay_data<D: DataDictionary + Clone>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Result<Option<std::borrow::Cow<'_, [u8]>>> {
+    let name = AttributeName::OverlayData;
+    match obj
+        .element_opt(Tag(group, 0x3000))
+        .context(RetrieveSnafu { name })?
+    {
+        Some(elem) => Ok(Some(elem.to_bytes().context(ConvertValueSnafu { name })?)),
+        None => Ok(None),
+    }
 }
 
 #[cfg(test)]

--- a/pixeldata/src/gdcm.rs
+++ b/pixeldata/src/gdcm.rs
@@ -360,6 +360,14 @@ where
             enforce_frame_fg_vm_match: false,
         })
     }
+
+    fn decode_overlays(&self) -> Result<Vec<crate::OverlayPlane>> {
+        crate::overlay::decode_overlays(self)
+    }
+
+    fn decode_overlay(&self, index: u8) -> Result<Option<crate::OverlayPlane>> {
+        crate::overlay::decode_overlay_group(self, 0x6000 + 2 * index as u16)
+    }
 }
 
 fn interleave_planes(cols: usize, rows: usize, bits_allocated: usize, data: Vec<u8>) -> Vec<u8> {

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -170,7 +170,7 @@ pub use attribute::{
     AttributeName, PhotometricInterpretation, PixelRepresentation, PlanarConfiguration,
 };
 pub use lut::{CreateLutError, Lut};
-pub use overlay::{OverlayPlane, OverlayType};
+pub use overlay::{OverlayError, OverlayPlane, OverlayType};
 pub use transcode::{Error as TranscodeError, Result as TranscodeResult, Transcode};
 pub use transform::{Rescale, VoiLutFunction, WindowLevel, WindowLevelTransform};
 
@@ -285,20 +285,10 @@ enum InnerError {
         nr_frames: u32,
         backtrace: Backtrace,
     },
-    #[snafu(display("Unsupported overlay plane configuration in group {group:#06X}: {reason}"))]
-    UnsupportedOverlay {
-        group: u16,
-        reason: String,
-        backtrace: Backtrace,
-    },
-    #[snafu(display(
-        "Overlay data of group {group:#06X} is too short: got {got} bytes, need at least {needed}"
-    ))]
-    OverlayDataLength {
-        group: u16,
-        got: usize,
-        needed: usize,
-        backtrace: Backtrace,
+    #[snafu(transparent)]
+    Overlay {
+        #[snafu(backtrace)]
+        source: overlay::OverlayError,
     },
 }
 
@@ -307,6 +297,12 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 impl From<attribute::GetAttributeError> for crate::Error {
     fn from(source: attribute::GetAttributeError) -> Self {
         Error(crate::InnerError::GetAttribute { source })
+    }
+}
+
+impl From<overlay::OverlayError> for crate::Error {
+    fn from(source: overlay::OverlayError) -> Self {
+        Error(crate::InnerError::Overlay { source })
     }
 }
 

--- a/pixeldata/src/lib.rs
+++ b/pixeldata/src/lib.rs
@@ -159,6 +159,7 @@ pub use ndarray;
 
 mod attribute;
 mod lut;
+mod overlay;
 mod transcode;
 
 pub mod encapsulation;
@@ -169,6 +170,7 @@ pub use attribute::{
     AttributeName, PhotometricInterpretation, PixelRepresentation, PlanarConfiguration,
 };
 pub use lut::{CreateLutError, Lut};
+pub use overlay::{OverlayPlane, OverlayType};
 pub use transcode::{Error as TranscodeError, Result as TranscodeResult, Transcode};
 pub use transform::{Rescale, VoiLutFunction, WindowLevel, WindowLevelTransform};
 
@@ -281,6 +283,21 @@ enum InnerError {
     LengthMismatchVoiLut {
         vm: u32,
         nr_frames: u32,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Unsupported overlay plane configuration in group {group:#06X}: {reason}"))]
+    UnsupportedOverlay {
+        group: u16,
+        reason: String,
+        backtrace: Backtrace,
+    },
+    #[snafu(display(
+        "Overlay data of group {group:#06X} is too short: got {got} bytes, need at least {needed}"
+    ))]
+    OverlayDataLength {
+        group: u16,
+        got: usize,
+        needed: usize,
         backtrace: Backtrace,
     },
 }
@@ -2120,6 +2137,35 @@ pub trait PixelDecoder {
 
         Ok(px)
     }
+
+    /// Decode all overlay planes in this object,
+    /// scanning the repeating groups `6000` to `601E`
+    /// (see [PS3.3 C.9.2][1] of the DICOM standard).
+    ///
+    /// Overlay data is recorded outside the pixel data
+    /// and is always in native form,
+    /// so no pixel data codec is involved.
+    /// Legacy overlay planes (retired in DICOM 2004)
+    /// which are embedded in unused bits of the pixel data samples
+    /// are also decoded,
+    /// as long as the pixel data is not in an encapsulated form.
+    ///
+    /// The default implementation yields no overlay planes.
+    ///
+    /// [1]: https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.9.2.html
+    fn decode_overlays(&self) -> Result<Vec<OverlayPlane>> {
+        Ok(Vec::new())
+    }
+
+    /// Decode the overlay plane with the given index
+    /// (0 to 15, for the repeating groups `6000` to `601E`),
+    /// returning `Ok(None)` if the plane is not present.
+    ///
+    /// The default implementation yields no overlay plane.
+    fn decode_overlay(&self, index: u8) -> Result<Option<OverlayPlane>> {
+        let _ = index;
+        Ok(None)
+    }
 }
 
 /// Aggregator of key properties for imaging data,
@@ -2523,6 +2569,14 @@ where
             voi_lut_sequence,
             enforce_frame_fg_vm_match: false,
         })
+    }
+
+    fn decode_overlays(&self) -> Result<Vec<OverlayPlane>> {
+        overlay::decode_overlays(self)
+    }
+
+    fn decode_overlay(&self, index: u8) -> Result<Option<OverlayPlane>> {
+        overlay::decode_overlay_group(self, 0x6000 + 2 * index as u16)
     }
 }
 

--- a/pixeldata/src/overlay.rs
+++ b/pixeldata/src/overlay.rs
@@ -1,0 +1,627 @@
+//! Support for DICOM overlay planes.
+//!
+//! Overlay planes are 1-bit deep bitmaps of graphics or regions of interest,
+//! stored in the repeating groups `6000` to `601E`
+//! (see [PS3.3 C.9.2][1] and [PS3.3 C.9.3][2] of the DICOM standard).
+//! Since overlay data is recorded outside the pixel data,
+//! it is always in native form and no pixel data codec is involved.
+//!
+//! Legacy overlay planes (retired in DICOM 2004)
+//! which are embedded in unused bits of the pixel data samples
+//! are also supported,
+//! as long as the pixel data is not in an encapsulated form.
+//!
+//! [1]: https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.9.2.html
+//! [2]: https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.9.3.html
+
+use dicom_core::DataDictionary;
+use dicom_object::{FileDicomObject, InMemDicomObject};
+
+use crate::{
+    FrameOutOfRangeSnafu, OverlayDataLengthSnafu, Result, UnsupportedOverlaySnafu, attribute,
+};
+
+/// The maximum number of overlay planes in a DICOM object,
+/// as per the repeating groups `6000` to `601E`.
+pub(crate) const MAX_OVERLAY_PLANES: u16 = 16;
+
+/// A decoded representation of the DICOM _Overlay Type_ attribute (60xx,0040).
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+pub enum OverlayType {
+    /// `G`: the overlay plane contains graphics
+    Graphics,
+    /// `R`: the overlay plane is a region of interest
+    Roi,
+}
+
+/// A decoded DICOM overlay plane,
+/// with its bitmap unpacked to one byte per overlay pixel
+/// (either 0 or 1).
+#[derive(Debug, Clone, PartialEq)]
+pub struct OverlayPlane {
+    group: u16,
+    rows: u16,
+    columns: u16,
+    overlay_type: OverlayType,
+    origin: [i32; 2],
+    frames: u32,
+    image_frame_origin: u32,
+    label: Option<String>,
+    description: Option<String>,
+    data: Vec<u8>,
+}
+
+impl OverlayPlane {
+    /// Get the group number of this overlay plane
+    /// (an even number between `0x6000` and `0x601E`)
+    pub fn group(&self) -> u16 {
+        self.group
+    }
+
+    /// Get the number of rows of the overlay bitmap
+    pub fn rows(&self) -> u16 {
+        self.rows
+    }
+
+    /// Get the number of columns of the overlay bitmap
+    pub fn columns(&self) -> u16 {
+        self.columns
+    }
+
+    /// Get the overlay type (graphics or region of interest)
+    pub fn overlay_type(&self) -> OverlayType {
+        self.overlay_type
+    }
+
+    /// Get the overlay origin,
+    /// the 1-based `[row, column]` of the image pixel
+    /// under the top left pixel of the overlay bitmap.
+    /// `[1, 1]` means that the overlay is aligned with the image,
+    /// and values may be zero or negative.
+    pub fn origin(&self) -> [i32; 2] {
+        self.origin
+    }
+
+    /// Get the number of frames in the overlay (at least 1)
+    pub fn number_of_frames(&self) -> u32 {
+        self.frames
+    }
+
+    /// Get the 1-based number of the first image frame
+    /// to which this overlay applies
+    pub fn image_frame_origin(&self) -> u32 {
+        self.image_frame_origin
+    }
+
+    /// Get the overlay label, if present
+    pub fn label(&self) -> Option<&str> {
+        self.label.as_deref()
+    }
+
+    /// Get the overlay description, if present
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    /// Get the full unpacked overlay bitmap,
+    /// one byte per overlay pixel (either 0 or 1),
+    /// in row-major order,
+    /// with all overlay frames in sequence
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Get the unpacked bitmap of a single overlay frame
+    /// (0-based within the overlay),
+    /// one byte per overlay pixel (either 0 or 1),
+    /// in row-major order
+    pub fn frame_data(&self, frame: u32) -> Result<&[u8]> {
+        if frame >= self.frames {
+            return FrameOutOfRangeSnafu {
+                frame_number: frame,
+            }
+            .fail()
+            .map_err(Into::into);
+        }
+        let frame_size = self.rows as usize * self.columns as usize;
+        let offset = frame_size * frame as usize;
+        Ok(&self.data[offset..offset + frame_size])
+    }
+
+    /// Get the 0-based overlay frame which applies to
+    /// the given 0-based image frame,
+    /// or `None` if the overlay does not apply to that image frame.
+    pub fn frame_for_image_frame(&self, image_frame: u32) -> Option<u32> {
+        let rel = image_frame as i64 - (self.image_frame_origin as i64 - 1);
+        (rel >= 0 && rel < self.frames as i64).then_some(rel as u32)
+    }
+
+    /// Get whether the overlay bit at the given position is set,
+    /// where `frame` is the 0-based overlay frame
+    /// and `row` and `col` are 0-based coordinates in the overlay bitmap.
+    ///
+    /// Returns `false` if the position is out of bounds.
+    pub fn is_set(&self, frame: u32, row: u32, col: u32) -> bool {
+        if frame >= self.frames || row >= self.rows as u32 || col >= self.columns as u32 {
+            return false;
+        }
+        let index = (frame as usize * self.rows as usize + row as usize) * self.columns as usize
+            + col as usize;
+        self.data[index] != 0
+    }
+}
+
+/// Unpack a 1-bit packed overlay bitmap
+/// into one byte (0 or 1) per pixel.
+///
+/// Overlay data is packed in row-major order,
+/// least significant bit first within each byte,
+/// with all frames in sequence without padding in between.
+fn unpack_overlay_bits(packed: &[u8], num_pixels: usize) -> Vec<u8> {
+    (0..num_pixels)
+        .map(|i| (packed[i >> 3] >> (i & 0x7)) & 1)
+        .collect()
+}
+
+/// Decode all overlay planes present in the object,
+/// scanning the repeating groups `6000` to `601E`.
+pub(crate) fn decode_overlays<D>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+) -> Result<Vec<OverlayPlane>>
+where
+    D: DataDictionary + Clone,
+{
+    (0..MAX_OVERLAY_PLANES)
+        .filter_map(|i| decode_overlay_group(obj, 0x6000 + 2 * i).transpose())
+        .collect()
+}
+
+/// Decode the overlay plane in the given repeating group
+/// (an even number between `0x6000` and `0x601E`),
+/// returning `Ok(None)` if the plane is not present.
+pub(crate) fn decode_overlay_group<D>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+) -> Result<Option<OverlayPlane>>
+where
+    D: DataDictionary + Clone,
+{
+    if !(0x6000..=0x601E).contains(&group) || group % 2 != 0 {
+        return Ok(None);
+    }
+
+    let rows = match attribute::overlay_rows(obj, group) {
+        Ok(rows) => rows,
+        // the group holds no overlay plane if Overlay Data is also absent
+        Err(e) => {
+            return if attribute::overlay_data(obj, group)?.is_none() {
+                Ok(None)
+            } else {
+                Err(e.into())
+            };
+        }
+    };
+    let columns = attribute::overlay_columns(obj, group)?;
+    let overlay_type = match attribute::overlay_type(obj, group)?.as_str() {
+        "G" => OverlayType::Graphics,
+        "R" => OverlayType::Roi,
+        other => {
+            return UnsupportedOverlaySnafu {
+                group,
+                reason: format!("unknown Overlay Type `{other}`"),
+            }
+            .fail()
+            .map_err(Into::into);
+        }
+    };
+    let origin = attribute::overlay_origin(obj, group)?;
+    let frames = attribute::number_of_frames_in_overlay(obj, group)?;
+    let image_frame_origin = attribute::image_frame_origin(obj, group)?;
+    let num_pixels = frames as usize * rows as usize * columns as usize;
+
+    let data = match attribute::overlay_data(obj, group)? {
+        Some(packed) => {
+            // standard overlay plane recorded in Overlay Data (60xx,3000)
+            let bits_allocated = attribute::overlay_bits_allocated(obj, group).unwrap_or(1);
+            if bits_allocated != 1 {
+                return UnsupportedOverlaySnafu {
+                    group,
+                    reason: format!("Overlay Bits Allocated is {bits_allocated}, expected 1"),
+                }
+                .fail()
+                .map_err(Into::into);
+            }
+            let bit_position = attribute::overlay_bit_position(obj, group).unwrap_or(0);
+            if bit_position != 0 {
+                return UnsupportedOverlaySnafu {
+                    group,
+                    reason: format!("Overlay Bit Position is {bit_position}, expected 0"),
+                }
+                .fail()
+                .map_err(Into::into);
+            }
+
+            let needed = num_pixels.div_ceil(8);
+            if packed.len() < needed {
+                return OverlayDataLengthSnafu {
+                    group,
+                    got: packed.len(),
+                    needed,
+                }
+                .fail()
+                .map_err(Into::into);
+            }
+            unpack_overlay_bits(&packed, num_pixels)
+        }
+        None => {
+            // no Overlay Data: a legacy overlay plane (retired in DICOM 2004)
+            // embedded in unused bits of the pixel data samples
+            let frame_pixels = rows as usize * columns as usize;
+            extract_embedded_overlay_bits(obj, group, num_pixels, frame_pixels, image_frame_origin)?
+        }
+    };
+
+    Ok(Some(OverlayPlane {
+        group,
+        rows,
+        columns,
+        overlay_type,
+        origin,
+        frames,
+        image_frame_origin,
+        label: attribute::overlay_label(obj, group),
+        description: attribute::overlay_description(obj, group),
+        data,
+    }))
+}
+
+/// Extract a legacy overlay plane which is embedded
+/// in otherwise unused bits of the pixel data samples,
+/// at the bit given by Overlay Bit Position (60xx,0102).
+fn extract_embedded_overlay_bits<D>(
+    obj: &FileDicomObject<InMemDicomObject<D>>,
+    group: u16,
+    num_pixels: usize,
+    frame_pixels: usize,
+    image_frame_origin: u32,
+) -> Result<Vec<u8>>
+where
+    D: DataDictionary + Clone,
+{
+    let bits_allocated = attribute::bits_allocated(obj)?;
+    if bits_allocated != 8 && bits_allocated != 16 {
+        return UnsupportedOverlaySnafu {
+            group,
+            reason: format!(
+                "embedded overlay in pixel data with Bits Allocated {bits_allocated} is not supported"
+            ),
+        }
+        .fail()
+        .map_err(Into::into);
+    }
+    let samples_per_pixel = attribute::samples_per_pixel(obj).unwrap_or(1);
+    if samples_per_pixel != 1 {
+        return UnsupportedOverlaySnafu {
+            group,
+            reason: format!(
+                "embedded overlay in pixel data with Samples per Pixel {samples_per_pixel} is not supported"
+            ),
+        }
+        .fail()
+        .map_err(Into::into);
+    }
+    let bit_position = attribute::overlay_bit_position(obj, group)?;
+    if bit_position >= bits_allocated {
+        return UnsupportedOverlaySnafu {
+            group,
+            reason: format!(
+                "Overlay Bit Position {bit_position} is out of range of Bits Allocated {bits_allocated}"
+            ),
+        }
+        .fail()
+        .map_err(Into::into);
+    }
+
+    let pixel_data = attribute::pixel_data(obj)?;
+    let samples = match pixel_data.value() {
+        dicom_core::DicomValue::Primitive(p) => p.to_bytes(),
+        _ => {
+            return UnsupportedOverlaySnafu {
+                group,
+                reason: "embedded overlay in encapsulated pixel data is not supported".to_string(),
+            }
+            .fail()
+            .map_err(Into::into);
+        }
+    };
+
+    // the overlay frames are embedded in the image frames
+    // starting at the image frame origin
+    let bytes_per_sample = (bits_allocated / 8) as usize;
+    let offset = (image_frame_origin as usize - 1) * frame_pixels * bytes_per_sample;
+    let needed = offset + num_pixels * bytes_per_sample;
+    if samples.len() < needed {
+        return OverlayDataLengthSnafu {
+            group,
+            got: samples.len(),
+            needed,
+        }
+        .fail()
+        .map_err(Into::into);
+    }
+
+    // pixel data sample values are in little endian byte order
+    Ok(samples[offset..needed]
+        .chunks_exact(bytes_per_sample)
+        .map(|sample| {
+            let value = if bytes_per_sample == 2 {
+                u16::from_le_bytes([sample[0], sample[1]])
+            } else {
+                sample[0] as u16
+            };
+            ((value >> bit_position) & 1) as u8
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PixelDecoder;
+    use dicom_core::{DataElement, PrimitiveValue, Tag, VR, dicom_value};
+    use dicom_dictionary_std::uids;
+    use dicom_object::{DefaultDicomObject, FileDicomObject, FileMetaTableBuilder};
+
+    fn dummy_dicom() -> DefaultDicomObject {
+        FileDicomObject::new_empty_with_meta(
+            FileMetaTableBuilder::new()
+                .transfer_syntax(uids::EXPLICIT_VR_LITTLE_ENDIAN)
+                .media_storage_sop_class_uid(uids::SECONDARY_CAPTURE_IMAGE_STORAGE)
+                .media_storage_sop_instance_uid("2.25.221545913343461877066277885826230616209")
+                .build()
+                .unwrap(),
+        )
+    }
+
+    fn put_overlay_plane(obj: &mut DefaultDicomObject, group: u16, rows: u16, columns: u16) {
+        obj.put_element(DataElement::new(
+            Tag(group, 0x0010),
+            VR::US,
+            dicom_value!(U16, rows),
+        ));
+        obj.put_element(DataElement::new(
+            Tag(group, 0x0011),
+            VR::US,
+            dicom_value!(U16, columns),
+        ));
+        obj.put_element(DataElement::new(
+            Tag(group, 0x0040),
+            VR::CS,
+            PrimitiveValue::from("R"),
+        ));
+        obj.put_element(DataElement::new(
+            Tag(group, 0x0050),
+            VR::SS,
+            dicom_value!(I16, [1, 1]),
+        ));
+        obj.put_element(DataElement::new(
+            Tag(group, 0x0100),
+            VR::US,
+            dicom_value!(U16, 1),
+        ));
+        obj.put_element(DataElement::new(
+            Tag(group, 0x0102),
+            VR::US,
+            dicom_value!(U16, 0),
+        ));
+        let num_bytes = (rows as usize * columns as usize).div_ceil(8).div_ceil(2) * 2;
+        obj.put_element(DataElement::new(
+            Tag(group, 0x3000),
+            VR::OB,
+            PrimitiveValue::from(vec![0b0000_0011u8; num_bytes]),
+        ));
+    }
+
+    #[test]
+    fn unpack_bits_is_lsb_first() {
+        let unpacked = unpack_overlay_bits(&[0b0000_0011, 0b1000_0000], 16);
+        let mut expected = vec![0u8; 16];
+        expected[0] = 1;
+        expected[1] = 1;
+        expected[15] = 1;
+        assert_eq!(unpacked, expected);
+    }
+
+    #[test]
+    fn decode_synthesized_overlay_plane() {
+        let mut obj = dummy_dicom();
+        put_overlay_plane(&mut obj, 0x6000, 4, 8);
+        obj.put_element(DataElement::new(
+            Tag(0x6000, 0x1500),
+            VR::LO,
+            PrimitiveValue::from("the label"),
+        ));
+
+        let overlays = obj.decode_overlays().unwrap();
+        assert_eq!(overlays.len(), 1);
+        let plane = &overlays[0];
+        assert_eq!(plane.group(), 0x6000);
+        assert_eq!(plane.rows(), 4);
+        assert_eq!(plane.columns(), 8);
+        assert_eq!(plane.overlay_type(), OverlayType::Roi);
+        assert_eq!(plane.origin(), [1, 1]);
+        assert_eq!(plane.number_of_frames(), 1);
+        assert_eq!(plane.image_frame_origin(), 1);
+        assert_eq!(plane.label(), Some("the label"));
+        assert_eq!(plane.data().len(), 4 * 8);
+        // each byte of `0b0000_0011` sets the first two bits of every 8 pixels,
+        // so the first two pixels of each row are set (columns = 8)
+        for row in 0..4 {
+            for col in 0..8 {
+                assert_eq!(plane.is_set(0, row, col), col < 2, "at ({row}, {col})");
+            }
+        }
+        assert_eq!(plane.frame_data(0).unwrap(), plane.data());
+        assert!(plane.frame_data(1).is_err());
+    }
+
+    #[test]
+    fn decode_overlay_plane_by_index() {
+        let mut obj = dummy_dicom();
+        put_overlay_plane(&mut obj, 0x6002, 4, 4);
+
+        assert!(obj.decode_overlay(0).unwrap().is_none());
+        let plane = obj.decode_overlay(1).unwrap().unwrap();
+        assert_eq!(plane.group(), 0x6002);
+        // out-of-range index is not an error
+        assert!(obj.decode_overlay(16).unwrap().is_none());
+
+        let overlays = obj.decode_overlays().unwrap();
+        assert_eq!(overlays.len(), 1);
+        assert_eq!(overlays[0].group(), 0x6002);
+    }
+
+    #[test]
+    fn decode_multi_frame_overlay() {
+        let mut obj = dummy_dicom();
+        put_overlay_plane(&mut obj, 0x6000, 2, 8);
+        obj.put_element(DataElement::new(
+            Tag(0x6000, 0x0015),
+            VR::IS,
+            PrimitiveValue::from("2"),
+        ));
+        obj.put_element(DataElement::new(
+            Tag(0x6000, 0x0051),
+            VR::US,
+            dicom_value!(U16, 2),
+        ));
+        // two frames of 2x8 pixels
+        obj.put_element(DataElement::new(
+            Tag(0x6000, 0x3000),
+            VR::OB,
+            PrimitiveValue::from(vec![0b0000_0011u8; 4]),
+        ));
+
+        let plane = obj.decode_overlay(0).unwrap().unwrap();
+        assert_eq!(plane.number_of_frames(), 2);
+        assert_eq!(plane.image_frame_origin(), 2);
+        assert_eq!(plane.data().len(), 2 * 2 * 8);
+        assert_eq!(plane.frame_data(1).unwrap().len(), 2 * 8);
+
+        // the overlay applies to image frames 1 and 2 (0-based)
+        assert_eq!(plane.frame_for_image_frame(0), None);
+        assert_eq!(plane.frame_for_image_frame(1), Some(0));
+        assert_eq!(plane.frame_for_image_frame(2), Some(1));
+        assert_eq!(plane.frame_for_image_frame(3), None);
+    }
+
+    #[test]
+    fn overlay_data_stored_as_words_unpacks_little_endian() {
+        let mut obj = dummy_dicom();
+        put_overlay_plane(&mut obj, 0x6000, 2, 8);
+        // one word covers 16 pixels: bits 0-7 in the low byte come first
+        obj.put_element(DataElement::new(
+            Tag(0x6000, 0x3000),
+            VR::OW,
+            dicom_value!(U16, [0x8001]),
+        ));
+
+        let plane = obj.decode_overlay(0).unwrap().unwrap();
+        assert!(plane.is_set(0, 0, 0));
+        assert!(!plane.is_set(0, 0, 1));
+        assert!(plane.is_set(0, 1, 7));
+    }
+
+    #[test]
+    fn decode_embedded_overlay_plane() {
+        let mut obj = dummy_dicom();
+        // 2x4 image, 16 bits allocated, 12 bits stored
+        obj.put_element(DataElement::new(
+            dicom_dictionary_std::tags::ROWS,
+            VR::US,
+            dicom_value!(U16, 2),
+        ));
+        obj.put_element(DataElement::new(
+            dicom_dictionary_std::tags::COLUMNS,
+            VR::US,
+            dicom_value!(U16, 4),
+        ));
+        obj.put_element(DataElement::new(
+            dicom_dictionary_std::tags::BITS_ALLOCATED,
+            VR::US,
+            dicom_value!(U16, 16),
+        ));
+        obj.put_element(DataElement::new(
+            dicom_dictionary_std::tags::SAMPLES_PER_PIXEL,
+            VR::US,
+            dicom_value!(U16, 1),
+        ));
+        // overlay embedded at bit 15: set on samples 0 and 5 only
+        let mut samples = vec![0x0123u16; 8];
+        samples[0] |= 0x8000;
+        samples[5] |= 0x8000;
+        obj.put_element(DataElement::new(
+            dicom_dictionary_std::tags::PIXEL_DATA,
+            VR::OW,
+            PrimitiveValue::U16(samples.into()),
+        ));
+
+        // overlay plane in group 6000 without Overlay Data
+        put_overlay_plane(&mut obj, 0x6000, 2, 4);
+        obj.remove_element(Tag(0x6000, 0x3000));
+        obj.put_element(DataElement::new(
+            Tag(0x6000, 0x0100),
+            VR::US,
+            dicom_value!(U16, 16),
+        ));
+        obj.put_element(DataElement::new(
+            Tag(0x6000, 0x0102),
+            VR::US,
+            dicom_value!(U16, 15),
+        ));
+
+        let plane = obj.decode_overlay(0).unwrap().unwrap();
+        assert_eq!(plane.rows(), 2);
+        assert_eq!(plane.columns(), 4);
+        let mut expected = vec![0u8; 8];
+        expected[0] = 1;
+        expected[5] = 1;
+        assert_eq!(plane.data(), &expected[..]);
+
+        // out-of-range bit position is an error
+        obj.put_element(DataElement::new(
+            Tag(0x6000, 0x0102),
+            VR::US,
+            dicom_value!(U16, 16),
+        ));
+        assert!(obj.decode_overlay(0).is_err());
+    }
+
+    #[test]
+    fn decode_overlay_error_cases() {
+        // overlay data too short
+        let mut obj = dummy_dicom();
+        put_overlay_plane(&mut obj, 0x6000, 64, 64);
+        obj.put_element(DataElement::new(
+            Tag(0x6000, 0x3000),
+            VR::OB,
+            PrimitiveValue::from(vec![0u8; 2]),
+        ));
+        assert!(obj.decode_overlay(0).is_err());
+
+        // unsupported bits allocated
+        let mut obj = dummy_dicom();
+        put_overlay_plane(&mut obj, 0x6000, 4, 8);
+        obj.put_element(DataElement::new(
+            Tag(0x6000, 0x0100),
+            VR::US,
+            dicom_value!(U16, 16),
+        ));
+        assert!(obj.decode_overlay(0).is_err());
+
+        // no overlay data element at all: not an error, just absent
+        let obj = dummy_dicom();
+        assert!(obj.decode_overlay(0).unwrap().is_none());
+        assert!(obj.decode_overlays().unwrap().is_empty());
+    }
+}

--- a/pixeldata/src/overlay.rs
+++ b/pixeldata/src/overlay.rs
@@ -16,14 +16,94 @@
 
 use dicom_core::DataDictionary;
 use dicom_object::{FileDicomObject, InMemDicomObject};
+use snafu::{Backtrace, Snafu};
 
-use crate::{
-    FrameOutOfRangeSnafu, OverlayDataLengthSnafu, Result, UnsupportedOverlaySnafu, attribute,
-};
+use crate::{FrameOutOfRangeSnafu, Result, attribute};
 
 /// The maximum number of overlay planes in a DICOM object,
 /// as per the repeating groups `6000` to `601E`.
 pub(crate) const MAX_OVERLAY_PLANES: u16 = 16;
+
+/// Error type for decoding an overlay plane.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum OverlayError {
+    /// Unsupported Overlay Bits Allocated (60xx,0100)
+    #[snafu(display(
+        "Unsupported Overlay Bits Allocated {bits_allocated} in group {group:#06X}, expected 1"
+    ))]
+    UnsupportedBitsAllocated {
+        group: u16,
+        bits_allocated: u16,
+        backtrace: Backtrace,
+    },
+
+    /// Unsupported Overlay Bit Position (60xx,0102)
+    #[snafu(display(
+        "Unsupported Overlay Bit Position {bit_position} in group {group:#06X}, expected 0"
+    ))]
+    UnsupportedBitPosition {
+        group: u16,
+        bit_position: u16,
+        backtrace: Backtrace,
+    },
+
+    /// Unknown Overlay Type (60xx,0040)
+    #[snafu(display("Unknown Overlay Type `{value}` in group {group:#06X}"))]
+    UnknownOverlayType {
+        group: u16,
+        value: String,
+        backtrace: Backtrace,
+    },
+
+    /// Overlay Data (60xx,3000) is too short
+    #[snafu(display(
+        "Overlay data of group {group:#06X} is too short: got {got} bytes, need at least {needed}"
+    ))]
+    DataLength {
+        group: u16,
+        got: usize,
+        needed: usize,
+        backtrace: Backtrace,
+    },
+
+    /// Unsupported image Bits Allocated for an overlay embedded in the pixel data
+    #[snafu(display(
+        "Embedded overlay in group {group:#06X}: image Bits Allocated {bits_allocated} is not supported"
+    ))]
+    EmbeddedBitsAllocated {
+        group: u16,
+        bits_allocated: u16,
+        backtrace: Backtrace,
+    },
+
+    /// Unsupported Samples per Pixel for an overlay embedded in the pixel data
+    #[snafu(display(
+        "Embedded overlay in group {group:#06X}: Samples per Pixel {samples_per_pixel} is not supported"
+    ))]
+    EmbeddedSamplesPerPixel {
+        group: u16,
+        samples_per_pixel: u16,
+        backtrace: Backtrace,
+    },
+
+    /// Overlay Bit Position out of range of the image Bits Allocated
+    #[snafu(display(
+        "Embedded overlay in group {group:#06X}: Overlay Bit Position {bit_position} is out of range of Bits Allocated {bits_allocated}"
+    ))]
+    EmbeddedBitPositionOutOfRange {
+        group: u16,
+        bit_position: u16,
+        bits_allocated: u16,
+        backtrace: Backtrace,
+    },
+
+    /// Overlays embedded in encapsulated pixel data are not supported
+    #[snafu(display(
+        "Embedded overlay in group {group:#06X}: encapsulated pixel data is not supported"
+    ))]
+    EmbeddedEncapsulated { group: u16, backtrace: Backtrace },
+}
 
 /// A decoded representation of the DICOM _Overlay Type_ attribute (60xx,0040).
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
@@ -206,9 +286,9 @@ where
         "G" => OverlayType::Graphics,
         "R" => OverlayType::Roi,
         other => {
-            return UnsupportedOverlaySnafu {
+            return UnknownOverlayTypeSnafu {
                 group,
-                reason: format!("unknown Overlay Type `{other}`"),
+                value: other.to_string(),
             }
             .fail()
             .map_err(Into::into);
@@ -224,18 +304,18 @@ where
             // standard overlay plane recorded in Overlay Data (60xx,3000)
             let bits_allocated = attribute::overlay_bits_allocated(obj, group).unwrap_or(1);
             if bits_allocated != 1 {
-                return UnsupportedOverlaySnafu {
+                return UnsupportedBitsAllocatedSnafu {
                     group,
-                    reason: format!("Overlay Bits Allocated is {bits_allocated}, expected 1"),
+                    bits_allocated,
                 }
                 .fail()
                 .map_err(Into::into);
             }
             let bit_position = attribute::overlay_bit_position(obj, group).unwrap_or(0);
             if bit_position != 0 {
-                return UnsupportedOverlaySnafu {
+                return UnsupportedBitPositionSnafu {
                     group,
-                    reason: format!("Overlay Bit Position is {bit_position}, expected 0"),
+                    bit_position,
                 }
                 .fail()
                 .map_err(Into::into);
@@ -243,7 +323,7 @@ where
 
             let needed = num_pixels.div_ceil(8);
             if packed.len() < needed {
-                return OverlayDataLengthSnafu {
+                return DataLengthSnafu {
                     group,
                     got: packed.len(),
                     needed,
@@ -290,33 +370,28 @@ where
 {
     let bits_allocated = attribute::bits_allocated(obj)?;
     if bits_allocated != 8 && bits_allocated != 16 {
-        return UnsupportedOverlaySnafu {
+        return EmbeddedBitsAllocatedSnafu {
             group,
-            reason: format!(
-                "embedded overlay in pixel data with Bits Allocated {bits_allocated} is not supported"
-            ),
+            bits_allocated,
         }
         .fail()
         .map_err(Into::into);
     }
     let samples_per_pixel = attribute::samples_per_pixel(obj).unwrap_or(1);
     if samples_per_pixel != 1 {
-        return UnsupportedOverlaySnafu {
+        return EmbeddedSamplesPerPixelSnafu {
             group,
-            reason: format!(
-                "embedded overlay in pixel data with Samples per Pixel {samples_per_pixel} is not supported"
-            ),
+            samples_per_pixel,
         }
         .fail()
         .map_err(Into::into);
     }
     let bit_position = attribute::overlay_bit_position(obj, group)?;
     if bit_position >= bits_allocated {
-        return UnsupportedOverlaySnafu {
+        return EmbeddedBitPositionOutOfRangeSnafu {
             group,
-            reason: format!(
-                "Overlay Bit Position {bit_position} is out of range of Bits Allocated {bits_allocated}"
-            ),
+            bit_position,
+            bits_allocated,
         }
         .fail()
         .map_err(Into::into);
@@ -326,12 +401,9 @@ where
     let samples = match pixel_data.value() {
         dicom_core::DicomValue::Primitive(p) => p.to_bytes(),
         _ => {
-            return UnsupportedOverlaySnafu {
-                group,
-                reason: "embedded overlay in encapsulated pixel data is not supported".to_string(),
-            }
-            .fail()
-            .map_err(Into::into);
+            return EmbeddedEncapsulatedSnafu { group }
+                .fail()
+                .map_err(Into::into);
         }
     };
 
@@ -341,7 +413,7 @@ where
     let offset = (image_frame_origin as usize - 1) * frame_pixels * bytes_per_sample;
     let needed = offset + num_pixels * bytes_per_sample;
     if samples.len() < needed {
-        return OverlayDataLengthSnafu {
+        return DataLengthSnafu {
             group,
             got: samples.len(),
             needed,

--- a/pixeldata/tests/overlay.rs
+++ b/pixeldata/tests/overlay.rs
@@ -1,0 +1,28 @@
+//! Test module for decoding overlay planes from real DICOM files.
+
+use dicom_object::open_file;
+use dicom_pixeldata::{OverlayType, PixelDecoder};
+
+#[test]
+fn decode_overlays_from_mr_with_overlays() {
+    let test_file = dicom_test_files::path("pydicom/MR-SIEMENS-DICOM-WithOverlays.dcm").unwrap();
+    let obj = open_file(test_file).unwrap();
+
+    let overlays = obj.decode_overlays().unwrap();
+    assert_eq!(overlays.len(), 1);
+
+    let plane = &overlays[0];
+    assert_eq!(plane.group(), 0x6000);
+    assert_eq!(plane.rows(), 484);
+    assert_eq!(plane.columns(), 484);
+    assert_eq!(plane.overlay_type(), OverlayType::Graphics);
+    assert_eq!(plane.number_of_frames(), 1);
+    assert_eq!(plane.data().len(), 484 * 484);
+    // the overlay is not empty
+    assert!(plane.data().iter().any(|&bit| bit != 0));
+
+    // same plane through the single plane decoding method
+    let plane_2 = obj.decode_overlay(0).unwrap().unwrap();
+    assert_eq!(&plane_2, plane);
+    assert!(obj.decode_overlay(1).unwrap().is_none());
+}

--- a/toimage/README.md
+++ b/toimage/README.md
@@ -25,6 +25,9 @@ Options:
       --8bit                  Force output bit depth to 8 bits per sample
       --16bit                 Force output bit depth to 16 bits per sample
       --unwrap                Output the raw pixel data instead of decoding it
+      --overlays              Render the overlay planes (groups 6000-601E) on top of the image (the output becomes RGB when an overlay applies to the frame)
+      --overlay-color <OVERLAY_COLOR>  Color for overlay rendering as an RGB hex code (e.g. "ff0000" or "#00ff00"). May be given multiple times to color each overlay plane differently, assigned in ascending overlay group order and cycled if there are more planes than colors [default: ffffff]
+      --overlay-file <OVERLAY_FILE>    Path to an additional DICOM file to take overlay planes from (e.g. a presentation state object referencing the image). May be given multiple times; planes are appended after those of the image itself
       --fail-first            Stop on the first failed conversion
   -v, --verbose               Print more information about the image and the output file
   -h, --help                  Print help

--- a/toimage/src/main.rs
+++ b/toimage/src/main.rs
@@ -6,7 +6,10 @@ use clap::Parser;
 use dicom_dictionary_std::uids;
 use dicom_encoding::adapters::PixelDataObject;
 use dicom_object::{FileDicomObject, InMemDicomObject, open_file};
-use dicom_pixeldata::{ConvertOptions, PixelDecoder};
+use dicom_pixeldata::{
+    ConvertOptions, OverlayPlane, PixelDecoder,
+    image::{DynamicImage, ImageBuffer, Pixel, Rgb},
+};
 use snafu::{OptionExt, Report, ResultExt, Snafu, Whatever};
 use tracing::{Level, error, warn};
 
@@ -54,7 +57,7 @@ struct App {
 }
 
 /// Options related to image output and conversion steps
-#[derive(Debug, Copy, Clone, Parser)]
+#[derive(Debug, Clone, Parser)]
 struct ImageOptions {
     /// Force output bit depth to 8 bits per sample
     #[arg(long = "8bit", conflicts_with = "force_16bit")]
@@ -74,6 +77,41 @@ struct ImageOptions {
     /// Decode all pixel data frames instead of just the one intended
     #[arg(hide(true), long)]
     decode_all: bool,
+
+    /// Render the overlay planes (groups 6000-601E) on top of the image
+    /// (the output becomes RGB when an overlay applies to the frame)
+    #[arg(long = "overlays", conflicts_with = "unwrap")]
+    overlays: bool,
+
+    /// Color for overlay rendering as an RGB hex code (e.g. "ff0000" or "#00ff00").
+    /// May be given multiple times to color each overlay plane differently,
+    /// assigned in ascending overlay group order and cycled if there are
+    /// more planes than colors
+    #[arg(
+        long = "overlay-color",
+        default_value = "ffffff",
+        value_parser = parse_color,
+        requires = "overlays"
+    )]
+    overlay_color: Vec<[u8; 3]>,
+
+    /// Path to an additional DICOM file to take overlay planes from
+    /// (e.g. a presentation state object referencing the image).
+    /// May be given multiple times;
+    /// planes are appended after those of the image itself
+    #[arg(long = "overlay-file", requires = "overlays")]
+    overlay_file: Vec<PathBuf>,
+}
+
+fn parse_color(s: &str) -> Result<[u8; 3], String> {
+    let s = s.trim_start_matches('#');
+    if s.len() != 6 || !s.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!(
+            "invalid RGB hex color `{s}` (expected 6 hexadecimal digits)"
+        ));
+    }
+    let v = u32::from_str_radix(s, 16).map_err(|e| e.to_string())?;
+    Ok([(v >> 16) as u8, (v >> 8) as u8, v as u8])
 }
 
 #[derive(Debug, Snafu)]
@@ -193,8 +231,15 @@ fn run(args: App) -> Result<(), Error> {
                     image_options.unwrap,
                 );
 
-                convert_single_file(&file.0, false, output, frame_number, image_options, verbose)
-                    .or_else(|e| {
+                convert_single_file(
+                    &file.0,
+                    false,
+                    output,
+                    frame_number,
+                    image_options.clone(),
+                    verbose,
+                )
+                .or_else(|e| {
                     if fail_first {
                         Err(e)
                     } else {
@@ -222,7 +267,7 @@ fn run(args: App) -> Result<(), Error> {
                 output_is_set,
                 output,
                 frame_number,
-                image_options,
+                image_options.clone(),
                 verbose,
             )?;
         }
@@ -255,7 +300,7 @@ fn run(args: App) -> Result<(), Error> {
                 false,
                 output,
                 frame_number,
-                image_options,
+                image_options.clone(),
                 verbose,
             )
             .or_else(|e| {
@@ -316,6 +361,9 @@ fn convert_single_file(
         force_16bit,
         unwrap,
         decode_all,
+        overlays,
+        overlay_color,
+        overlay_file,
     } = image_options;
 
     if unwrap {
@@ -382,6 +430,20 @@ fn convert_single_file(
             .to_dynamic_image_with_options(frame_num, &options)
             .context(ConvertImageSnafu)?;
 
+        let image = if overlays {
+            let mut overlay_planes = file.decode_overlays().context(DecodePixelDataSnafu)?;
+            for path in &overlay_file {
+                let obj = open_file(path).with_context(|_| ReadFileSnafu { path: path.clone() })?;
+                overlay_planes.extend(obj.decode_overlays().context(DecodePixelDataSnafu)?);
+            }
+            if verbose {
+                println!("{} overlay plane(s) found", overlay_planes.len());
+            }
+            apply_overlays(image, &overlay_planes, frame_number, &overlay_color)
+        } else {
+            image
+        };
+
         std::fs::create_dir_all(output.parent().unwrap()).unwrap();
 
         image.save(&output).context(SaveImageSnafu)?;
@@ -392,6 +454,77 @@ fn convert_single_file(
     }
 
     Ok(())
+}
+
+/// Paint the overlay planes which apply to the given image frame
+/// on top of the image.
+///
+/// Colors are assigned to the planes in the order given,
+/// cycling through the color list
+/// if there are more planes than colors.
+fn apply_overlays(
+    image: DynamicImage,
+    overlays: &[OverlayPlane],
+    image_frame: u32,
+    colors: &[[u8; 3]],
+) -> DynamicImage {
+    if colors.is_empty()
+        || !overlays
+            .iter()
+            .any(|plane| plane.frame_for_image_frame(image_frame).is_some())
+    {
+        return image;
+    }
+
+    match image {
+        DynamicImage::ImageLuma16(_)
+        | DynamicImage::ImageLumaA16(_)
+        | DynamicImage::ImageRgb16(_)
+        | DynamicImage::ImageRgba16(_) => {
+            let mut img = image.into_rgb16();
+            for (i, plane) in overlays.iter().enumerate() {
+                let color = Rgb(colors[i % colors.len()].map(|c| c as u16 * 257));
+                paint_overlay(&mut img, plane, image_frame, color);
+            }
+            DynamicImage::ImageRgb16(img)
+        }
+        _ => {
+            let mut img = image.into_rgb8();
+            for (i, plane) in overlays.iter().enumerate() {
+                paint_overlay(&mut img, plane, image_frame, Rgb(colors[i % colors.len()]));
+            }
+            DynamicImage::ImageRgb8(img)
+        }
+    }
+}
+
+fn paint_overlay<P: Pixel>(
+    img: &mut ImageBuffer<P, Vec<P::Subpixel>>,
+    plane: &OverlayPlane,
+    image_frame: u32,
+    color: P,
+) {
+    let Some(overlay_frame) = plane.frame_for_image_frame(image_frame) else {
+        return;
+    };
+    let (width, height) = (img.width() as i64, img.height() as i64);
+    // 1-based origin: an origin of [1, 1] aligns the overlay with the image
+    let [origin_row, origin_col] = plane.origin();
+    for orow in 0..plane.rows() as i64 {
+        let ir = orow + origin_row as i64 - 1;
+        if ir < 0 || ir >= height {
+            continue;
+        }
+        for ocol in 0..plane.columns() as i64 {
+            let ic = ocol + origin_col as i64 - 1;
+            if ic < 0 || ic >= width {
+                continue;
+            }
+            if plane.is_set(overlay_frame, orow as u32, ocol as u32) {
+                img.put_pixel(ic as u32, ir as u32, color);
+            }
+        }
+    }
 }
 
 fn collect_dicom_files(
@@ -439,5 +572,13 @@ mod tests {
     #[test]
     fn verify_cli() {
         App::command().debug_assert();
+    }
+
+    #[test]
+    fn verify_parse_color() {
+        assert_eq!(crate::parse_color("ff0000"), Ok([255, 0, 0]));
+        assert_eq!(crate::parse_color("#00FF7f"), Ok([0, 255, 127]));
+        assert!(crate::parse_color("ff00").is_err());
+        assert!(crate::parse_color("gggggg").is_err());
     }
 }


### PR DESCRIPTION
This PR adds 2 new functions to the `PixelDecoder` trait:
- `decode_overlays`: This decodes all OverlayPlanes present in the file as vec
- `decode_overlay`: This decodes a single OverlayPlane by it's index

There's currently one default implementation in `overlay.rs`, which is used by all PixelDecoder implementations
Additionally i added support to the `toimage` crate, with the following options:
- `overlays`: A toggle to enable overlay burnins (defaults to false)
- `overlay-color`: A repeating argument which can be used to change the default overlay color (default is white)
- `overlay-file`: If overlays stored in a separate file (presentation state) these can be passed here

This closes #818