### PR TITLE
json: return an error instead of panicking on a primitive value with VR SQ (#812)

### DIFF
--- a/json/src/ser/mod.rs
+++ b/json/src/ser/mod.rs
@@ -262,7 +262,15 @@ impl<D> Serialize for DicomJson<&'_ InMemElement<D>> {
                 VR::OB | VR::OD | VR::OF | VR::OL | VR::OV | VR::OW | VR::UN => {
                     serializer.serialize_entry("InlineBinary", &InlineBinary::from(v))?;
                 }
-                VR::SQ => unreachable!("unexpected VR SQ in primitive value"),
+                // A primitive value tagged with VR SQ is an inconsistent state
+                // (e.g. built from malformed DICOM JSON declaring `"vr":"SQ"`
+                // alongside inline binary). Surface it as an error instead of
+                // panicking. (#812)
+                VR::SQ => {
+                    return Err(serde::ser::Error::custom(
+                        "cannot serialize a primitive value with VR SQ",
+                    ));
+                }
             },
         }
 
@@ -328,6 +336,19 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn serialize_primitive_with_sq_vr_is_error() {
+        // #812: a primitive value tagged with VR SQ is an inconsistent state
+        // (constructible from malformed DICOM JSON, e.g. `"vr":"SQ"` with inline
+        // binary). Serializing it must return an error rather than panic.
+        let obj = InMemDicomObject::from_element_iter([InMemElement::new(
+            Tag(0x0008, 0x0018),
+            VR::SQ,
+            PrimitiveValue::from("x"),
+        )]);
+        assert!(to_string(&obj).is_err());
+    }
 
     #[test]
     fn serialize_simple_data_elements() {


### PR DESCRIPTION
Fixes #812.

### Problem

`dicom_json`'s element serializer panics on a primitive value tagged with VR `SQ`:

```
internal error: entered unreachable code: unexpected VR SQ in primitive value
   at json/src/ser/mod.rs:265
```

That inconsistent state is constructible from malformed DICOM JSON (e.g. an element declaring `"vr":"SQ"` while carrying inline binary, which deserializes to a `DicomValue::Primitive`). Round-tripping such an object back out via `dicom_json::to_string` / `to_vec` then hits the `unreachable!()`, so the public `from_str` -> `to_string` path aborts on realistic fuzzer/edge input (reported by @qarmin's fuzzer).

### Fix

Replace the `unreachable!()` with a serialization error, so an anomalous primitive-with-SQ element surfaces as `Err` instead of panicking. `serialize` already returns `Result`.

### Test

Added `serialize_primitive_with_sq_vr_is_error`: it builds an object with a primitive value tagged VR `SQ` and asserts `to_string` returns an error. Red-green verified with `cargo test -p dicom-json`: before the fix the test panics at `ser/mod.rs:265`; after, it returns `Err`. `cargo fmt --check` and `clippy` are clean.
