### PR TITLE
[json] Restrict binary value deserialization to compatible VRs

### DIFF
--- a/json/src/de/mod.rs
+++ b/json/src/de/mod.rs
@@ -186,7 +186,7 @@ where
                     inline_binary = Some(val);
                 }
                 "BulkDataURI" => {
-                    if values.is_some() {
+                    if value.is_some() {
                         return Err(A::Error::custom("\"BulkDataURI\" conflicts with \"Value\""));
                     }
 
@@ -638,6 +638,18 @@ mod tests {
                 "vr": "OW",
                 "InlineBinary": "AAE=",
                 "BulkDataURI": "http://localhost:8042/dicom-web/instances/1.2.3.4.5/pixeldata"
+            }
+        });
+
+        let res: Result<InMemDicomObject, _> = super::from_value(serialized);
+        let e = res.unwrap_err();
+        assert_eq!(e.classify(), serde_json::error::Category::Data);
+
+        let serialized = serde_json::json!({
+            "00081010": {
+                "vr": "SH",
+                "Value": [ "RUSTATION" ],
+                "BulkDataURI": "http://localhost:8042/dicom-web/instances/1.2.3.4.5/station_name"
             }
         });
 

--- a/json/src/de/mod.rs
+++ b/json/src/de/mod.rs
@@ -170,7 +170,7 @@ where
                     value = Some(map.next_value()?);
                 }
                 "InlineBinary" => {
-                    if values.is_some() {
+                    if value.is_some() {
                         return Err(A::Error::custom(
                             "\"InlineBinary\" conflicts with \"Value\"",
                         ));
@@ -351,9 +351,14 @@ where
             }
         }
 
-        let value = match (values, inline_binary) {
-            (None, None) => PrimitiveValue::Empty.into(),
-            (None, Some(inline_binary)) => {
+        let value = match (values, vr, inline_binary) {
+            (None, _, None) => PrimitiveValue::Empty.into(),
+            (
+                None,
+                // PS3.19 Table A.1.5-2
+                VR::OB | VR::OD | VR::OF | VR::OL | VR::OV | VR::OW | VR::UN,
+                Some(inline_binary),
+            ) => {
                 // decode from Base64
                 use base64::Engine;
                 let data = base64::engine::general_purpose::STANDARD
@@ -361,8 +366,13 @@ where
                     .map_err(|_| A::Error::custom("inline binary data is not valid base64"))?;
                 PrimitiveValue::from(data).into()
             }
-            (Some(values), None) => values,
-            _ => unreachable!(),
+            (None, vr, Some(_inline_binary)) => {
+                return Err(A::Error::custom(format!("value of VR {vr} should not be encoded in InlineBinary")));
+            }
+            (Some(values), _, None) => values,
+            (Some(_), _, Some(_)) => unreachable!(
+                "conflict between InlineBinary and Value should have already been checked"
+            )
         };
 
         Ok(JsonDataElement {
@@ -593,5 +603,46 @@ mod tests {
         ];
 
         assert_float_slice_eq(&actual_values_multifloat_64, expected_values_multifloat_64);
+    }
+
+    #[test]
+    fn rejects_inline_binary_for_non_binary_vr() {
+        let serialized = serde_json::json!({
+            "00020001": {
+                "vr": "DS",
+                "InlineBinary": "AAE="
+            }
+        });
+
+        let res: Result<InMemDicomObject, _> = super::from_value(serialized);
+        let e = res.unwrap_err();
+        assert_eq!(e.classify(), serde_json::error::Category::Data);
+    }
+
+    #[test]
+    fn rejects_value_conflicts() {
+        let serialized = serde_json::json!({
+            "00020001": {
+                "vr": "DS",
+                "Value": [0, 1],
+                "InlineBinary": "AAE="
+            }
+        });
+
+        let res: Result<InMemDicomObject, _> = super::from_value(serialized);
+        let e = res.unwrap_err();
+        assert_eq!(e.classify(), serde_json::error::Category::Data);
+
+        let serialized = serde_json::json!({
+            "7FE00010": {
+                "vr": "OW",
+                "InlineBinary": "AAE=",
+                "BulkDataURI": "http://localhost:8042/dicom-web/instances/1.2.3.4.5/pixeldata"
+            }
+        });
+
+        let res: Result<InMemDicomObject, _> = super::from_value(serialized);
+        let e = res.unwrap_err();
+        assert_eq!(e.classify(), serde_json::error::Category::Data);
     }
 }


### PR DESCRIPTION
Should resolve #813.

- reject InlineBinary with a VR that is not on the list of enclosing Attribute VRs in PS3.19 A.1.5
- expand final match clauses in `DataElementVisitor::vist_map` for clarity
- fix check for conflicting Value and InlineBinary fields
- extend test coverage